### PR TITLE
Deprecate libssocket.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ gohsr: libhsr
 	cd go && make hsr
 
 # Order is important
-clibs: libscion libfilter libssocket liblwip libtcpmw
+clibs: libscion libfilter liblwip libtcpmw
 
 libscion:
 	$(MAKE) -C lib/libscion install

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -62,10 +62,6 @@ Cert/TRC request
 test/integration/cert_req_test.py -l ERROR
 Sibra Ext
 test/integration/sibra_ext_test.py -l ERROR --wait 30 --runs 10
-SSP
-test/integration/ssp_test.py -l ERROR
-MPUDP
-test/integration/mpudp_test.py -l ERROR
 EOF
 result=$?
 


### PR DESCRIPTION
libssocket (./endhost/ssp) has major threading/locking issues. These
prevent it from working at all on the new HP DL20 servers we're starting
to buy. Our best guess is that this is because the servers have
non-hyperthreaded CPUs, and this is somehow triggering otherwise latent
bugs in the thread handling.

Fixing this would involve a major amount of engineering time (and
probably a rewrite). So, this change stops building/testing libssocket
by default. It can still be used as a proof of concept, but is
definitely unsuitable for any kind of production traffic for the time
being.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/927)
<!-- Reviewable:end -->
