### PR TITLE
TCP fixes

### DIFF
--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -109,7 +109,6 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     ZK_REV_OBJ_MAX_AGE = HASHTREE_EPOCH_TIME
     # Interval to checked for timed out interfaces.
     IF_TIMEOUT_INTERVAL = 1
-    USE_TCP = True
 
     def __init__(self, server_id, conf_dir):
         """

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -109,7 +109,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     ZK_REV_OBJ_MAX_AGE = HASHTREE_EPOCH_TIME
     # Interval to checked for timed out interfaces.
     IF_TIMEOUT_INTERVAL = 1
-    USE_TCP = False
+    USE_TCP = True
 
     def __init__(self, server_id, conf_dir):
         """

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -63,7 +63,6 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
     ZK_SHARE_LIMIT = 10
     # Time to store revocations in zookeeper
     ZK_REV_OBJ_MAX_AGE = HASHTREE_EPOCH_TIME
-    USE_TCP = True
 
     def __init__(self, server_id, conf_dir):
         """

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -63,7 +63,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
     ZK_SHARE_LIMIT = 10
     # Time to store revocations in zookeeper
     ZK_REV_OBJ_MAX_AGE = HASHTREE_EPOCH_TIME
-    USE_TCP = False
+    USE_TCP = True
 
     def __init__(self, server_id, conf_dir):
         """
@@ -268,6 +268,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             del self.pending_req[key]
 
     def handle_path_segment_record(self, seg_recs, meta):
+        meta.close()  # FIXME(PSz): validate before
         params = self._dispatch_params(seg_recs, meta)
         added = set()
         for type_, pcb in seg_recs.iter_pcbs():
@@ -275,7 +276,6 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         # Handling pending requests, basing on added segments.
         for dst_ia, sibra in added:
             self._handle_pending_requests(dst_ia, sibra)
