### PR TITLE
Add scion-web to CircleCI integrations tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ RUN sudo chown -R scion: $HOME
 RUN ./deps.sh zlog
 RUN ./deps.sh misc
 RUN ./deps.sh pip
+# Copy over scion-web requirements.txt. If it has changed, then re-run the remaining steps.
+COPY sub/web/requirements.txt $BASE/sub/web/
+# Install scion-web dependencies
+RUN ./deps.sh pipweb
 
 RUN sudo rm -rf /usr/share/man
 # Clean out the cached packages now they're no longer necessary
@@ -58,6 +62,11 @@ RUN sudo du -hsx /
 # Now copy over the current branch
 COPY . $BASE/
 RUN sudo chown -R scion: $HOME
+
+# Setup scion-web
+RUN cp sub/web/web_scion/settings/private.dist.py sub/web/web_scion/settings/private.py
+RUN sub/web/manage.py makemigrations
+
 # Build topology files
 RUN ./scion.sh topology
 # Install bash config

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ checkout:
         export PATH=$GOBIN:$PATH
         ' >> ~/.circlerc
       - git submodule sync
-      - git submodule update --init sub/lwip sub/lwip-contrib/
+      - git submodule update --init sub/web sub/lwip sub/lwip-contrib/
 
 dependencies:
     cache_directories:
@@ -45,6 +45,7 @@ test:
         - ./docker.sh run -c "./scion.sh lint"
         - ./docker.sh run -c "make -f sphinx-doc/Makefile clean html"
         - ./docker.sh run -c "make -s install clean && docker/integration_test.sh"
+        - ./docker.sh run -c "cd sub/web && ./manage.py test"
     post:
         - mkdir "$ARTIFACTS"
         - mv htmlcov "$ARTIFACTS"/coverage

--- a/deps.sh
+++ b/deps.sh
@@ -5,6 +5,7 @@ set -e
 cmd_all() {
     cmd_pkgs
     cmd_pip
+    cmd_pipweb
     cmd_zlog
     cmd_golang
     cmd_misc
@@ -38,6 +39,11 @@ pkg_deb_chk() {
 cmd_pip() {
     echo "Installing necessary packages from pip3"
     pip3 install --user -r requirements.txt
+}
+
+cmd_pipweb() {
+    echo "Installing necessary packages from pip3 for scion-web"
+    pip3 install --user -r sub/web/requirements.txt
 }
 
 cmd_zlog() {
@@ -94,6 +100,9 @@ cmd_help() {
 	    $PROGRAM pip
 	        Install all pip package dependencies (using --user, so no root
 	        access required)
+	    $PROGRAM pipweb
+	        Install all pip package dependencies of scion-web (using --user, so
+	        no root access required)
 	    $PROGRAM zlog
 	        Install libzlog
 	    $PROGRAM golang
@@ -111,7 +120,7 @@ COMMAND="$1"
 shift || { cmd_help; exit; }
 
 case "$COMMAND" in
-    all|pkgs|pip|golang|zlog|misc)
+    all|pkgs|pip|pipweb|golang|zlog|misc)
             "cmd_$COMMAND" "$@" ;;
     help)  cmd_help ;;
     *)  cmd_help; exit 1 ;;


### PR DESCRIPTION
Includes the scion-web tests into CircleCI tests to prevent code rot of the local management system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/898)
<!-- Reviewable:end -->
