### PR TITLE
Fix race-condition in ExpiringDict.__setitem__

### DIFF
--- a/external/expiring_dict.py
+++ b/external/expiring_dict.py
@@ -72,7 +72,10 @@ class ExpiringDict(OrderedDict):
         """ Set d[key] to value. """
         with self.lock:
             if len(self) == self.max_len:
-                self.popitem(last=False)
+                try:
+                    self.popitem(last=False)
+                except KeyError:
+                    pass
             OrderedDict.__setitem__(self, key, (value, time.time()))
 
     def pop(self, key, default=None):

--- a/external/expiring_dict.py
+++ b/external/expiring_dict.py
@@ -75,6 +75,9 @@ class ExpiringDict(OrderedDict):
                 try:
                     self.popitem(last=False)
                 except KeyError:
+                    # This can happen if the item to be evicted actually expires
+                    # during eviction. In any case it means the item was
+                    # removed, so we can continue.
                     pass
             OrderedDict.__setitem__(self, key, (value, time.time()))
 


### PR DESCRIPTION
If these conditions are true:
- the dict is full
- an item is being added
- the item to be evicted has already expired
then popitem (which calls __getitem__) can raise an KeyError exception.

This patch handles this case, just ignoring the exception, as it means
the item has been removed.

A trivial way to trigger the bug in the existing code:

    d = ExpiringDict(1, 0)
    d[1] = 1
    d[2] = 2  # Raises exception

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/901)
<!-- Reviewable:end -->
