### PR TITLE
Fix SCMP/UDP checksum calculation.

### DIFF
--- a/go/lib/libscion/checksum.go
+++ b/go/lib/libscion/checksum.go
@@ -30,8 +30,8 @@ import (
 
 func Checksum(srcs ...util.RawBytes) uint16 {
 	chkin := C.mk_chk_input(C.int(len(srcs)))
-	for i, src := range srcs {
-		C.chk_add_chunk(chkin, C.int(i), (*C.uint8_t)(unsafe.Pointer(&src[0])), C.int(len(src)))
+	for _, src := range srcs {
+		C.chk_add_chunk(chkin, (*C.uint8_t)(unsafe.Pointer(&src[0])), C.int(len(src)))
 	}
 	val := uint16(C.ntohs(C.checksum(chkin)))
 	C.rm_chk_input(chkin)

--- a/lib/libscion/checksum.h
+++ b/lib/libscion/checksum.h
@@ -2,7 +2,8 @@
 #define _CHECKSUM_H_
 
 typedef struct {
-    uint8_t count;
+    uint8_t idx;
+    uint8_t total;
     uint16_t *len;
     uint8_t **ptr;
 } chk_input;
@@ -10,6 +11,6 @@ typedef struct {
 uint16_t checksum(chk_input *in);
 chk_input *mk_chk_input(int count);
 void rm_chk_input(chk_input *in);
-uint8_t * chk_add_chunk(chk_input *in, int idx, uint8_t *ptr, int len);
+uint8_t * chk_add_chunk(chk_input *in, uint8_t *ptr, int len);
 
 #endif


### PR DESCRIPTION
While the python code includes a zero'd checksum field in the checksum
calculation input, libscion's UDP and SCMP checksum functions did not.
It's unclear why this didn't cause obvious problems with UDP before, but
it completely broke SCMP checksum support in libscion.

Also:
- Change chk_add_chunk to keep an internal index, removing the need for
  specifying the index by the caller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/903)
<!-- Reviewable:end -->
