### PR TITLE
Let proxy do its own signal handling

### DIFF
--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -81,7 +81,7 @@ SCIONSocket::SCIONSocket(int protocol, const char *sciond)
     mDataProfile(SCION_PROFILE_DEFAULT)
 {
     struct sigaction signew, sigold;
-    memset(&signew, 0, sizeof(sigold));
+    memset(&sigold, 0, sizeof(sigold));
     memset(&signew, 0, sizeof(signew));
     signew.sa_handler = signalHandler;
     sigaction(SIGINT, NULL, &sigold);

--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -80,7 +80,15 @@ SCIONSocket::SCIONSocket(int protocol, const char *sciond)
     mParent(NULL),
     mDataProfile(SCION_PROFILE_DEFAULT)
 {
-    signal(SIGINT, signalHandler);
+    struct sigaction signew, sigold;
+    memset(&signew, 0, sizeof(sigold));
+    memset(&signew, 0, sizeof(signew));
+    signew.sa_handler = signalHandler;
+    sigaction(SIGINT, NULL, &sigold);
+    if (!sigold.sa_handler) {
+        DEBUG("install SIGINT handler as none exists\n");
+        sigaction(SIGINT, &signew, NULL);
+    }
 
     strcpy(mSCIONDAddr, sciond);
     memset(&mLocalAddr, 0, sizeof(mLocalAddr));


### PR DESCRIPTION
Calling C code from the main thread of a Python program makes it impossible to run the Python signal handlers.

Proxy will now do all its work in a daemon thread while the main thread stays alert to signals like ctrl+c.
Also, libssock will not install a SIGINT handler if one already exists (e.g. called from Python).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/906)
<!-- Reviewable:end -->
