### PR TITLE
Add config command to work-around not having github account.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "sub/lwip"]
 	path = sub/lwip
-	url = https://github.com/netsec-ethz/scion-lwip.git
+	url = git@github.com:netsec-ethz/scion-lwip.git
 [submodule "sub/lwip-contrib"]
 	path = sub/lwip-contrib
-	url = https://github.com/netsec-ethz/scion-lwip-contrib.git
+	url = git@github.com:netsec-ethz/scion-lwip-contrib.git
 [submodule "sub/web"]
 	path = sub/web
-	url = https://github.com/netsec-ethz/scion-web.git
+	url = git@github.com:netsec-ethz/scion-web.git

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Necessary steps in order to run SCION:
    git clone --recursive git@github.com:netsec-ethz/scion
    cd scion
    ```
+   If you don't have a github account, or haven't setup ssh access to it, this
+   command will make git use https instead:
+   `git config --global --add url.https://github.com/.insteadOf git@github.com:`
 
 1. Install required packages with dependencies:
     ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Necessary steps in order to run SCION:
    ```
    If you don't have a github account, or haven't setup ssh access to it, this
    command will make git use https instead:
-   `git config --global --add url.https://github.com/.insteadOf git@github.com:`
+   `git config --global url.https://github.com/.insteadOf git@github.com:`
 
 1. Install required packages with dependencies:
     ```


### PR DESCRIPTION
This allows us to switch the submodule urls back to ssh, to be
consistent with everything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/930)
<!-- Reviewable:end -->
