### PR TITLE
Fix go dependency ordering

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,8 +30,8 @@ dependencies:
     override:
         - docker/cache.sh restore
         - mv ~/cache ~/cache.old; mkdir ~/cache
-        - ./deps.sh golang
         - sudo apt-get install -y clang-3.4 capnproto
+        - ./deps.sh golang
         - make -s go
         - ./docker.sh build
         - docker/cache.sh save

--- a/deps.sh
+++ b/deps.sh
@@ -74,11 +74,13 @@ cmd_golang() {
     go get -v $(<go/deps.txt)
     echo "Installing managed go dependencies (via trash)"
     trash -C go
-    echo "Installing go dependencies"
-    go get -v $(tools/godeps.py)
     echo "Copying go-capnproto2's go.capnp into proto/"
     local srcdir=$(go list -f "{{.Dir}}" zombiezen.com/go/capnproto2)
     cp ${srcdir:?}/std/go.capnp proto/go.capnp
+    echo "Generating go capnp code"
+    make goproto
+    echo "Installing go dependencies"
+    go get -v $(tools/godeps.py)
 }
 
 chk_go() {


### PR DESCRIPTION
Before the go external library dependencies can be resolved, the
generated go code for the capnp definitions needs to be in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/920)
<!-- Reviewable:end -->
