### PR TITLE
Fix MPUDP send return value

### DIFF
--- a/endhost/ssp/SCIONProtocol.cpp
+++ b/endhost/ssp/SCIONProtocol.cpp
@@ -980,7 +980,10 @@ int SUDPProtocol::send(uint8_t *buf, size_t len, SCIONAddr *dstAddr, double time
     sp.payload = malloc(len);
     sp.payloadLen = len;
     memcpy(sp.payload, buf, len);
-    return mConnectionManager->sendPacket(&packet);
+    int ret = mConnectionManager->sendPacket(&packet);
+    if (ret < 0)
+        return ret;
+    return len;
 }
 
 int SUDPProtocol::recv(uint8_t *buf, size_t len, SCIONAddr *srcAddr, double timeout)


### PR DESCRIPTION
MPUDP send was returning bytes sent to dispatcher which was obviously not the expected return value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/905)
<!-- Reviewable:end -->
