### PR TITLE
fix for #916

### DIFF
--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -312,13 +312,11 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def _handle_waiting_targets(self, pcb, reverse=False):
+    def _handle_waiting_targets(self, pcb):
         """
         Handle any queries that are waiting for a path to any core AS in an ISD.
         """
         dst_ia = pcb.first_ia()
-        if reverse:
-            dst_ia = pcb.last_ia()
         if not self.is_core_as(dst_ia):
             logging.warning("Invalid waiting target, not a core AS: %s", dst_ia)
             return

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -322,13 +322,13 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         if not self.is_core_as(dst_ia):
             logging.warning("Invalid waiting target, not a core AS: %s", dst_ia)
             return
-        self._send_waiting_queries(dst_ia[0], pcb, not reverse)
+        self._send_waiting_queries(dst_ia[0], pcb)
 
-    def _send_waiting_queries(self, dst_isd, pcb, reverse_path):
+    def _send_waiting_queries(self, dst_isd, pcb):
         targets = self.waiting_targets[dst_isd]
         if not targets:
             return
-        path = pcb.get_path(reverse_direction=reverse_path)
+        path = pcb.get_path(reverse_direction=True)
         src_ia = pcb.first_ia()
         while targets:
             seg_req = targets.pop(0)

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -322,13 +322,13 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         if not self.is_core_as(dst_ia):
             logging.warning("Invalid waiting target, not a core AS: %s", dst_ia)
             return
-        self._send_waiting_queries(dst_ia[0], pcb)
+        self._send_waiting_queries(dst_ia[0], pcb, not reverse)
 
-    def _send_waiting_queries(self, dst_isd, pcb):
+    def _send_waiting_queries(self, dst_isd, pcb, reverse_path):
         targets = self.waiting_targets[dst_isd]
         if not targets:
             return
-        path = pcb.get_path(reverse_direction=True)
+        path = pcb.get_path(reverse_direction=reverse_path)
         src_ia = pcb.first_ia()
         while targets:
             seg_req = targets.pop(0)

--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -133,8 +133,9 @@ class CorePathServer(PathServer):
         if not added:
             return set()
         # Send pending requests that couldn't be processed due to the lack of
-        # a core segment to the destination PS.
-        self._handle_waiting_targets(pcb, reverse=reverse)
+        # a core segment to the destination PS. Don't use SIBRA PCBs for that.
+        if not reverse:
+            self._handle_waiting_targets(pcb)
         ret = set([(first_ia, pcb.is_sibra())])
         if first_ia[0] != self.addr.isd_as[0]:
             # Remote core segment, signal the entire ISD

--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -134,7 +134,7 @@ class CorePathServer(PathServer):
             return set()
         # Send pending requests that couldn't be processed due to the lack of
         # a core segment to the destination PS. Don't use SIBRA PCBs for that.
-        if not reverse:
+        if not pcb.is_sibra():
             self._handle_waiting_targets(pcb)
         ret = set([(first_ia, pcb.is_sibra())])
         if first_ia[0] != self.addr.isd_as[0]:

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -451,7 +451,7 @@ class SCIONElement(object):
                                  meta.ia, msg, dst_port)
         if not next_hop_port:
             next_hop_port = self.get_first_hop(pkt)
-        if not next_hop_port:
+        if next_hop_port == (None, None):
             logging.error("Can't find first hop, dropping packet\n%s", pkt)
             return False
         return self.send(pkt, *next_hop_port)


### PR DESCRIPTION
I believe it fixes #916.
`_send_waiting_queries()` always extracts a reversed path from pcb. This is incorrect when pcb is reversed already (i.e., happens only for SIBRA core-path segments).
However, the bug is older than the TCP support, thus it is quite suspicious that we didn't notice it before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/917)
<!-- Reviewable:end -->
