### PR TITLE
Use `golang` package instead of `golang-1.6`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	if type -P go >/dev/null; then cd go && make clean; fi
 
 go: libscion
-	# `make -C go` breaks if there are symlinks in $PWD
+	@# `make -C go` breaks if there are symlinks in $PWD
 	cd go && make
 
 gohsr: libhsr

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ Necessary steps in order to run SCION:
 
 1. Make sure that you have a
    [Go workspace](https://golang.org/doc/code.html#GOPATH) setup, and that
-   `~/.local/bin`, `/usr/lib/go-1.6/bin` and `$GOPATH/bin` can be found in your
-   `$PATH` variable. For example:
+   `~/.local/bin`, and `$GOPATH/bin` can be found in your `$PATH` variable. For example:
 
     ```
     echo 'export GOPATH="$HOME/go"' >> ~/.profile
-    echo 'export PATH="$HOME/.local/bin:/usr/lib/go-1.6/bin:$GOPATH/bin:$PATH"' >> ~/.profile
+    echo 'export PATH="$HOME/.local/bin:$GOPATH/bin:$PATH"' >> ~/.profile
     source ~/.profile
     mkdir -p "$GOPATH"
     ```

--- a/docker/profile
+++ b/docker/profile
@@ -1,5 +1,5 @@
 export GOPATH="$HOME/go"
-export PATH="$HOME/.local/bin:/usr/share/zookeeper/bin:/usr/lib/go-1.6/bin:$GOPATH/bin:$PATH"
+export PATH="$HOME/.local/bin:/usr/share/zookeeper/bin:$GOPATH/bin:$PATH"
 export SHELL
 export BASEDIR="$GOPATH/src/github.com/netsec-ethz/scion"
 export PYTHONPATH="$BASEDIR"

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all clean test coverage fmt deps_proto deps depspurge proto bin libs hsr
 
+SHELL=/bin/bash
 LOCAL_DIRS = $(shell find * -maxdepth 0 -type d | grep -v '^vendor$$')
 LOCAL_PKGS = $(patsubst %, ./%/..., $(LOCAL_DIRS))
 LOCAL_GOBIN = $(shell realpath -s $$PWD/../bin)
@@ -27,9 +28,14 @@ deps_proto: proto
 
 deps: vendor/.deps.stamp
 
-vendor/.deps.stamp: vendor/vendor.json 
-	govendor sync
-	go install -v ./vendor/...
+vendor/.deps.stamp: vendor/vendor.json
+	@echo "$$(date -Iseconds) Syncing deps"; govendor sync
+	@echo "$$(date -Iseconds) Installing deps"; go install ./vendor/...
+	@if [ -n "$$(govendor list -no-status +outside)" ]; then \
+	    echo "ERROR: external/missing packages:"; \
+	    govendor list +outside; \
+	    exit 1; \
+	fi;
 	touch $@
 
 depspurge:


### PR DESCRIPTION
On ubuntu 16.04, the default golang version is 1.6, and installing the
`golang` package adds a symlink in `/usr/bin`, so there's no need to add
`/usr/lib/go-1.6/bin` to `$PATH` any more.

Also:
- Improve the golang version detection to allow golang >=1.6
- Generate an error if govendor detects any "outside" packages (i.e.
  third-party packages that are outside go/vendor/, or missing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/928)
<!-- Reviewable:end -->