-        meta.close()
 
     def _dispatch_segment_record(self, type_, seg, **kwargs):
         handle_map = {

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -108,7 +108,7 @@ class SCIONElement(object):
     """
     SERVICE_TYPE = None
     STARTUP_QUIET_PERIOD = STARTUP_QUIET_PERIOD
-    USE_TCP = True
+    USE_TCP = False
 
     def __init__(self, server_id, conf_dir, host_addr=None, port=None):
         """

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -481,7 +481,7 @@ class SCIONElement(object):
             sock.connect(dst, meta.port, meta.path, first_ip, first_port,
                          flags=meta.flags)
         except SCIONTCPError:
-            log_exception("Error on connect()")
+            log_exception("Error on connect(), marking socket inactive")
             active = False
         # Create and return TCPSocketWrapper
         return TCPSocketWrapper(sock, dst, meta.path, active)

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -108,7 +108,7 @@ class SCIONElement(object):
     """
     SERVICE_TYPE = None
     STARTUP_QUIET_PERIOD = STARTUP_QUIET_PERIOD
-    USE_TCP = False
+    USE_TCP = True
 
     def __init__(self, server_id, conf_dir, host_addr=None, port=None):
         """

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -476,10 +476,15 @@ class SCIONElement(object):
         sock.bind((self.addr, 0))
         dst = meta.get_addr()
         first_ip, first_port = self._get_first_hop(meta.path, dst)
-        sock.connect(dst, meta.port, meta.path, first_ip, first_port,
-                     flags=meta.flags)
+        active = True
+        try:
+            sock.connect(dst, meta.port, meta.path, first_ip, first_port,
+                         flags=meta.flags)
+        except SCIONTCPError:
+            log_exception("Error on connect()")
+            active = False
         # Create and return TCPSocketWrapper
-        return TCPSocketWrapper(sock, dst, meta.path)
+        return TCPSocketWrapper(sock, dst, meta.path, active)
 
     def _tcp_conns_put(self, sock):
         dropped = 0

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -647,7 +647,10 @@ class SCIONElement(object):
                 log_exception("TCP: error on accept()")
                 logging.error("TCP: leaving the accept loop")
                 break
-        self._tcp_sock.close()
+        try:
+            self._tcp_sock.close()
+        except SCIONTCPError:
+            log_exception("TCP: error on closing _tcp_sock")
 
     def _tcp_recv_loop(self):
         active_conns = {}

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -471,17 +471,18 @@ class SCIONElement(object):
             meta.ia = self.addr.isd_as
         if meta.path is None:
             meta.path = SCIONPath()
-        # Create low-level TCP socket and connect
-        sock = SCIONTCPSocket()
-        sock.bind((self.addr, 0))
         dst = meta.get_addr()
         first_ip, first_port = self._get_first_hop(meta.path, dst)
         active = True
         try:
+            # Create low-level TCP socket and connect
+            sock = SCIONTCPSocket()
+            sock.bind((self.addr, 0))
             sock.connect(dst, meta.port, meta.path, first_ip, first_port,
                          flags=meta.flags)
         except SCIONTCPError:
             log_exception("Error on connect(), marking socket inactive")
+            sock = None
             active = False
         # Create and return TCPSocketWrapper
         return TCPSocketWrapper(sock, dst, meta.path, active)

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -481,7 +481,7 @@ class SCIONElement(object):
             sock.connect(dst, meta.port, meta.path, first_ip, first_port,
                          flags=meta.flags)
         except SCIONTCPError:
-            log_exception("Error on connect(), marking socket inactive")
+            log_exception("TCP: connection init error, marking socket inactive")
             sock = None
             active = False
         # Create and return TCPSocketWrapper

--- a/infrastructure/sibra_server/main.py
+++ b/infrastructure/sibra_server/main.py
@@ -145,6 +145,7 @@ class SibraServerBase(SCIONElement):
         determine which interface the segments use, then pass the segment to the
         appropriate Link.
         """
+        meta.close()
         name = PST.to_str(self.PST_TYPE)
         with self.lock:
             for type_, pcb in payload.iter_pcbs():

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -139,6 +139,6 @@ HASHTREE_UPDATE_WINDOW = HASHTREE_TTL / 3
 
 # TCP polling timeouts, used by accept() and recv().
 TCP_ACCEPT_POLLING_TOUT = 1.0
-TCP_RECV_POLLING_TOUT = 0.05
+TCP_RECV_POLLING_TOUT = 0.005
 # SCION control-plane TCP connection timeout.
 TCP_TIMEOUT = 5.0

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -359,14 +359,14 @@ class TCPSocketWrapper(object):
     """
     RECV_SIZE = 8092
 
-    def __init__(self, sock, addr, path):
+    def __init__(self, sock, addr, path, active=True):
         self._buf = bytearray()
         self._sock = sock
         self._sock.set_recv_tout(TCP_RECV_POLLING_TOUT)
         self._addr = addr
         self._path = path
         self._lock = threading.RLock()
-        self.active = True
+        self.active = active
 
     def _get_meta(self):
         return TCPMetadata.from_values(ia=self._addr.isd_as,
@@ -393,23 +393,30 @@ class TCPSocketWrapper(object):
             msg = self._get_msg()
             if msg:
                 return msg, self._get_meta()
-            try:
-                read = self._sock.recv(self.RECV_SIZE)
-                self._buf += read
-            except SCIONTCPTimeout:
-                return None, self._get_meta()
-            except SCIONTCPError:
-                logging.debug("TCP: calling close() after socket error")
-                self.close()
+            if self.active:
+                try:
+                    read = self._sock.recv(self.RECV_SIZE)
+                    self._buf += read
+                except SCIONTCPTimeout:
+                    return None, self._get_meta()
+                except SCIONTCPError:
+                    logging.debug("TCP: calling close() after socket error")
+                    self.close()
+            else:
+                logging.warning("TCP: get_msg_meta(): inactive socket")
             return self._get_msg(), self._get_meta()
 
     def send_msg(self, raw):
         with self._lock:
-            try:
-                self._sock.send(raw)
-            except SCIONTCPError:
-                logging.debug("TCP: calling close() after socket error")
-                self.close()
+            if self.active:
+                try:
+                    self._sock.send(raw)
+                except SCIONTCPError:
+                    logging.debug("TCP: calling close() after socket error")
+                    self.close()
+            else:
+                logging.warning("TCP: send_msg(): inactive socket")
+
 
     def close(self):
         with self._lock:

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -403,7 +403,7 @@ class TCPSocketWrapper(object):
                     logging.debug("TCP: calling close() after socket error")
                     self.close()
             else:
-                logging.warning("TCP: get_msg_meta(): inactive socket")
+                logging.debug("TCP: get_msg_meta(): inactive socket")
             return self._get_msg(), self._get_meta()
 
     def send_msg(self, raw):
@@ -415,7 +415,7 @@ class TCPSocketWrapper(object):
                     logging.debug("TCP: calling close() after socket error")
                     self.close()
             else:
-                logging.warning("TCP: send_msg(): inactive socket")
+                logging.debug("TCP: send_msg(): inactive socket")
 
 
     def close(self):

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -417,7 +417,6 @@ class TCPSocketWrapper(object):
             else:
                 logging.debug("TCP: send_msg(): inactive socket")
 
-
     def close(self):
         with self._lock:
             try:

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -404,6 +404,7 @@ class TCPSocketWrapper(object):
                     self.close()
             else:
                 logging.debug("TCP: get_msg_meta(): inactive socket")
+                return None, self._get_meta()
             return self._get_msg(), self._get_meta()
 
     def send_msg(self, raw):


### PR DESCRIPTION
TCP for infrastructure seems to be pretty stable, although still disabled by default.
- dropping `USE_TCP`s from BS and PS (they interfere)
- handling `connect()` error
- do not send/recv through an inactive socket
- close TCP connection in SIBRA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/890)
<!-- Reviewable:end -->
