### PR TITLE
Fix mutex locking in SSP and related code

### DIFF
--- a/endhost/ssp/ConnectionManager.h
+++ b/endhost/ssp/ConnectionManager.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef PATH_MANAGER_H
 #define PATH_MANAGER_H
 
@@ -7,6 +22,8 @@
 #include "OrderedList.h"
 #include "PathPolicy.h"
 #include "SCIONDefines.h"
+#include "Mutex.h"
+#include "MutexScion.h"
 
 class SSPProtocol;
 class Path;
@@ -51,9 +68,9 @@ protected:
     SCIONAddr                    mDstAddr;
 
     std::vector<Path *>          mPaths;
-    pthread_mutex_t              mPathMutex;
+    Mutex                        mPathMutex;
+    Mutex                        mDispatcherMutex;
     pthread_cond_t               mPathCond;
-    pthread_mutex_t              mDispatcherMutex;
     int                          mInvalid;
     PathPolicy                   mPolicy;
 };
@@ -120,14 +137,13 @@ protected:
     OrderedList<SCIONPacket *>   *mRetryPackets;
     OrderedList<SCIONPacket *>   *mFreshPackets;
 
-    pthread_mutex_t              mMutex;
     pthread_cond_t               mCond;
 
-    pthread_mutex_t              mSentMutex;
+    Mutex                        mSentMutex;
     pthread_cond_t               mSentCond;
-    pthread_mutex_t              mFreshMutex;
-    pthread_mutex_t              mRetryMutex;
-    pthread_mutex_t              mPacketMutex;
+    Mutex                        mFreshMutex;
+    Mutex                        mRetryMutex;
+    Mutex                        mPacketMutex;
     pthread_cond_t               mPacketCond;
 
     pthread_t                    mWorker;

--- a/endhost/ssp/DataStructures.h
+++ b/endhost/ssp/DataStructures.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef SCION_DATASTRUCTURES_H
 #define SCION_DATASTRUCTURES_H
 

--- a/endhost/ssp/Extensions.cpp
+++ b/endhost/ssp/Extensions.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2016 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <arpa/inet.h>
 #include <stdio.h>
 

--- a/endhost/ssp/Extensions.h
+++ b/endhost/ssp/Extensions.h
@@ -1,3 +1,18 @@
+/* Copyright 2016 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef EXTENSIONS_H
 #define EXTENSIONS_H
 

--- a/endhost/ssp/Makefile
+++ b/endhost/ssp/Makefile
@@ -1,7 +1,9 @@
 .PHONY: all clean install uninstall
 
 CXX = clang++
-CXXFLAGS ?= -Wall -Werror -g -fPIC -std=c++11
+# Add -DSCIONDEBUGPRINT below to enable debug printing. Doing so *will*
+# break e.g. CircleCI since it is so spammy.
+CXXFLAGS ?= -Wall -Werror -g -fPIC -std=c++11 -Wthread-safety
 LDFLAGS ?= -shared -Wl,-z,defs -lpthread -lscion
 
 LIB_DIR = ../../lib/libscion

--- a/endhost/ssp/Mutex.h
+++ b/endhost/ssp/Mutex.h
@@ -1,0 +1,162 @@
+/* The base of this file was fetched from:
+ * https://github.com/google/lmctfy/blob/master/base/mutex.h
+ * at revision f75d7afd2063b8c87c3a9626236f0fb0f806c8f1
+ *
+ * Copyright 2013 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BASE_MUTEX_H_
+#define BASE_MUTEX_H_
+
+#include <stdlib.h>
+#include <pthread.h>
+
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+TypeName(const TypeName&);                 \
+void operator=(const TypeName&)
+
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
+#endif
+
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
+
+#define CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY \
+  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define REQUIRES_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define ACQUIRE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define RELEASE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define RELEASE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define ASSERT_SHARED_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define RETURN_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+  THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+#ifdef USE_LOCK_STYLE_THREAD_SAFETY_ATTRIBUTES
+// The original version of thread safety analysis the following attribute
+// definitions.  These use a lock-based terminology.  They are still in use
+// by existing thread safety code, and will continue to be supported.
+
+// Deprecated.
+#define PT_GUARDED_VAR \
+  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded)
+
+// Deprecated.
+#define GUARDED_VAR \
+  THREAD_ANNOTATION_ATTRIBUTE__(guarded)
+
+// Replaced by REQUIRES
+#define EXCLUSIVE_LOCKS_REQUIRED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_locks_required(__VA_ARGS__))
+
+// Replaced by REQUIRES_SHARED
+#define SHARED_LOCKS_REQUIRED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_locks_required(__VA_ARGS__))
+
+// Replaced by CAPABILITY
+#define LOCKABLE \
+  THREAD_ANNOTATION_ATTRIBUTE__(lockable)
+
+// Replaced by SCOPED_CAPABILITY
+#define SCOPED_LOCKABLE \
+  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+// Replaced by ACQUIRE
+#define EXCLUSIVE_LOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock_function(__VA_ARGS__))
+
+// Replaced by ACQUIRE_SHARED
+#define SHARED_LOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_lock_function(__VA_ARGS__))
+
+// Replaced by RELEASE and RELEASE_SHARED
+#define UNLOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(unlock_function(__VA_ARGS__))
+
+// Replaced by TRY_ACQUIRE
+#define EXCLUSIVE_TRYLOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock_function(__VA_ARGS__))
+
+// Replaced by TRY_ACQUIRE_SHARED
+#define SHARED_TRYLOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock_function(__VA_ARGS__))
+
+// Replaced by ASSERT_CAPABILITY
+#define ASSERT_EXCLUSIVE_LOCK(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_exclusive_lock(__VA_ARGS__))
+
+// Replaced by ASSERT_SHARED_CAPABILITY
+#define ASSERT_SHARED_LOCK(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_lock(__VA_ARGS__))
+
+// Replaced by EXCLUDE_CAPABILITY.
+#define LOCKS_EXCLUDED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+// Replaced by RETURN_CAPABILITY
+#define LOCK_RETURNED(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#endif  // USE_LOCK_STYLE_THREAD_SAFETY_ATTRIBUTES
+
+#endif  // BASE_MUTEX_H_

--- a/endhost/ssp/MutexScion.h
+++ b/endhost/ssp/MutexScion.h
@@ -1,0 +1,75 @@
+/* Copyright 2016 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MUTEXSCION_H_
+#define MUTEXSCION_H_
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <string.h>
+#include "Mutex.h"
+
+// From Utils.h
+extern int debugprint(FILE *stream, const char *format, ...);
+
+// Basic wrapper around a pthread mutex
+class CAPABILITY("mutex") Mutex {
+public:
+    enum LinkerInitialized { LINKER_INITIALIZED };
+
+    // pthread_mutex_init() always returns 0, so no need to assert()
+    inline Mutex() {pthread_mutex_init(&lock, nullptr);}
+    inline Mutex(LinkerInitialized) {pthread_mutex_init(&lock, nullptr);}
+
+    inline ~Mutex() {
+        auto ret = pthread_mutex_destroy(&lock);
+        if (ret) {
+            debugprint(stderr, "%lx Held mutex: %p: %d\n", pthread_self(), &lock, ret);
+        }
+    }
+
+    inline void Lock() ACQUIRE() {
+        debugprint(stderr, "%lx  ML>: %p\n", pthread_self(), &lock);
+        auto ret = pthread_mutex_lock(&lock);
+        debugprint(stderr, "%lx  ML<: %p: %d\n", pthread_self(), &lock, ret);
+    }
+
+    inline void Unlock() RELEASE() {
+        auto ret = pthread_mutex_unlock(&lock);
+        debugprint(stderr, "%lx   MR: %p: %d\n", pthread_self(), &lock, ret);
+    }
+
+    inline int timedWait(pthread_cond_t *cond, struct timespec *ts) REQUIRES(this) {
+        debugprint(stderr, "%lx MTw>: %p\n", pthread_self(), &lock);
+        auto ret = pthread_cond_timedwait(cond, &lock, ts);
+        debugprint(stderr, "%lx MTw<: %p: %d\n", pthread_self(), &lock, ret);
+    return ret;
+    }
+
+    inline void condWait(pthread_cond_t *cond) REQUIRES(this) {
+        // While pcw has an int return value, it's always 0.
+        debugprint(stderr, "%lx MCw>: %p\n", pthread_self(), &lock);
+        pthread_cond_wait(cond, &lock);
+        debugprint(stderr, "%lx MCw<: %p\n", pthread_self(), &lock);
+    }
+
+private:
+    pthread_mutex_t lock;
+    DISALLOW_COPY_AND_ASSIGN(Mutex);
+};
+
+#endif  // MUTEXSCION_H_

--- a/endhost/ssp/OrderedList.cpp
+++ b/endhost/ssp/OrderedList.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "OrderedList.h"
 #include "Utils.h"
 

--- a/endhost/ssp/OrderedList.h
+++ b/endhost/ssp/OrderedList.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef ORDERED_LIST_H
 #define ORDERED_LIST_H
 

--- a/endhost/ssp/Path.h
+++ b/endhost/ssp/Path.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef PATH_H
 #define PATH_H
 
@@ -83,7 +98,7 @@ protected:
     int             mProbeAttempts;
     struct timeval  mLastSendTime;
 
-    pthread_mutex_t mMutex;
+    Mutex           mMutex;
 
     PathManager *mManager;
 };
@@ -121,8 +136,8 @@ protected:
     int             mTimeoutCount;
     struct timeval  mLastLossTime;
 
-    pthread_mutex_t mTimeMutex;
-    pthread_mutex_t mWindowMutex;
+    Mutex           mTimeMutex;
+    Mutex           mWindowMutex;
     pthread_cond_t  mWindowCond;
 
     pthread_t       mThread;

--- a/endhost/ssp/PathPolicy.cpp
+++ b/endhost/ssp/PathPolicy.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2016 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "Path.h"
 #include "PathPolicy.h"
 

--- a/endhost/ssp/PathPolicy.h
+++ b/endhost/ssp/PathPolicy.h
@@ -1,3 +1,18 @@
+/* Copyright 2016 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef PATH_POLICY_H
 #define PATH_POLICY_H
 

--- a/endhost/ssp/PathState.h
+++ b/endhost/ssp/PathState.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef PATH_STATE_H
 #define PATH_STATE_H
 
@@ -6,6 +21,8 @@
 #include <list>
 
 #include "SCIONDefines.h"
+#include "Mutex.h"
+#include "MutexScion.h"
 #include "DataStructures.h"
 #include "ProtocolConfigs.h"
 
@@ -70,7 +87,7 @@ protected:
     uint64_t        mTotalAcked;
     uint64_t        mLastTotalAcked;
     uint64_t        mTotalLost;
-    pthread_mutex_t mMutex;
+    Mutex           mMutex;
     list<uint64_t>  mLossIntervals;
     uint64_t        mAverageLossInterval;
 };
@@ -125,7 +142,7 @@ private:
     uint64_t        mMonitorReceived;
     uint64_t        mMonitorLost;
     bool            mMonitoring;
-    pthread_mutex_t mMonitorMutex;
+    Mutex           mMonitorMutex;
 
     double          mUtility;
     double          mTrialResults[PCC_TRIALS];

--- a/endhost/ssp/ProtocolConfigs.h
+++ b/endhost/ssp/ProtocolConfigs.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef SCION_PROTO_CONFIGS_H
 #define SCION_PROTO_CONFIGS_H
 

--- a/endhost/ssp/SCIONDefines.h
+++ b/endhost/ssp/SCIONDefines.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef SCION_DEFINES_H
 #define SCION_DEFINES_H
 

--- a/endhost/ssp/SCIONProtocol.h
+++ b/endhost/ssp/SCIONProtocol.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef SCION_PROTOCOL_H
 #define SCION_PROTOCOL_H
 
@@ -6,6 +21,7 @@
 
 #include "ConnectionManager.h"
 #include "DataStructures.h"
+#include "Mutex.h"
 #include "OrderedList.h"
 #include "ProtocolConfigs.h"
 #include "SCIONDefines.h"
@@ -65,7 +81,8 @@ protected:
     bool                   mIsReceiver;
     bool                   mReadyToRead;
     bool                   mBlocking;
-    pthread_mutex_t        mReadMutex;
+    Mutex                  mReadMutex;
+    Mutex                  mStateMutex;
     pthread_cond_t         mReadCond;
     SCIONState             mState;
     uint64_t               mNextSendByte;
@@ -76,7 +93,6 @@ protected:
     struct timeval         mLastProbeTime;
 
     pthread_t              mTimerThread;
-    pthread_mutex_t        mStateMutex;
 };
 
 class SSPProtocol: public SCIONProtocol {
@@ -150,7 +166,7 @@ protected:
     OrderedList<SSPPacket *> *mOOPackets;
 
     // select
-    pthread_mutex_t        mSelectMutex;
+    Mutex                   mSelectMutex;
     std::map<int, Notification> mSelectRead;
     std::map<int, Notification> mSelectWrite;
     int mSelectCount;

--- a/endhost/ssp/SCIONSocket.h
+++ b/endhost/ssp/SCIONSocket.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef SCION_SOCKET_H
 #define SCION_SOCKET_H
 
@@ -7,6 +22,7 @@
 #include <vector>
 
 #include "SCIONDefines.h"
+#include "Mutex.h"
 #include "DataStructures.h"
 #include "SCIONProtocol.h"
 #include "Utils.h"
@@ -81,14 +97,14 @@ private:
     std::vector<SCIONAddr>     mDstAddrs;
     std::vector<SCIONSocket *> mAcceptedSockets;
     DataProfile                mDataProfile;
-    pthread_mutex_t            mAcceptMutex;
+    Mutex                      mAcceptMutex;
     pthread_cond_t             mAcceptCond;
-    pthread_mutex_t            mRegisterMutex;
+    Mutex                      mRegisterMutex;
     pthread_cond_t             mRegisterCond;
     pthread_t                  mReceiverThread;
 
     int                         mSelectCount;
-    pthread_mutex_t             mSelectMutex;
+    Mutex                       mSelectMutex;
     std::map<int, Notification> mSelectRead;
 };
 

--- a/endhost/ssp/SCIONWrapper.h
+++ b/endhost/ssp/SCIONWrapper.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _SCION_WRAPPER_H
 #define _SCION_WRAPPER_H
 

--- a/endhost/ssp/SocketConfigs.h
+++ b/endhost/ssp/SocketConfigs.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef SCION_GENERAL_CONFIG_H
 #define SCION_GENERAL_CONFIG_H
 

--- a/endhost/ssp/Utils.h
+++ b/endhost/ssp/Utils.h
@@ -1,3 +1,18 @@
+/* Copyright 2015 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef UTILS_H
 #define UTILS_H
 
@@ -5,6 +20,8 @@
 
 #include "DataStructures.h"
 #include "SCIONDefines.h"
+#include "Mutex.h"
+#include "MutexScion.h"
 
 // elapsed time in ms
 inline long elapsedTime(struct timeval *old, struct timeval *current)
@@ -31,5 +48,13 @@ int registerFlow(int proto, DispatcherEntry *e, int sock);
 void destroyStats(SCIONStats *stats);
 
 int timedWait(pthread_cond_t *cond, pthread_mutex_t *mutex, double timeout);
+int timedWaitMutex(pthread_cond_t *cond, Mutex *mutex, double timeout);
 
-#endif
+// pthread_mutex_lock and pthread_mutex_unlock wrappers that use debugprint()
+int p_m_lock(pthread_mutex_t *mutex, char const *filename, int lineno);
+int p_m_unlock(pthread_mutex_t *mutex, char const *filename, int lineno);
+
+// Print text to stream iff SCIONDEBUGPRINT is defined
+int debugprint(FILE *stream, const char *format, ...);
+
+#endif // UTILS_H


### PR DESCRIPTION
To debug correct use of mutexes in multithreaded applications, it's always handy
to use lock annotations:

http://clang.llvm.org/docs/ThreadSafetyAnalysis.html

In order to do this in our C++ code, this commit does the following:

1. Make a wrapper around pthread mutexes that is annotated with the correct
   macros (`ACQUIRE()`, `RELEASE()`, `CAPABILITY("mutex")` and so on) (in
   `MutexScion.h`)
2. Import the preprocessor macros that are used by the Clang thread safety
   analysis tooling (`Mutex.h`, taken from the Apache-2 licensed lmctfy).
3. Change all uses of mutex-reladed pthread functions to use the class from
   (1). There are some raw uses of pthread functions left in
   `SCIONWrapper.h`/`.cpp` since that code is used with `extern "C"`. Said code
   is simple enough to be checked manually.
4. Annotate all relevant C++ functions/methods with `EXCLUDES()` directives.
5. Compile the code with `-Wthread-safety`.

This leads to the discovery of various `threadCleanup()` methods that release
mutexes "just in case". While this sometimes works well enough, double releases
of mutexes trigger undefined behavior and thus can lead to SEGV and a host of
other problems. On top of that dealing with locks in this manner can easily
paper over concurrency problems.

Note that all of this annotation is for compile-time checks _only_. Thus, it
should have no performance or memory impact after compilation.

This commit also adds a wrapper around `fprintf()` (`debugprint` in
`Utils.h/cpp`) that allows for easily squelched debug messages to be printed to
stderr.

Finally, this commit adds appropriate file header comments containing the ETH
copyright notice and a reference to the Apache-2 license.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/926)
<!-- Reviewable:end -->
