### PR TITLE
Switch to Go router.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ test:
     override:
         # Go isn't installed in docker, so run the tests outside.
         - ./scion.sh coverage go
-        - ./scion.sh gofmt
+        - ./scion.sh golint
         - ./docker.sh run -c "./scion.sh coverage py"
         - ./docker.sh run -c "./scion.sh lint"
         - ./docker.sh run -c "make -f sphinx-doc/Makefile clean html"

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -60,8 +60,6 @@ SCMP error
 test/integration/scmp_error_test.py -l ERROR --runs 60
 Cert/TRC request
 test/integration/cert_req_test.py -l ERROR
-Sibra Ext
-test/integration/sibra_ext_test.py -l ERROR --wait 30 --runs 10
 EOF
 result=$?
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,9 +1,11 @@
-.PHONY: all clean test coverage fmt deps_proto deps depspurge proto bin libs hsr
+.PHONY: all clean test coverage lint deps_proto deps depspurge proto bin libs hsr
 
 SHELL=/bin/bash
 LOCAL_DIRS = $(shell find * -maxdepth 0 -type d | grep -v '^vendor$$')
 LOCAL_PKGS = $(patsubst %, ./%/..., $(LOCAL_DIRS))
 LOCAL_GOBIN = $(shell realpath -s $$PWD/../bin)
+LOCAL_NONGEN = $(shell find ${LOCAL_DIRS} -type f -iname '*.go' -a '!' -iname '*.capnp.go')
+GOTAGS = assert
 
 all: deps_proto bin
 
@@ -14,22 +16,27 @@ clean:
 	cd proto && $(MAKE) clean
 
 test: deps_proto
-	govendor test +local
+	GOCONVEY_REPORTER=story govendor test +local
 
 coverage: deps_proto
-	gocov test ${LOCAL_PKGS} | gocov-html > gocover.html
+	set -o pipefail; GOCONVEY_REPORTER=story gocov test ${LOCAL_PKGS} | gocov-html > gocover.html
 	@echo
 	@echo "Go coverage report here: file://$$PWD/gocover.html"
 
-fmt:
-	gofmt -d -s ${LOCAL_DIRS}
+lint:
+	@echo "======> goimports"
+	out=$$(goimports -d -local github.com/netsec-ethz ${LOCAL_NONGEN}); if [ -n "$$out" ]; then echo "$$out"; exit 1; fi
+	@echo "======> gofmt"
+	out=$$(gofmt -d -s ${LOCAL_DIRS}); if [ -n "$$out" ]; then echo "$$out"; exit 1; fi
+	@echo "======> go vet"
+	go vet ${LOCAL_PKGS}
 
 deps_proto: proto
 
 deps: vendor/.deps.stamp
 
 vendor/.deps.stamp: vendor/vendor.json
-	@echo "$$(date -Iseconds) Syncing deps"; govendor sync
+	@echo "$$(date -Iseconds) Syncing deps"; govendor sync -v
 	@echo "$$(date -Iseconds) Installing deps"; go install ./vendor/...
 	@if [ -n "$$(govendor list -no-status +outside)" ]; then \
 	    echo "ERROR: external/missing packages:"; \
@@ -47,7 +54,7 @@ proto: deps
 	cd proto && $(MAKE)
 
 bin: deps_proto
-	GOBIN=${LOCAL_GOBIN} govendor install -v +local,program
+	GOBIN=${LOCAL_GOBIN} govendor install --tags "$(GOTAGS)" -v +local,program
 
 libs: deps_proto
 	govendor install -v +local,^program

--- a/go/border/conf/conf.go
+++ b/go/border/conf/conf.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netsec-ethz/scion/go/border/netconf"
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/as_conf"
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/spath"
 	"github.com/netsec-ethz/scion/go/lib/topology"
 	"github.com/netsec-ethz/scion/go/lib/util"
@@ -41,14 +42,19 @@ type Conf struct {
 	Dir        string
 	IFStates   struct {
 		sync.RWMutex
-		M map[spath.IntfID]proto.IFStateInfo
+		M map[spath.IntfID]IFState
 	}
+}
+
+type IFState struct {
+	P      proto.IFStateInfo
+	RawRev common.RawBytes
 }
 
 var C *Conf
 
-func Load(id, confDir string) *util.Error {
-	var err *util.Error
+func Load(id, confDir string) *common.Error {
+	var err *common.Error
 
 	conf := &Conf{}
 	conf.Dir = confDir
@@ -61,7 +67,7 @@ func Load(id, confDir string) *util.Error {
 
 	topoBR, ok := conf.TopoMeta.T.BR[id]
 	if !ok {
-		return util.NewError("Unable to find element ID in topology", "id", id, "path", topoPath)
+		return common.NewError("Unable to find element ID in topology", "id", id, "path", topoPath)
 	}
 	conf.BR = &topoBR
 

--- a/go/border/error.go
+++ b/go/border/error.go
@@ -1,0 +1,127 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	//log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/scion/go/border/conf"
+	"github.com/netsec-ethz/scion/go/border/rpkt"
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/scmp"
+	"github.com/netsec-ethz/scion/go/lib/spkt"
+)
+
+func (r *Router) handlePktError(rp *rpkt.RtrPkt, perr *common.Error, desc string) {
+	sdata, ok := perr.Data.(*scmp.ErrData)
+	if ok {
+		perr.Ctx = append(perr.Ctx, "SCMP", sdata.CT)
+	}
+	rp.Error(desc, perr.Ctx...)
+	if !ok || perr.Data == nil || rp.DirFrom == rpkt.DirSelf || rp.SCMPError {
+		// No scmp error data, packet is from self, or packet is already an SCMPError, so no reply.
+		return
+	}
+	if sdata.CT.Class == scmp.C_CmnHdr {
+		switch sdata.CT.Type {
+		case scmp.T_C_BadVersion, scmp.T_C_BadSrcType, scmp.T_C_BadDstType:
+			// For any of these cases, do nothing. A reply would only be
+			// possible in the case of a version/addr type being understood but
+			// deprecated, which hasn't happened yet.
+			return
+		}
+	}
+	reply, err := r.createSCMPErrorReply(rp, sdata.CT, sdata.Info)
+	if err != nil {
+		rp.Error("Error creating SCMP response", err.Ctx...)
+		return
+	}
+	reply.Route()
+}
+
+func (r *Router) createSCMPErrorReply(rp *rpkt.RtrPkt, ct scmp.ClassType,
+	info scmp.Info) (*rpkt.RtrPkt, *common.Error) {
+	sp, err := r.createReplyScnPkt(rp)
+	if err != nil {
+		return nil, err
+	}
+	if len(sp.HBHExt) > 0 && sp.HBHExt[0].Type() == common.ExtnSCMPType {
+		// If there's already an SCMP hbh header, remove it.
+		sp.HBHExt = sp.HBHExt[1:]
+	}
+	if len(sp.HBHExt) > common.ExtnMaxHBH {
+		// Too many HBH extensions, so trim to the excess ones.
+		sp.HBHExt = sp.HBHExt[:common.ExtnMaxHBH]
+	}
+	// Add new SCMP HBH extension at the start.
+	ext := &scmp.Extn{Error: true}
+	if ct.Class == scmp.C_Path && ct.Type == scmp.T_P_RevokedIF {
+		// Revocation SCMP errors have to be inspected by intermediate routers.
+		ext.HopByHop = true
+	}
+	sp.HBHExt = append([]common.Extension{ext}, sp.HBHExt...)
+	// Add SCMP l4 header and payload
+	sp.Pld = scmp.PldFromQuotes(ct, info, sp.L4.L4Type(), rp.GetRaw)
+	sp.L4 = scmp.NewHdr(ct, sp.Pld.Len())
+	// Convert back to RtrPkt
+	reply, err := rpkt.RtrPktFromScnPkt(sp, rp.DirFrom)
+	if err != nil {
+		return nil, err
+	}
+	if rp.DirFrom == rpkt.DirExternal {
+		reply.InfoF()
+		reply.HopF()
+		if err := reply.IncPath(); err != nil {
+			return nil, err
+		}
+	}
+	egress, err := r.replyEgress(rp)
+	if err != nil {
+		return nil, err
+	}
+	reply.Egress = append(reply.Egress, egress)
+	return reply, nil
+}
+
+func (r *Router) createReplyScnPkt(rp *rpkt.RtrPkt) (*spkt.ScnPkt, *common.Error) {
+	sp, err := rp.ToScnPkt(false)
+	if err != nil {
+		return nil, err
+	}
+	if err = sp.Reverse(); err != nil {
+		return nil, err
+	}
+	// Use the ingress address as the source host
+	sp.SrcIA = conf.C.IA
+	sp.SrcHost = addr.HostFromIP(rp.Ingress.Dst.IP)
+	return sp, nil
+}
+
+func (r *Router) replyEgress(rp *rpkt.RtrPkt) (rpkt.EgressPair, *common.Error) {
+	if rp.DirFrom == rpkt.DirLocal {
+		locIdx := conf.C.Net.LocAddrMap[rp.Ingress.Dst.String()]
+		return rpkt.EgressPair{F: r.locOutFs[locIdx], Dst: rp.Ingress.Src}, nil
+	}
+	intf, err := rp.IFCurr()
+	if err != nil {
+		return rpkt.EgressPair{}, err
+	}
+	return rpkt.EgressPair{F: r.intfOutFs[*intf], Dst: rp.Ingress.Src}, nil
+}
+
+var validateErrorSCMP = map[string]scmp.ClassType{
+	rpkt.ErrorBadTotalLen: {scmp.C_CmnHdr, scmp.T_C_BadPktLen},
+}

--- a/go/border/io-hsr.go
+++ b/go/border/io-hsr.go
@@ -28,9 +28,9 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/log"
 )
 
-func (r *Router) readHSRInput(q chan *rpkt.RPkt) {
+func (r *Router) readHSRInput(q chan *rpkt.RtrPkt) {
 	defer liblog.PanicLog()
-	rpkts := make([]*rpkt.RPkt, hsr.MaxPkts)
+	rpkts := make([]*rpkt.RtrPkt, hsr.MaxPkts)
 	h := hsr.NewHSR()
 	for {
 		usedPortIdxs := make(map[int]bool)
@@ -72,7 +72,7 @@ func (r *Router) readHSRInput(q chan *rpkt.RPkt) {
 	}
 }
 
-func (r *Router) writeHSROutput(rp *rpkt.RPkt, portID int, labels prometheus.Labels) {
+func (r *Router) writeHSROutput(rp *rpkt.RtrPkt, portID int, labels prometheus.Labels) {
 	for _, epair := range rp.Egress {
 		if epair.Dst == nil {
 			rp.Crit("No dst address set")

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -44,6 +44,12 @@ func main() {
 		profile.Start(*id)
 	}
 	setupSignals()
+	// Set max virtual memory size to 1GiB in bytes.
+	rLimit := &syscall.Rlimit{Max: 1 << 30, Cur: 1 << 30}
+	if err := syscall.Setrlimit(syscall.RLIMIT_AS, rLimit); err != nil {
+		log.Crit("Setting RLIMIT_AS failed", "err", err)
+		os.Exit(1)
+	}
 	r, err := NewRouter(*id, *confDir)
 	if err != nil {
 		log.Crit("Startup failed", err.Ctx...)

--- a/go/border/rpkt/addr.go
+++ b/go/border/rpkt/addr.go
@@ -16,7 +16,7 @@ package rpkt
 
 import (
 	"github.com/netsec-ethz/scion/go/lib/addr"
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 const (
@@ -26,29 +26,29 @@ const (
 	ErrorGetDstHost = "Unable to retrieve destination host"
 )
 
-func (rp *RPkt) SrcIA() (*addr.ISD_AS, *util.Error) {
+func (rp *RtrPkt) SrcIA() (*addr.ISD_AS, *common.Error) {
 	if rp.srcIA == nil {
-		var err *util.Error
+		var err *common.Error
 		rp.srcIA, err = rp.hookIA(rp.hooks.SrcIA, rp.idxs.srcIA)
 		if err != nil {
-			return nil, util.NewError(ErrorGetSrcIA, "err", err)
+			return nil, common.NewError(ErrorGetSrcIA, "err", err)
 		}
 	}
 	return rp.srcIA, nil
 }
 
-func (rp *RPkt) DstIA() (*addr.ISD_AS, *util.Error) {
+func (rp *RtrPkt) DstIA() (*addr.ISD_AS, *common.Error) {
 	if rp.dstIA == nil {
-		var err *util.Error
+		var err *common.Error
 		rp.dstIA, err = rp.hookIA(rp.hooks.DstIA, rp.idxs.dstIA)
 		if err != nil {
-			return nil, util.NewError(ErrorGetDstIA, "err", err)
+			return nil, common.NewError(ErrorGetDstIA, "err", err)
 		}
 	}
 	return rp.dstIA, nil
 }
 
-func (rp *RPkt) hookIA(hooks []HookIA, idx int) (*addr.ISD_AS, *util.Error) {
+func (rp *RtrPkt) hookIA(hooks []HookIA, idx int) (*addr.ISD_AS, *common.Error) {
 	for _, f := range hooks {
 		ret, ia, err := f()
 		switch {
@@ -63,30 +63,30 @@ func (rp *RPkt) hookIA(hooks []HookIA, idx int) (*addr.ISD_AS, *util.Error) {
 	return addr.IAFromRaw(rp.Raw[idx:]), nil
 }
 
-func (rp *RPkt) SrcHost() (addr.HostAddr, *util.Error) {
+func (rp *RtrPkt) SrcHost() (addr.HostAddr, *common.Error) {
 	if rp.srcHost == nil {
-		var err *util.Error
+		var err *common.Error
 		rp.srcHost, err = rp.hookHost(rp.hooks.SrcHost, rp.idxs.srcHost, rp.CmnHdr.SrcType)
 		if err != nil {
-			return nil, util.NewError(ErrorGetSrcHost, "err", err)
+			return nil, common.NewError(ErrorGetSrcHost, "err", err)
 		}
 	}
 	return rp.srcHost, nil
 }
 
-func (rp *RPkt) DstHost() (addr.HostAddr, *util.Error) {
+func (rp *RtrPkt) DstHost() (addr.HostAddr, *common.Error) {
 	if rp.dstHost == nil {
-		var err *util.Error
+		var err *common.Error
 		rp.dstHost, err = rp.hookHost(rp.hooks.DstHost, rp.idxs.dstHost, rp.CmnHdr.DstType)
 		if err != nil {
-			return nil, util.NewError(ErrorGetDstHost, "err", err)
+			return nil, common.NewError(ErrorGetDstHost, "err", err)
 		}
 	}
 	return rp.dstHost, nil
 }
 
-func (rp *RPkt) hookHost(
-	hooks []HookHost, idx int, htype uint8) (addr.HostAddr, *util.Error) {
+func (rp *RtrPkt) hookHost(
+	hooks []HookHost, idx int, htype uint8) (addr.HostAddr, *common.Error) {
 	for _, f := range hooks {
 		ret, host, err := f()
 		switch {

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -20,65 +20,129 @@ import (
 	log "github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"
 
-	"github.com/netsec-ethz/scion/go/border/conf"
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/l4"
 	"github.com/netsec-ethz/scion/go/lib/spkt"
-	"github.com/netsec-ethz/scion/go/lib/util"
-	"github.com/netsec-ethz/scion/go/proto"
 )
 
-func CreateCtrlPacket(dirTo Dir, srcHost addr.HostAddr, dstIA *addr.ISD_AS,
-	dstHost addr.HostAddr) (*RPkt, *util.Error) {
-	addrLen := addr.IABytes*2 + srcHost.Size() + dstHost.Size()
-	addrPad := util.CalcPadding(addrLen, common.LineLen)
-	hdrLen := spkt.CmnHdrLen + addrLen + addrPad
-	rp := &RPkt{}
-	rp.Raw = make(util.RawBytes, hdrLen)
+func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo Dir) (*RtrPkt, *common.Error) {
+	rp := NewRtrPkt()
+	hdrLen := sp.HdrLen()
+	totalLen := sp.TotalLen()
 	rp.TimeIn = time.Now()
-	rp.Logger = log.New("rpkt", logext.RandId(4))
+	rp.Id = logext.RandId(4)
+	rp.Logger = log.New("rpkt", rp.Id)
 	rp.DirFrom = DirSelf
 	rp.DirTo = dirTo
 	// Fill in common header and write it out
-	rp.CmnHdr.SrcType = srcHost.Type()
-	rp.CmnHdr.DstType = dstHost.Type()
+	rp.CmnHdr.SrcType = sp.SrcHost.Type()
+	rp.CmnHdr.DstType = sp.DstHost.Type()
 	rp.CmnHdr.HdrLen = uint8(hdrLen)
-	rp.CmnHdr.TotalLen = uint16(hdrLen)
-	rp.CmnHdr.NextHdr = common.L4UDP
+	rp.CmnHdr.TotalLen = uint16(totalLen)
+	rp.CmnHdr.NextHdr = common.L4None
 	rp.CmnHdr.CurrInfoF = uint8(hdrLen)
 	rp.CmnHdr.CurrHopF = uint8(hdrLen)
-	rp.CmnHdr.Write(rp.Raw)
 	// Fill in address header and indexes
 	rp.idxs.srcIA = spkt.CmnHdrLen
-	rp.srcIA = conf.C.IA
+	rp.srcIA = sp.SrcIA
 	rp.idxs.srcHost = rp.idxs.srcIA + addr.IABytes
-	rp.srcHost = srcHost
+	rp.srcHost = sp.SrcHost
 	rp.idxs.dstIA = rp.idxs.srcHost + rp.srcHost.Size()
-	rp.dstIA = dstIA
+	rp.dstIA = sp.DstIA
 	rp.idxs.dstHost = rp.idxs.dstIA + addr.IABytes
-	rp.dstHost = dstHost
-	rp.idxs.path = hdrLen
-	rp.idxs.l4 = hdrLen
-	// Write out address header
+	rp.dstHost = sp.DstHost
 	rp.srcIA.Write(rp.Raw[rp.idxs.srcIA:])
 	copy(rp.Raw[rp.idxs.srcHost:], rp.srcHost.Pack())
 	rp.dstIA.Write(rp.Raw[rp.idxs.dstIA:])
 	copy(rp.Raw[rp.idxs.dstHost:], rp.dstHost.Pack())
+	// Fill in path
+	rp.idxs.path = spkt.CmnHdrLen + sp.AddrLen()
+	if sp.Path != nil {
+		copy(rp.Raw[rp.idxs.path:], sp.Path.Raw)
+		rp.CmnHdr.CurrInfoF = uint8(rp.idxs.path) + sp.Path.InfOff
+		rp.CmnHdr.CurrHopF = uint8(rp.idxs.path) + sp.Path.HopOff
+	}
+	// Fill in extensions
+	rp.idxs.l4 = hdrLen // Will be updated as necessary by ExtnAddHBH
+	for _, se := range sp.HBHExt {
+		if err := rp.extnAddHBH(se); err != nil {
+			return nil, err
+		}
+	}
+	// Fill in L4 Header
+	rp.idxs.pld = hdrLen // Will be updated as necessary by AddL4
+	if sp.L4 != nil {
+		if err := rp.addL4(sp.L4); err != nil {
+			return nil, err
+		}
+		// Fill in payload
+		if err := rp.SetPld(sp.Pld); err != nil {
+			return nil, err
+		}
+	} else {
+		// Trim buffer to the end of the last extension header (or path header,
+		// if there are no extensions)
+		rp.Raw = rp.Raw[:rp.idxs.l4]
+		rp.CmnHdr.TotalLen = uint16(len(rp.Raw))
+		rp.CmnHdr.Write(rp.Raw)
+	}
 	return rp, nil
 }
 
-func (rp *RPkt) AddL4UDP(srcPort, dstPort int) {
-	rp.L4Type = common.L4UDP
-	udp := l4.UDP{SrcPort: uint16(srcPort), DstPort: uint16(dstPort)}
-	rp.l4 = L4Header(&udp)
-	rp.idxs.pld = rp.idxs.l4 + l4.UDPLen
+func (rp *RtrPkt) addL4(l4h l4.L4Header) *common.Error {
+	rp.L4Type = l4h.L4Type()
+	rp.l4 = l4h
+	// Reset buffer to full size
+	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+	// Write L4 header into buffer
+	if err := rp.l4.Write(rp.Raw[rp.idxs.l4:]); err != nil {
+		return err
+	}
+	// Locate the last extension in the packet, whether HBH (hop-by-hop) or E2E (end-to-end),
+	// so that its sub-header can be updated with the L4 prototcol type.
+	rp.idxs.pld = rp.idxs.l4 + l4h.L4Len()
+	var nextHdr *uint8
+	for _, eIdx := range rp.idxs.hbhExt {
+		nextHdr = &rp.Raw[eIdx.Index]
+	}
+	for _, eIdx := range rp.idxs.e2eExt {
+		nextHdr = &rp.Raw[eIdx.Index]
+	}
+	if nextHdr != nil {
+		// Last extension sub-header found, update its nextHdr field.
+		*nextHdr = uint8(rp.L4Type)
+	} else {
+		// There are no extensions, so the common header NextHDr field needs to be updated.
+		rp.CmnHdr.NextHdr = rp.L4Type
+	}
+	// Trim buffer to the end of the L4 header.
+	rp.Raw = rp.Raw[:rp.idxs.pld]
+	rp.CmnHdr.TotalLen = uint16(len(rp.Raw))
+	rp.CmnHdr.Write(rp.Raw)
+	return nil
 }
 
-func (rp *RPkt) AddCtrlPld(msg *proto.SCION) *util.Error {
-	rp.pld = msg
-	rawLen := len(rp.Raw)
-	rp.Raw = append(rp.Raw, make(util.RawBytes, rp.idxs.pld-rawLen)...)
-	rp.Raw = rp.Raw[:rawLen]
-	return rp.updateCtrlPld()
+func (rp *RtrPkt) SetPld(pld common.Payload) *common.Error {
+	rp.pld = pld
+	var plen int
+	if rp.pld != nil {
+		// Reset buffer to full size
+		rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+		// Write payload into buffer
+		var err *common.Error
+		plen, err = rp.pld.Write(rp.Raw[rp.idxs.pld:])
+		if err != nil {
+			return err
+		}
+	}
+	// Trim buffer to the end of the payload.
+	rp.Raw = rp.Raw[:rp.idxs.pld+plen]
+	// Update headers
+	if err := rp.updateL4(); err != nil {
+		return err
+	}
+	rp.CmnHdr.TotalLen = uint16(len(rp.Raw))
+	rp.CmnHdr.Write(rp.Raw)
+	return nil
 }

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -18,28 +18,32 @@ import (
 	log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/border/conf"
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/spath"
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/spkt"
 )
 
-type OneHopPath struct {
+var _ RExtension = (*ROneHopPath)(nil)
+
+type ROneHopPath struct {
 	log.Logger
-	rp *RPkt
+	rp *RtrPkt
+	spkt.OneHopPath
 }
 
-func OneHopPathFromRaw(rp *RPkt) (*OneHopPath, *util.Error) {
-	o := &OneHopPath{rp: rp}
+func ROneHopPathFromRaw(rp *RtrPkt) (*ROneHopPath, *common.Error) {
+	o := &ROneHopPath{rp: rp}
 	o.Logger = rp.Logger.New("ext", "OneHopPath")
 	o.rp = rp
 	return o, nil
 }
 
-func (o *OneHopPath) RegisterHooks(hooks *Hooks) *util.Error {
+func (o *ROneHopPath) RegisterHooks(hooks *Hooks) *common.Error {
 	hooks.HopF = append(hooks.HopF, o.HopF)
 	return nil
 }
 
-func (o *OneHopPath) HopF() (HookResult, *spath.HopField, *util.Error) {
+func (o *ROneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 	if o.rp.DirFrom == DirLocal {
 		return HookContinue, nil, nil
 	}
@@ -60,6 +64,18 @@ func (o *OneHopPath) HopF() (HookResult, *spath.HopField, *util.Error) {
 	return HookContinue, nil, nil
 }
 
-func (o *OneHopPath) String() string {
+func (o *ROneHopPath) Type() common.ExtnType {
+	return common.ExtnOneHopPathType
+}
+
+func (o *ROneHopPath) Len() int {
+	return common.LineLen
+}
+
+func (o *ROneHopPath) String() string {
 	return "OneHopPath"
+}
+
+func (o *ROneHopPath) GetExtn() (common.Extension, *common.Error) {
+	return &o.OneHopPath, nil
 }

--- a/go/border/rpkt/extn_traceroute.go
+++ b/go/border/rpkt/extn_traceroute.go
@@ -15,7 +15,6 @@
 package rpkt
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -24,14 +23,14 @@ import (
 	"github.com/netsec-ethz/scion/go/border/conf"
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/spkt"
 )
 
-var _ Extension = (*Traceroute)(nil)
+var _ RExtension = (*RTraceroute)(nil)
 
-type Traceroute struct {
-	rp        *RPkt
-	raw       util.RawBytes
+type RTraceroute struct {
+	rp        *RtrPkt
+	raw       common.RawBytes
 	NumHops   uint8
 	TotalHops uint8
 	log.Logger
@@ -47,64 +46,65 @@ const (
 
 var ErrorLenMultiple = fmt.Sprintf("Header length isn't a multiple of %dB", common.LineLen)
 
-func TracerouteFromRaw(rp *RPkt, start, end int) (*Traceroute, *util.Error) {
-	t := &Traceroute{rp: rp, raw: rp.Raw[start:end]}
-	// Index past ext subheader:
-	t.NumHops = t.raw[3]
-	// Ignore subheader line:
-	t.TotalHops = uint8(len(t.raw)/common.LineLen) - 1
+func RTracerouteFromRaw(rp *RtrPkt, start, end int) (*RTraceroute, *common.Error) {
+	t := &RTraceroute{rp: rp, raw: rp.Raw[start:end]}
+	t.NumHops = t.raw[0]
+	// Ignore subheader line
+	t.TotalHops = uint8(len(t.raw)-common.ExtnSubHdrLen) / common.LineLen
 	t.Logger = rp.Logger.New("ext", "traceroute")
 	return t, nil
 }
 
-func (t *Traceroute) Add(entry *TracerouteEntry) *util.Error {
+func (t *RTraceroute) Add(entry *spkt.TracerouteEntry) *common.Error {
 	if t.NumHops == t.TotalHops {
-		return util.NewError(ErrorHdrFull, log.Ctx{"entries": t.NumHops})
+		return common.NewError(ErrorHdrFull, log.Ctx{"entries": t.NumHops})
 	}
 	t.NumHops += 1
 	offset := common.LineLen * t.NumHops
 	entry.IA.Write(t.raw[offset:])
 	offset += addr.IABytes
-	order.PutUint16(t.raw[offset:], entry.IfID)
+	common.Order.PutUint16(t.raw[offset:], entry.IfID)
 	offset += 2
-	order.PutUint16(t.raw[offset:], entry.TimeStamp)
+	common.Order.PutUint16(t.raw[offset:], entry.TimeStamp)
 	return nil
 }
 
-func (t *Traceroute) Entry(idx int) (*TracerouteEntry, *util.Error) {
+func (t *RTraceroute) Entry(idx int) (*spkt.TracerouteEntry, *common.Error) {
 	if idx > int(t.NumHops-1) {
-		return nil, util.NewError(ErrorIdx, "idx", idx, "max", t.NumHops-1)
+		return nil, common.NewError(ErrorIdx, "idx", idx, "max", t.NumHops-1)
 	}
-	entry := TracerouteEntry{}
+	entry := spkt.TracerouteEntry{}
 	offset := common.LineLen * (idx + 1)
 	entry.IA = *addr.IAFromRaw(t.raw[offset:])
 	offset += addr.IABytes
-	entry.IfID = order.Uint16(t.raw[offset:])
+	entry.IfID = common.Order.Uint16(t.raw[offset:])
 	offset += 2
-	entry.TimeStamp = order.Uint16(t.raw[offset:])
+	entry.TimeStamp = common.Order.Uint16(t.raw[offset:])
 	return &entry, nil
 }
 
-func (t *Traceroute) RegisterHooks(h *Hooks) *util.Error {
+func (t *RTraceroute) RegisterHooks(h *Hooks) *common.Error {
 	h.Validate = append(h.Validate, t.Validate)
 	h.Process = append(h.Process, t.Process)
 	return nil
 }
 
-func (t *Traceroute) Validate() (HookResult, *util.Error) {
-	if len(t.raw)%common.LineLen != 0 {
-		return HookError, util.NewError(ErrorLenMultiple, "len", len(t.raw))
+func (t *RTraceroute) Validate() (HookResult, *common.Error) {
+	if (len(t.raw)-common.ExtnFirstLineLen)%common.LineLen != 0 {
+		return HookError, common.NewError(ErrorLenMultiple, "len", len(t.raw))
 	}
 	if t.NumHops > t.TotalHops {
-		return HookError, util.NewError(ErrorTooManyEntries,
+		return HookError, common.NewError(ErrorTooManyEntries,
 			"max", t.TotalHops, "actual", t.NumHops)
 	}
 	return HookContinue, nil
 }
 
-func (t *Traceroute) Process() (HookResult, *util.Error) {
+func (t *RTraceroute) Process() (HookResult, *common.Error) {
 	ts := (time.Now().UnixNano() / 1000) % (1 << 16)
-	entry := TracerouteEntry{*conf.C.IA, uint16(*t.rp.ifCurr), uint16(ts)}
+	entry := spkt.TracerouteEntry{
+		IA: *conf.C.IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
+	}
 	if err := t.Add(&entry); err != nil {
 		t.Error("Unable to add entry", err)
 	}
@@ -112,28 +112,35 @@ func (t *Traceroute) Process() (HookResult, *util.Error) {
 	return HookContinue, nil
 }
 
-func (t *Traceroute) String() string {
-	buf := &bytes.Buffer{}
-	fmt.Fprintf(buf, "Traceroute (%dB): Hops filled/total: %d/%d\n",
-		len(t.raw), t.NumHops, t.TotalHops)
+func (t *RTraceroute) GetExtn() (common.Extension, *common.Error) {
+	s := spkt.NewTraceroute(int(t.TotalHops))
 	for i := 0; i < int(t.NumHops); i++ {
 		entry, err := t.Entry(i)
 		if err != nil {
-			t.Error("Unable to retrieve entry", "idx", i, "err", err)
-			fmt.Fprintf(buf, "ERROR")
-			break
+			return nil, err
 		}
-		fmt.Fprintf(buf, "%s\n", entry)
+		s.Hops = append(s.Hops, entry)
 	}
-	return buf.String()
+	return s, nil
 }
 
-type TracerouteEntry struct {
-	IA        addr.ISD_AS
-	IfID      uint16
-	TimeStamp uint16
+func (t *RTraceroute) Len() int {
+	return len(t.raw)
 }
 
-func (t *TracerouteEntry) String() string {
-	return fmt.Sprintf("IA: %s IfID: %v Timestamp: %v", t.IA, t.IfID, t.TimeStamp)
+func (t *RTraceroute) Class() common.L4ProtocolType {
+	return common.HopByHopClass
+}
+
+func (t *RTraceroute) Type() common.ExtnType {
+	return common.ExtnTracerouteType
+}
+
+func (t *RTraceroute) String() string {
+	// Delegate string representation to spkt.Traceroute
+	e, err := t.GetExtn()
+	if err != nil {
+		return fmt.Sprintf("Traceroute - %v: %v", err.Desc, err.String())
+	}
+	return e.String()
 }

--- a/go/border/rpkt/extns.go
+++ b/go/border/rpkt/extns.go
@@ -15,23 +15,21 @@
 package rpkt
 
 import (
-	"fmt"
-
 	//log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/scmp"
 )
 
-type Extension interface {
-	fmt.Stringer
-	RegisterHooks(*Hooks) *util.Error
+type RExtension interface {
+	common.ExtnBase
+	GetExtn() (common.Extension, *common.Error)
+	RegisterHooks(*Hooks) *common.Error
 }
 
-const ExtMaxHopByHop = 3
-
 const (
-	ErrorUnsupportedExt  = "Unsupported extension"
+	ErrorBadHopByHop     = "Unsupported hop-by-hop extension"
+	ErrorBadEnd2End      = "Unsupported end2end extension"
 	ErrorExtChainTooLong = "Extension header chain longer than packet"
 )
 
@@ -41,17 +39,70 @@ var ExtHBHKnown = map[common.ExtnType]bool{
 	common.ExtnSIBRAType:      true,
 }
 
-func (rp *RPkt) ExtnParse(extType common.ExtnType, start, end int) (Extension, *util.Error) {
+func (rp *RtrPkt) ExtnParseHBH(extType common.ExtnType,
+	start, end, pos int) (RExtension, *common.Error) {
 	switch {
 	case extType == common.ExtnTracerouteType:
-		return TracerouteFromRaw(rp, start, end)
+		return RTracerouteFromRaw(rp, start, end)
 	case extType == common.ExtnOneHopPathType:
-		return OneHopPathFromRaw(rp)
+		return ROneHopPathFromRaw(rp)
 	case extType == common.ExtnSCMPType:
-		return SCMPExtFromRaw(rp, start, end)
-	case ExtHBHKnown[extType]:
-		return nil, util.NewError("Known but unsupported extension", "type", extType)
+		return RSCMPExtFromRaw(rp, start, end)
 	default:
-		return nil, util.NewError(ErrorUnsupportedExt, "type", extType)
+		sdata := scmp.NewErrData(scmp.C_Ext, scmp.T_E_BadHopByHop,
+			&scmp.InfoExtIdx{Idx: uint8(pos)})
+		return nil, common.NewErrorData(ErrorBadHopByHop, sdata, "type", extType)
 	}
+}
+
+func (rp *RtrPkt) extnAddHBH(e common.Extension) *common.Error {
+	max := common.ExtnMaxHBH
+	if len(rp.HBHExt) > 1 && rp.HBHExt[0].Type() == common.ExtnSCMPType {
+		max += 1
+	}
+	if len(rp.HBHExt) >= max {
+		// No point in generating an SCMP error, as this is a packet we're constructing locally.
+		return common.NewError(ErrorTooManyHBH, "curr", len(rp.HBHExt), "max", max)
+	}
+	if len(rp.HBHExt) > 1 && e.Type() == common.ExtnSCMPType {
+		return common.NewError("Bad extension order - SCMP must be first",
+			"idx", len(rp.HBHExt), "first", rp.HBHExt[0].Type())
+	}
+	offset := int(rp.CmnHdr.HdrLen)
+	var nextHdr *uint8 = (*uint8)(&rp.CmnHdr.NextHdr)
+	for i, hIdx := range rp.idxs.hbhExt {
+		nextHdr = &rp.Raw[hIdx.Index]
+		offset = hIdx.Index + common.ExtnSubHdrLen + rp.HBHExt[i].Len()
+	}
+	// Check if the extension's length is legal
+	eLen := e.Len() + common.ExtnSubHdrLen
+	if eLen%common.LineLen != 0 {
+		return common.NewError("HBH Ext length not multiple of line length",
+			"lineLen", common.LineLen, "actual", eLen)
+	}
+	et := e.Type()
+	// Set the preceding NextHdr field, whether it's in the common header, or a
+	// preceding hop-by-hop extension.
+	*nextHdr = uint8(et.Class)
+	// Write extension sub-header into buffer
+	rp.Raw[offset] = uint8(common.L4None)
+	rp.Raw[offset+1] = uint8(eLen/common.LineLen) - 1
+	rp.Raw[offset+2] = et.Type
+	// Write extension into buffer
+	if err := e.Write(rp.Raw[offset+common.ExtnSubHdrLen : offset+eLen]); err != nil {
+		return err
+	}
+	// Parse extension back in, to set up appropriate metadata
+	re, err := rp.ExtnParseHBH(e.Type(), offset+common.ExtnSubHdrLen,
+		offset+eLen, len(rp.idxs.hbhExt))
+	if err != nil {
+		return err
+	}
+	re.RegisterHooks(&rp.hooks)
+	rp.HBHExt = append(rp.HBHExt, re)
+	// Update metadata indexes
+	rp.idxs.hbhExt = append(rp.idxs.hbhExt, extnIdx{e.Type(), offset})
+	rp.idxs.l4 = offset + eLen
+	rp.idxs.pld = rp.idxs.l4
+	return nil
 }

--- a/go/border/rpkt/hooks.go
+++ b/go/border/rpkt/hooks.go
@@ -16,21 +16,22 @@ package rpkt
 
 import (
 	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/l4"
 	"github.com/netsec-ethz/scion/go/lib/spath"
-	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
-type HookIA func() (HookResult, *addr.ISD_AS, *util.Error)
-type HookHost func() (HookResult, addr.HostAddr, *util.Error)
-type HookInfoF func() (HookResult, *spath.InfoField, *util.Error)
-type HookHopF func() (HookResult, *spath.HopField, *util.Error)
-type HookBool func() (HookResult, bool, *util.Error)
-type HookIntf func(up bool, dirFrom, dirTo Dir) (HookResult, spath.IntfID, *util.Error)
-type HookValidate func() (HookResult, *util.Error)
-type HookL4 func() (HookResult, interface{}, *util.Error)
-type HookPayload func() (HookResult, interface{}, *util.Error)
-type HookProcess func() (HookResult, *util.Error)
-type HookRoute func() (HookResult, *util.Error)
+type HookIA func() (HookResult, *addr.ISD_AS, *common.Error)
+type HookHost func() (HookResult, addr.HostAddr, *common.Error)
+type HookInfoF func() (HookResult, *spath.InfoField, *common.Error)
+type HookHopF func() (HookResult, *spath.HopField, *common.Error)
+type HookBool func() (HookResult, bool, *common.Error)
+type HookIntf func(up bool, dirFrom, dirTo Dir) (HookResult, spath.IntfID, *common.Error)
+type HookValidate func() (HookResult, *common.Error)
+type HookL4 func() (HookResult, l4.L4Header, *common.Error)
+type HookPayload func() (HookResult, common.Payload, *common.Error)
+type HookProcess func() (HookResult, *common.Error)
+type HookRoute func() (HookResult, *common.Error)
 
 type Hooks struct {
 	SrcIA    []HookIA

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -17,7 +17,9 @@ package rpkt
 import (
 	"github.com/netsec-ethz/scion/go/border/conf"
 	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/assert"
 	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/scmp"
 	"github.com/netsec-ethz/scion/go/lib/spkt"
 	"github.com/netsec-ethz/scion/go/lib/util"
 )
@@ -28,10 +30,11 @@ const (
 	ErrorTooManyHBH  = "Too many hop-by-hop extensions"
 )
 
-func (rp *RPkt) Parse() *util.Error {
+func (rp *RtrPkt) Parse() *common.Error {
 	if err := rp.parseBasic(); err != nil {
 		return err
 	}
+	// TODO(kormat): support end2end extensions where the router is the destination
 	if err := rp.parseHopExtns(); err != nil {
 		return err
 	}
@@ -56,17 +59,21 @@ func (rp *RPkt) Parse() *util.Error {
 	if _, err := rp.IFCurr(); err != nil {
 		return err
 	}
+	if _, err := rp.IFNext(); err != nil {
+		return err
+	}
 	if *rp.dstIA != *conf.C.IA {
 		if _, err := rp.IFNext(); err != nil {
 			return err
 		}
 	}
+	rp.setDirTo()
 	return nil
 }
 
 // Parse Common and address headers
-func (rp *RPkt) parseBasic() *util.Error {
-	var err *util.Error
+func (rp *RtrPkt) parseBasic() *common.Error {
+	var err *common.Error
 	if err := rp.CmnHdr.Parse(rp.Raw); err != nil {
 		return err
 	}
@@ -74,46 +81,61 @@ func (rp *RPkt) parseBasic() *util.Error {
 	rp.idxs.srcHost = rp.idxs.srcIA + addr.IABytes
 	srcLen, err := addr.HostLen(rp.CmnHdr.SrcType)
 	if err != nil {
+		if err.Desc == addr.ErrorBadHostAddrType {
+			err.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil)
+		}
 		return err
 	}
 	rp.idxs.dstIA = rp.idxs.srcHost + int(srcLen)
 	rp.idxs.dstHost = rp.idxs.dstIA + addr.IABytes
 	dstLen, err := addr.HostLen(rp.CmnHdr.DstType)
 	if err != nil {
+		if err.Desc == addr.ErrorBadHostAddrType {
+			err.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil)
+		}
 		return err
 	}
 	addrLen := addr.IABytes + int(srcLen) + addr.IABytes + int(dstLen)
 	addrPad := util.CalcPadding(addrLen, common.LineLen)
 	rp.idxs.path = spkt.CmnHdrLen + addrLen + addrPad
 	if rp.idxs.path > int(rp.CmnHdr.HdrLen) {
-		return util.NewError(ErrorHdrTooShort, "min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen)
+		// Can't generate SCMP error as we can't parse anything after the address header
+		return common.NewError(ErrorHdrTooShort, "min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen)
 	}
 	return nil
 }
 
-func (rp *RPkt) parseHopExtns() *util.Error {
+func (rp *RtrPkt) parseHopExtns() *common.Error {
 	rp.idxs.hbhExt = make([]extnIdx, 0, 4)
-	nextHdr := rp.CmnHdr.NextHdr
-	offset := int(rp.CmnHdr.HdrLen)
+	rp.idxs.nextHdrIdx.Type = rp.CmnHdr.NextHdr
+	rp.idxs.nextHdrIdx.Index = int(rp.CmnHdr.HdrLen)
+	nextHdr := &rp.idxs.nextHdrIdx.Type
+	offset := &rp.idxs.nextHdrIdx.Index
 	count := 0
-	for offset < len(rp.Raw) {
-		currHdr := nextHdr
+	for *offset < len(rp.Raw) {
+		currHdr := *nextHdr
 		if currHdr != common.HopByHopClass { // Reached end2end header or L4 protocol
 			break
 		}
-		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[offset+2]}
+		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[*offset+2]}
 		if currExtn == common.ExtnSCMPType {
 			if count != 0 {
-				return util.NewError(ErrorExtOrder, "scmpIdx", count)
+				sdata := scmp.NewErrData(scmp.C_Ext, scmp.T_E_BadExtOrder,
+					&scmp.InfoExtIdx{Idx: uint8(len(rp.idxs.hbhExt))})
+				return common.NewErrorData(ErrorExtOrder, sdata, "scmpIdx", count)
 			}
 		} else {
 			count++
 		}
-		if count > ExtMaxHopByHop {
-			return util.NewError(ErrorTooManyHBH, "max", ExtMaxHopByHop, "actual", count)
+		if count > common.ExtnMaxHBH {
+			sdata := scmp.NewErrData(scmp.C_Ext, scmp.T_E_TooManyHopbyHop,
+				&scmp.InfoExtIdx{Idx: uint8(len(rp.idxs.hbhExt))})
+			return common.NewErrorData(ErrorTooManyHBH,
+				sdata, "max", common.ExtnMaxHBH, "actual", count)
 		}
-		hdrLen := int((rp.Raw[offset+1] + 1) * common.LineLen)
-		e, err := rp.ExtnParse(currExtn, offset, offset+hdrLen)
+		hdrLen := int((rp.Raw[*offset+1] + 1) * common.LineLen)
+		e, err := rp.ExtnParseHBH(
+			currExtn, *offset+common.ExtnSubHdrLen, *offset+hdrLen, len(rp.idxs.hbhExt))
 		if err != nil {
 			return err
 		}
@@ -121,14 +143,47 @@ func (rp *RPkt) parseHopExtns() *util.Error {
 			e.RegisterHooks(&rp.hooks)
 			rp.HBHExt = append(rp.HBHExt, e)
 		}
-		rp.idxs.hbhExt = append(rp.idxs.hbhExt, extnIdx{currExtn, offset})
-		nextHdr = common.L4ProtocolType(rp.Raw[offset])
-		offset += hdrLen
+		rp.idxs.hbhExt = append(rp.idxs.hbhExt, extnIdx{currExtn, *offset})
+		*nextHdr = common.L4ProtocolType(rp.Raw[*offset])
+		*offset += hdrLen
 	}
-	if offset > len(rp.Raw) {
-		return util.NewError(ErrorExtChainTooLong, "curr", offset, "max", len(rp.Raw))
+	if *offset > len(rp.Raw) {
+		// Can't generate SCMP error in general as we can't parse anything
+		// after the hbh extensions (e.g. an l4 header).
+		return common.NewError(ErrorExtChainTooLong, "curr", offset, "max", len(rp.Raw))
 	}
-	rp.idxs.nextHdrIdx.Type = nextHdr
-	rp.idxs.nextHdrIdx.Index = offset
 	return nil
+}
+
+// Figure out which Dir a packet is going to.
+func (rp *RtrPkt) setDirTo() {
+	if assert.On {
+		assert.Must(rp.DirFrom != DirSelf, rp.ErrStr("DirFrom must not be DirSelf."))
+		assert.Must(rp.DirFrom != DirUnset, rp.ErrStr("DirFrom must not be DirUnset."))
+		assert.Must(rp.ifCurr != nil, rp.ErrStr("rp.ifCurr must not be nil."))
+	}
+	if *rp.dstIA != *conf.C.IA {
+		// Packet is not destined to the local AS, so it can't be DirSelf.
+		if rp.DirFrom == DirLocal {
+			rp.DirTo = DirExternal
+		} else if rp.DirFrom == DirExternal {
+			// XXX(kormat): this logic might be too simple once a router can
+			// have multiple interfaces.
+			rp.DirTo = DirLocal
+		}
+		return
+	}
+	// Local AS is the destination, so figure out if it's DirLocal or DirSelf.
+	intf := conf.C.Net.IFs[*rp.ifCurr]
+	var intfHost addr.HostAddr
+	if rp.DirFrom == DirExternal {
+		intfHost = addr.HostFromIP(intf.IFAddr.PublicAddr().IP)
+	} else {
+		intfHost = addr.HostFromIP(conf.C.Net.LocAddr[intf.LocAddrIdx].PublicAddr().IP)
+	}
+	if addr.HostEq(rp.dstHost, intfHost) {
+		rp.DirTo = DirSelf
+	} else {
+		rp.DirTo = DirLocal
+	}
 }

--- a/go/border/rpkt/payload.go
+++ b/go/border/rpkt/payload.go
@@ -15,7 +15,7 @@
 package rpkt
 
 import (
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 const (
@@ -25,9 +25,9 @@ const (
 )
 
 // No fallback for payload - a hook must be registered to read it.
-func (rp *RPkt) Payload() (interface{}, *util.Error) {
+func (rp *RtrPkt) Payload(verify bool) (common.Payload, *common.Error) {
 	if rp.pld == nil && len(rp.hooks.Payload) > 0 {
-		_, err := rp.L4Hdr()
+		_, err := rp.L4Hdr(verify)
 		if err != nil {
 			return nil, err
 		}

--- a/go/border/rpkt/payload_ctrl.go
+++ b/go/border/rpkt/payload_ctrl.go
@@ -15,61 +15,31 @@
 package rpkt
 
 import (
-	"bytes"
-
-	"zombiezen.com/go/capnproto2"
-
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/util"
-	"github.com/netsec-ethz/scion/go/proto"
+	"github.com/netsec-ethz/scion/go/lib/spkt"
 )
 
-func (rp *RPkt) parseCtrlPayload() (HookResult, interface{}, *util.Error) {
+func (rp *RtrPkt) parseCtrlPayload() (HookResult, common.Payload, *common.Error) {
 	if rp.L4Type != common.L4UDP {
 		return HookContinue, nil, nil
 	}
-	rawPld := rp.Raw[rp.idxs.pld:]
-	pldLen := order.Uint32(rawPld)
-	rawPld = rawPld[4:]
-	if int(pldLen) != len(rawPld) {
-		return HookError, nil, util.NewError(ErrorPayloadLenWrong,
-			"expected", pldLen, "actual", len(rawPld))
-	}
-	buf := bytes.NewBuffer(rawPld)
-	msg, err := capnp.NewPackedDecoder(buf).Decode()
+	cpld, err := spkt.NewCtrlPldFromRaw(rp.Raw[rp.idxs.pld:])
 	if err != nil {
-		return HookError, nil, util.NewError(ErrorPayloadDecode, "err", err)
+		return HookError, nil, err
 	}
-	// Handle any panics while parsing
-	defer func() *util.Error {
-		if err := recover(); err != nil {
-			return util.NewError(ErrorPayloadParse, "err", err)
-		}
-		return nil
-	}()
-	pld, err := proto.ReadRootSCION(msg)
-	if err != nil {
-		return HookError, nil, util.NewError(ErrorPayloadParse, "err", err)
-	}
-	return HookFinish, &pld, nil
+	return HookFinish, cpld, nil
 }
 
-func (rp *RPkt) updateCtrlPld() *util.Error {
-	// First remove old payload, if any
-	rp.Raw = rp.Raw[:rp.idxs.pld]
-	var buf bytes.Buffer
-	// Reserve space for length
-	buf.Write(make([]byte, 4))
-	enc := capnp.NewPackedEncoder(&buf)
-	pld := rp.pld.(*proto.SCION)
-	if err := enc.Encode(pld.Segment().Message()); err != nil {
-		return util.NewError("Unable to encode ctrl payload", "err", err)
+func (rp *RtrPkt) updateCtrlPld() *common.Error {
+	// Reset buffer to full size
+	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+	// Write payload to buffer
+	plen, err := rp.pld.Write(rp.Raw[rp.idxs.pld:])
+	if err != nil {
+		return err
 	}
-	newPld := util.RawBytes(buf.Bytes())
-	// Set payload length
-	order.PutUint32(newPld, uint32(len(newPld)-4))
-	// Append new payload
-	rp.Raw = append(rp.Raw, newPld...)
+	// Trim buffer to the end of the payload.
+	rp.Raw = rp.Raw[:rp.idxs.pld+plen]
 	// Now start updating headers
 	if err := rp.updateL4(); err != nil {
 		return err

--- a/go/border/rpkt/payload_scmp.go
+++ b/go/border/rpkt/payload_scmp.go
@@ -15,12 +15,14 @@
 package rpkt
 
 import (
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/scmp"
-	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
-func (rp *RPkt) parseSCMPPayload() (HookResult, interface{}, *util.Error) {
-	pld, err := scmp.PldFromRaw(rp.Raw[rp.idxs.pld:], rp.l4.(*scmp.Hdr))
+func (rp *RtrPkt) parseSCMPPayload() (HookResult, common.Payload, *common.Error) {
+	hdr := rp.l4.(*scmp.Hdr)
+	pld, err := scmp.PldFromRaw(rp.Raw[rp.idxs.pld:],
+		scmp.ClassType{Class: hdr.Class, Type: hdr.Type})
 	if err != nil {
 		return HookError, nil, err
 	}

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -15,7 +15,7 @@
 package rpkt
 
 import (
-	"encoding/binary"
+	"fmt"
 	"net"
 	"time"
 
@@ -23,54 +23,103 @@ import (
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/l4"
+	"github.com/netsec-ethz/scion/go/lib/scmp"
 	"github.com/netsec-ethz/scion/go/lib/spath"
 	"github.com/netsec-ethz/scion/go/lib/spkt"
-	"github.com/netsec-ethz/scion/go/lib/util"
 	"github.com/netsec-ethz/scion/go/proto"
 )
+
+// FIXME(kormat): this should be reduced as soon as we respect the actual link MTU.
+const pktBufSize = 1 << 16
 
 var callbacks struct {
 	locOutFs   map[int]OutputFunc
 	intfOutFs  map[spath.IntfID]OutputFunc
 	ifStateUpd func(proto.IFStateInfos)
-	revTokenF  func(util.RawBytes)
+	revTokenF  func(common.RawBytes)
 }
 
 func Init(locOut map[int]OutputFunc, intfOut map[spath.IntfID]OutputFunc,
-	ifStateUpd func(proto.IFStateInfos), revTokenF func(util.RawBytes)) {
+	ifStateUpd func(proto.IFStateInfos), revTokenF func(common.RawBytes)) {
 	callbacks.locOutFs = locOut
 	callbacks.intfOutFs = intfOut
 	callbacks.ifStateUpd = ifStateUpd
 	callbacks.revTokenF = revTokenF
 }
 
-// Router representation of SCION packet, including metadata.
-type RPkt struct {
-	Raw       util.RawBytes
-	TimeIn    time.Time
-	DirFrom   Dir
-	DirTo     Dir
-	Ingress   AddrPair
-	Egress    []EgressPair
-	CmnHdr    spkt.CmnHdr
-	idxs      packetIdxs
-	srcIA     *addr.ISD_AS
-	srcHost   addr.HostAddr
-	dstIA     *addr.ISD_AS
-	dstHost   addr.HostAddr
-	infoF     *spath.InfoField
-	hopF      *spath.HopField
-	ifCurr    *spath.IntfID
-	ifNext    *spath.IntfID
-	upFlag    *bool
-	HBHExt    []Extension
-	E2EExt    []Extension
-	L4Type    common.L4ProtocolType
-	l4        L4Header
-	pld       interface{}
-	hooks     Hooks
+// Router representation of SCION packet, including metadata.  The comments for the members have
+// tags to specifiy if the member is set during receiving (RECV), parsing (PARSE), processing
+// (PROCESS) or routing (ROUTE). A number of the non-exported fields are pointers, as they are
+// either optional or computed only on demand.
+type RtrPkt struct {
+	// Id is a pseudo-random identifier for a packet, to allow correlation of logging statements.
+	// (RECV)
+	Id string
+	// Raw is the underlying buffer that represents the raw packet bytes. (RECV)
+	Raw common.RawBytes
+	// TimeIn is the time the packet was received. This is used for metrics calculations. (RECV)
+	TimeIn time.Time
+	// DirFrom is the direction from which the packet was received. (RECV)
+	DirFrom Dir
+	// DirTo is the direction to which the packet is travelling. (PARSE)
+	DirTo Dir
+	// Ingress contains the incoming overlay metadata the packet arrived with, and the (list of)
+	// interface(s) it arrived on. (RECV)
+	Ingress AddrIFPair
+	// Egress is a list of function & address pairs that determine how and where to the packet will
+	// be sent. (PROCESS/ROUTE)
+	Egress []EgressPair
+	// CmnHdr is the SCION common header. Required for every packet. (PARSE)
+	CmnHdr spkt.CmnHdr
+	// idxs contains a set of indexes into Raw which point to the start of certain sections of the
+	// packet. (PARSE)
+	idxs packetIdxs
+	// srcIA is the source ISD-AS. (PARSE, only if needed)
+	srcIA *addr.ISD_AS
+	// srcHost is the source Host. (PARSE, only if needed)
+	srcHost addr.HostAddr
+	// dstIA is the destination ISD-AS. (PARSE)
+	dstIA *addr.ISD_AS
+	// dstHost is the destination Host. (PARSE, only if dstIA is local)
+	dstHost addr.HostAddr
+	// infoF is the current Info Field, if any. (PARSE)
+	infoF *spath.InfoField
+	// hopF is the current Hop Field, if any. (PARSE)
+	hopF *spath.HopField
+	// ifCurr is the current interface ID. (PARSE)
+	ifCurr *spath.IntfID
+	// ifNext is the next interface ID, if any. (PARSE)
+	ifNext *spath.IntfID
+	// upFlag indicates if the packet is currently on an up path. (PARSE)
+	upFlag *bool
+	// HBHExt is the list of Hop-by-hop extensions, if any. (PARSE)
+	HBHExt []RExtension
+	// E2EExt is the list of end2end extensions, if any. (PARSE, only if needed)
+	// TODO(kormat): The router currently ignores these.
+	E2EExt []RExtension
+	// L4Type is the type of the L4 protocol. If there isn't an L4 header, this will be L4None
+	// (PROCESS, only if needed)
+	L4Type common.L4ProtocolType
+	// l4 is the L4 header, if any. (PROCESS, only if needed)
+	l4 l4.L4Header
+	// pld is the L4 payload, if any. (PROCESS, only if needed)
+	pld common.Payload
+	// hooks are registered callbacks to override/supplement normal processing. Their main use is
+	// for extensions to modify packet handling.  (PARSE/PROCESS, only if needed)
+	hooks Hooks
+	// SCMPError flags if the packet is an SCMP Error packet, in which case it should never trigger
+	// an error response packet. (PARSE, if SCMP extension header is present)
 	SCMPError bool
+	// Logger is used to log messages associated with a packet. The Id field is automatically
+	// included in the output.
 	log.Logger
+}
+
+func NewRtrPkt() *RtrPkt {
+	r := &RtrPkt{}
+	r.Raw = make(common.RawBytes, pktBufSize)
+	return r
 }
 
 type Dir int
@@ -97,12 +146,13 @@ func (d Dir) String() string {
 	}
 }
 
-type AddrPair struct {
-	Src *net.UDPAddr
-	Dst *net.UDPAddr
+type AddrIFPair struct {
+	Src   *net.UDPAddr
+	Dst   *net.UDPAddr
+	IfIDs []spath.IntfID
 }
 
-type OutputFunc func(*RPkt)
+type OutputFunc func(*RtrPkt)
 
 type EgressPair struct {
 	F   OutputFunc
@@ -132,14 +182,13 @@ type extnIdx struct {
 	Index int
 }
 
-var order = binary.BigEndian
-
-func (rp *RPkt) Reset() {
+func (rp *RtrPkt) Reset() {
 	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
 	rp.DirFrom = DirUnset
 	rp.DirTo = DirUnset
 	rp.Ingress.Src = nil
 	rp.Ingress.Dst = nil
+	rp.Ingress.IfIDs = nil
 	rp.Egress = rp.Egress[:0]
 	rp.idxs = packetIdxs{}
 	rp.srcIA = nil
@@ -159,4 +208,80 @@ func (rp *RPkt) Reset() {
 	rp.hooks = Hooks{}
 	rp.SCMPError = false
 	rp.Logger = nil
+}
+
+func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, *common.Error) {
+	var err *common.Error
+	sp := &spkt.ScnPkt{}
+	if sp.SrcIA, err = rp.SrcIA(); err != nil {
+		return nil, err
+	}
+	if sp.SrcHost, err = rp.SrcHost(); err != nil {
+		return nil, err
+	}
+	if sp.DstIA, err = rp.DstIA(); err != nil {
+		return nil, err
+	}
+	if sp.DstHost, err = rp.DstHost(); err != nil {
+		return nil, err
+	}
+	sp.Path = &spath.Path{
+		Raw:    rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLen],
+		InfOff: rp.CmnHdr.CurrInfoF - uint8(rp.idxs.path),
+		HopOff: rp.CmnHdr.CurrHopF - uint8(rp.idxs.path),
+	}
+	for _, re := range rp.HBHExt {
+		se, err := re.GetExtn()
+		if err != nil {
+			return nil, err
+		}
+		sp.HBHExt = append(sp.HBHExt, se)
+	}
+	for _, re := range rp.E2EExt {
+		se, err := re.GetExtn()
+		if err != nil {
+			return nil, err
+		}
+		sp.E2EExt = append(sp.E2EExt, se)
+	}
+	if sp.L4, err = rp.L4Hdr(verify); err != nil {
+		return nil, err
+	}
+	if sp.Pld, err = rp.Payload(verify); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+func (rp *RtrPkt) GetRaw(blk scmp.RawBlock) common.RawBytes {
+	switch blk {
+	case scmp.RawCmnHdr:
+		return rp.Raw[:spkt.CmnHdrLen]
+	case scmp.RawAddrHdr:
+		return rp.Raw[rp.idxs.srcIA:rp.idxs.path]
+	case scmp.RawPathHdr:
+		return rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLen]
+	case scmp.RawExtHdrs:
+		return rp.Raw[rp.CmnHdr.HdrLen:rp.idxs.l4]
+	case scmp.RawL4Hdr:
+		return rp.Raw[rp.idxs.l4:rp.idxs.pld]
+	}
+	rp.Crit("Invalid raw block requested", "blk", blk)
+	return nil
+}
+
+func (rp *RtrPkt) String() string {
+	// Pre-fetch required attributes
+	rp.SrcIA()
+	rp.SrcHost()
+	rp.DstIA()
+	rp.DstHost()
+	rp.InfoF()
+	rp.HopF()
+	return fmt.Sprintf("Id: %v Dir from/to: %v/%v Src: %v %v Dst: %v %v\n  InfoF: %v\n  HopF: %v",
+		rp.Id, rp.DirFrom, rp.DirTo, rp.srcIA, rp.srcHost, rp.dstIA, rp.dstHost, rp.infoF, rp.hopF)
+}
+
+func (rp *RtrPkt) ErrStr(desc string) string {
+	return fmt.Sprintf("Error: %v\n  RtrPkt: %v\n  Raw: %v", desc, rp, rp.Raw)
 }

--- a/go/discovery/main.go
+++ b/go/discovery/main.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/netsec-ethz/scion/go/zkutil"
 	"github.com/samuel/go-zookeeper/zk"
+
+	"github.com/netsec-ethz/scion/go/zkutil"
 )
 
 var zkHost = flag.String("zk-host", "127.0.0.1", "Zookeeper host")

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -15,12 +15,11 @@
 package addr
 
 import (
-	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 const (
@@ -36,19 +35,21 @@ const (
 	ErrorIAUnpack = "Unable to unpack ISD-AS"
 )
 
-var order = binary.BigEndian
-
-func IAFromRaw(b util.RawBytes) *ISD_AS {
-	iaInt := order.Uint32(b)
+func IAFromRaw(b common.RawBytes) *ISD_AS {
+	iaInt := common.Order.Uint32(b)
 	return &ISD_AS{I: int(iaInt >> 20), A: int(iaInt & 0x000FFFFF)}
 }
 
-func (ia *ISD_AS) Write(b util.RawBytes) {
-	order.PutUint32(b, uint32((ia.I<<20)|(ia.A&0x000FFFFF)))
+func (ia *ISD_AS) Write(b common.RawBytes) {
+	common.Order.PutUint32(b, uint32((ia.I<<20)|(ia.A&0x000FFFFF)))
 }
 
 func (ia *ISD_AS) SizeOf() int {
 	return IABytes
+}
+
+func (ia *ISD_AS) Copy() *ISD_AS {
+	return &ISD_AS{I: ia.I, A: ia.A}
 }
 
 func (ia ISD_AS) String() string {

--- a/go/lib/as_conf/conf.go
+++ b/go/lib/as_conf/conf.go
@@ -19,6 +19,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
@@ -39,10 +40,10 @@ const (
 
 var CurrConf *ASConf
 
-func Load(path string) *util.Error {
+func Load(path string) *common.Error {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return util.NewError(ErrorOpen, "err", err)
+		return common.NewError(ErrorOpen, "err", err)
 	}
 	if err := Parse(b, path); err != nil {
 		return err
@@ -50,10 +51,10 @@ func Load(path string) *util.Error {
 	return nil
 }
 
-func Parse(data []byte, path string) *util.Error {
+func Parse(data []byte, path string) *common.Error {
 	c := &ASConf{}
 	if err := yaml.Unmarshal(data, c); err != nil {
-		return util.NewError(ErrorParse, "err", err, "path", path)
+		return common.NewError(ErrorParse, "err", err, "path", path)
 	}
 	CurrConf = c
 	return nil

--- a/go/lib/as_conf/conf_test.go
+++ b/go/lib/as_conf/conf_test.go
@@ -17,8 +17,9 @@ package as_conf
 import (
 	"testing"
 
-	"github.com/netsec-ethz/scion/go/lib/util"
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
 func Test_ASConf(t *testing.T) {

--- a/go/lib/assert/assert.go
+++ b/go/lib/assert/assert.go
@@ -12,41 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package assert
 
 import (
-	"io"
-
-	"github.com/netsec-ethz/scion/go/lib/common"
+	"fmt"
 )
 
-var _ io.ReadWriter = (*Raw)(nil)
-
-type Raw struct {
-	B      common.RawBytes
-	Offset int
-}
-
-func (r *Raw) Peek(p []byte) (int, error) {
-	if len(r.B[r.Offset:]) <= 0 {
-		return 0, io.EOF
+func Must(condition bool, s string, args ...interface{}) {
+	if !condition {
+		panic(fmt.Sprintf(s, args...))
 	}
-	return copy(p, r.B[r.Offset:]), nil
-}
-
-func (r *Raw) Read(p []byte) (int, error) {
-	n, err := r.Peek(p)
-	if err == nil {
-		r.Offset += n
-	}
-	return n, err
-}
-
-func (r *Raw) Write(p []byte) (int, error) {
-	if len(r.B[r.Offset:]) == 0 {
-		return 0, io.EOF
-	}
-	count := copy(r.B[r.Offset:], p)
-	r.Offset += count
-	return count, nil
 }

--- a/go/lib/assert/const_off.go
+++ b/go/lib/assert/const_off.go
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+// +build !assert
 
-import (
-	"github.com/netsec-ethz/scion/go/lib/common"
-)
+package assert
 
-func CalcPadding(length, blkSize int) int {
-	spare := length % blkSize
-	if spare != 0 {
-		return blkSize - spare
-	}
-	return 0
-}
-
-func FillPadding(b common.RawBytes, length, blkSize int) int {
-	padding := CalcPadding(length, blkSize)
-	total := length + padding
-	for i := range b[length:total] {
-		b[i] = 0
-	}
-	return total
-}
+const On = false

--- a/go/lib/assert/const_on.go
+++ b/go/lib/assert/const_on.go
@@ -12,31 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+// +build assert
 
-import (
-	"fmt"
+package assert
 
-	"github.com/kormat/fmt15"
-)
-
-type Error struct {
-	Desc string
-	Ctx  fmt15.FCtx
-}
-
-func NewError(desc string, ctx ...interface{}) *Error {
-	e := &Error{Desc: desc}
-	e.Ctx = make(fmt15.FCtx, 0, len(ctx)+2)
-	e.Ctx = append(e.Ctx, fmt15.FCtx{"desc", desc}...)
-	e.Ctx = append(e.Ctx, ctx...)
-	return e
-}
-
-func (e Error) String() string {
-	return fmt.Sprintf("%+v", e.Ctx)
-}
-
-func (e Error) Error() string {
-	return e.String()
-}
+const On = true

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -14,6 +14,12 @@
 
 package common
 
+import (
+	"encoding/binary"
+)
+
 const (
 	LineLen = 8
 )
+
+var Order = binary.BigEndian

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -1,0 +1,53 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/kormat/fmt15"
+)
+
+type Error struct {
+	Desc string
+	Ctx  fmt15.FCtx
+	Data ErrorData
+}
+
+type ErrorData interface {
+	fmt.Stringer
+}
+
+func NewError(desc string, ctx ...interface{}) *Error {
+	e := &Error{Desc: desc}
+	e.Ctx = make(fmt15.FCtx, 0, len(ctx)+2)
+	e.Ctx = append(e.Ctx, fmt15.FCtx{"desc", desc}...)
+	e.Ctx = append(e.Ctx, ctx...)
+	return e
+}
+
+func NewErrorData(desc string, data ErrorData, ctx ...interface{}) *Error {
+	e := NewError(desc, ctx...)
+	e.Data = data
+	return e
+}
+
+func (e Error) String() string {
+	return fmt.Sprintf("%+v", e.Ctx)
+}
+
+func (e Error) Error() string {
+	return e.String()
+}

--- a/go/lib/common/extn.go
+++ b/go/lib/common/extn.go
@@ -49,3 +49,29 @@ func (e ExtnType) String() string {
 	}
 	return fmt.Sprintf("UNKNOWN (%d)", e)
 }
+
+const (
+	// Maximum allowed hop-by-hop extensions, excluding a potential leading SCMP extension.
+	ExtnMaxHBH       = 3
+	ExtnSubHdrLen    = 3
+	ExtnFirstLineLen = LineLen - ExtnSubHdrLen
+)
+
+type ExtnBase interface {
+	// Length in bytes, excluding 3B subheader
+	Len() int
+	Class() L4ProtocolType
+	Type() ExtnType
+	fmt.Stringer
+}
+
+type Extension interface {
+	ExtnBase
+	// Allocate buffer, write extn into it, and return it.
+	Pack() (RawBytes, *Error)
+	// Write extn into supplied buffer
+	Write(b RawBytes) *Error
+	Copy() Extension
+	// bool is true if extn is reversed, and false if it should be dropped.
+	Reverse() (bool, *Error)
+}

--- a/go/lib/common/pld.go
+++ b/go/lib/common/pld.go
@@ -12,41 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package common
 
 import (
-	"io"
-
-	"github.com/netsec-ethz/scion/go/lib/common"
+	"fmt"
 )
 
-var _ io.ReadWriter = (*Raw)(nil)
-
-type Raw struct {
-	B      common.RawBytes
-	Offset int
-}
-
-func (r *Raw) Peek(p []byte) (int, error) {
-	if len(r.B[r.Offset:]) <= 0 {
-		return 0, io.EOF
-	}
-	return copy(p, r.B[r.Offset:]), nil
-}
-
-func (r *Raw) Read(p []byte) (int, error) {
-	n, err := r.Peek(p)
-	if err == nil {
-		r.Offset += n
-	}
-	return n, err
-}
-
-func (r *Raw) Write(p []byte) (int, error) {
-	if len(r.B[r.Offset:]) == 0 {
-		return 0, io.EOF
-	}
-	count := copy(r.B[r.Offset:], p)
-	r.Offset += count
-	return count, nil
+type Payload interface {
+	fmt.Stringer
+	Len() int
+	Copy() (Payload, *Error)
+	Write(b RawBytes) (int, *Error)
 }

--- a/go/lib/common/raw.go
+++ b/go/lib/common/raw.go
@@ -12,41 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package common
 
 import (
-	"io"
-
-	"github.com/netsec-ethz/scion/go/lib/common"
+	"fmt"
 )
 
-var _ io.ReadWriter = (*Raw)(nil)
+type RawBytes []byte
 
-type Raw struct {
-	B      common.RawBytes
-	Offset int
-}
-
-func (r *Raw) Peek(p []byte) (int, error) {
-	if len(r.B[r.Offset:]) <= 0 {
-		return 0, io.EOF
-	}
-	return copy(p, r.B[r.Offset:]), nil
-}
-
-func (r *Raw) Read(p []byte) (int, error) {
-	n, err := r.Peek(p)
-	if err == nil {
-		r.Offset += n
-	}
-	return n, err
-}
-
-func (r *Raw) Write(p []byte) (int, error) {
-	if len(r.B[r.Offset:]) == 0 {
-		return 0, io.EOF
-	}
-	count := copy(r.B[r.Offset:], p)
-	r.Offset += count
-	return count, nil
+func (r RawBytes) String() string {
+	return fmt.Sprintf("%x", []byte(r))
 }

--- a/go/lib/l4/common.go
+++ b/go/lib/l4/common.go
@@ -1,0 +1,74 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4
+
+import (
+	"bytes"
+	"fmt"
+
+	//log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/libscion"
+)
+
+const ErrorInvalidChksum = "Invalid L4 checksum"
+
+type L4Header interface {
+	fmt.Stringer
+	L4Type() common.L4ProtocolType
+	L4Len() int
+	SetPldLen(int)
+	GetCSum() common.RawBytes
+	SetCSum(common.RawBytes)
+	Copy() L4Header
+	Write(common.RawBytes) *common.Error
+	Pack(csum bool) (common.RawBytes, *common.Error)
+	Validate(plen int) *common.Error
+	Reverse()
+}
+
+func CalcCSum(h L4Header, src, dst, pld common.RawBytes) (common.RawBytes, *common.Error) {
+	rawh, err := h.Pack(true)
+	if err != nil {
+		return nil, err
+	}
+	sum := libscion.Checksum(src, dst, []uint8{uint8(h.L4Type())}, rawh, pld)
+	out := make(common.RawBytes, 2)
+	common.Order.PutUint16(out, sum)
+	return out, nil
+}
+
+func SetCSum(h L4Header, src, dst, pld common.RawBytes) *common.Error {
+	out, err := CalcCSum(h, src, dst, pld)
+	if err != nil {
+		return err
+	}
+	h.SetCSum(out)
+	return nil
+}
+
+func CheckCSum(h L4Header, src, dst, pld common.RawBytes) *common.Error {
+	calc, err := CalcCSum(h, src, dst, pld)
+	if err != nil {
+		return err
+	}
+	exp := h.GetCSum()
+	if bytes.Compare(exp, calc) != 0 {
+		return common.NewError(ErrorInvalidChksum,
+			"expected", exp, "actual", calc, "proto", h.L4Type())
+	}
+	return nil
+}

--- a/go/lib/l4/udp.go
+++ b/go/lib/l4/udp.go
@@ -15,65 +15,90 @@
 package l4
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"gopkg.in/restruct.v1"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/libscion"
-	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
 const (
 	UDPLen = 8
 )
 
-var order = binary.BigEndian
+var _ L4Header = (*UDP)(nil)
 
 type UDP struct {
 	SrcPort  uint16
 	DstPort  uint16
 	TotalLen uint16
-	Checksum util.RawBytes `struct:"[2]byte"`
+	Checksum common.RawBytes `struct:"[2]byte"`
 }
 
-func UDPFromRaw(b util.RawBytes) (*UDP, *util.Error) {
+func UDPFromRaw(b common.RawBytes) (*UDP, *common.Error) {
 	u := &UDP{}
-	if err := restruct.Unpack(b, order, u); err != nil {
-		return nil, util.NewError("Error unpacking UDP header", "err", err)
-	}
-	if len(b) != int(u.TotalLen) {
-		return nil, util.NewError("L4 UDP header total length doesn't match",
-			"expected", u.TotalLen, "actual", len(b))
+	if err := restruct.Unpack(b, common.Order, u); err != nil {
+		return nil, common.NewError("Error unpacking UDP header", "err", err)
 	}
 	return u, nil
 }
 
-func (u *UDP) Pack() (util.RawBytes, *util.Error) {
-	out, err := restruct.Pack(order, u)
+func (u *UDP) Validate(plen int) *common.Error {
+	if plen+UDPLen != int(u.TotalLen) {
+		return common.NewError("UDP header total length doesn't match",
+			"expected", u.TotalLen, "actual", plen)
+	}
+	return nil
+}
+
+func (u *UDP) Pack(csum bool) (common.RawBytes, *common.Error) {
+	out, err := restruct.Pack(common.Order, u)
 	if err != nil {
-		return nil, util.NewError("Error packing UDP header", "err", err)
+		return nil, common.NewError("Error packing UDP header", "err", err)
+	}
+	if csum {
+		// Zero out the checksum field if this is being used for checksum calculation.
+		out[6] = 0
+		out[7] = 0
 	}
 	return out, nil
 }
 
-func (u *UDP) CalcChecksum(srcAddr, dstAddr, pld util.RawBytes) (util.RawBytes, *util.Error) {
-	out := make([]byte, 2)
-	hdr, err := u.Pack()
+func (u *UDP) Write(b common.RawBytes) *common.Error {
+	raw, err := u.Pack(false)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	// Zero checksum
-	hdr[6] = 0
-	hdr[7] = 0
-	sum := libscion.Checksum(srcAddr, dstAddr, []byte{byte(common.L4UDP)}, hdr, pld)
-	order.PutUint16(out, sum)
-	return out, nil
+	copy(b, raw)
+	return nil
+}
+
+func (u *UDP) GetCSum() common.RawBytes {
+	return u.Checksum
+}
+
+func (u *UDP) SetCSum(csum common.RawBytes) {
+	u.Checksum = csum
 }
 
 func (u *UDP) SetPldLen(pldLen int) {
 	u.TotalLen = uint16(UDPLen + pldLen)
+}
+
+func (u *UDP) Copy() L4Header {
+	return &UDP{u.SrcPort, u.DstPort, u.TotalLen, append(common.RawBytes(nil), u.Checksum...)}
+}
+
+func (u *UDP) L4Len() int {
+	return UDPLen
+}
+
+func (u *UDP) L4Type() common.L4ProtocolType {
+	return common.L4UDP
+}
+
+func (u *UDP) Reverse() {
+	u.SrcPort, u.DstPort = u.DstPort, u.SrcPort
 }
 
 func (u *UDP) String() string {

--- a/go/lib/scmp/extn.go
+++ b/go/lib/scmp/extn.go
@@ -1,0 +1,88 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scmp
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+var _ common.Extension = (*Extn)(nil)
+
+const (
+	ExtnErrorFlag = 0x1
+	ExtnHBHFlag   = 0x2
+)
+
+type Extn struct {
+	Error    bool
+	HopByHop bool
+}
+
+func ExtnFromRaw(b common.RawBytes) (*Extn, *common.Error) {
+	e := &Extn{}
+	flags := b[0]
+	e.Error = (flags & ExtnErrorFlag) != 0
+	e.HopByHop = (flags & ExtnHBHFlag) != 0
+	return e, nil
+}
+
+func (e *Extn) Copy() common.Extension {
+	return &Extn{Error: e.Error, HopByHop: e.HopByHop}
+}
+
+func (e *Extn) Write(b common.RawBytes) *common.Error {
+	var flags uint8
+	if e.Error {
+		flags |= ExtnErrorFlag
+	}
+	if e.HopByHop {
+		flags |= ExtnHBHFlag
+	}
+	b[0] = flags
+	// Zero rest of first line
+	copy(b[1:], make(common.RawBytes, common.ExtnFirstLineLen-1))
+	return nil
+}
+
+func (e *Extn) Pack() (common.RawBytes, *common.Error) {
+	b := make(common.RawBytes, e.Len())
+	if err := e.Write(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (e *Extn) Reverse() (bool, *common.Error) {
+	// Reversing removes the extension.
+	return false, nil
+}
+
+func (e *Extn) Len() int {
+	return common.ExtnFirstLineLen
+}
+
+func (e *Extn) Class() common.L4ProtocolType {
+	return common.HopByHopClass
+}
+
+func (e *Extn) Type() common.ExtnType {
+	return common.ExtnSCMPType
+}
+
+func (e *Extn) String() string {
+	return fmt.Sprintf("SCMP Ext(%dB): Error? %v HopByHop: %v", e.Len(), e.Error, e.HopByHop)
+}

--- a/go/lib/scmp/info.go
+++ b/go/lib/scmp/info.go
@@ -20,34 +20,110 @@ import (
 	//log "github.com/inconshreveable/log15"
 	"gopkg.in/restruct.v1"
 
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/util"
 )
+
+type Info interface {
+	fmt.Stringer
+	Copy() Info
+	Len() int
+	Write(b common.RawBytes) (int, *common.Error)
+}
+
+var _ Info = (*InfoString)(nil)
+
+type InfoString string
+
+func (s InfoString) Copy() Info {
+	// Strings are immutable, so no need to actually copy.
+	return s
+}
+
+func (s InfoString) Len() int {
+	l := 2 + len(s)
+	return l + util.CalcPadding(l, common.LineLen)
+}
+
+func (s InfoString) Write(b common.RawBytes) (int, *common.Error) {
+	common.Order.PutUint16(b, uint16(len(s)))
+	copy(b[:2], s)
+	return util.FillPadding(b, 2+len(s), common.LineLen), nil
+}
+
+func (s InfoString) String() string {
+	return string(s)
+}
+
+var _ Info = (*InfoEcho)(nil)
 
 type InfoEcho struct {
 	Id  uint16
 	Seq uint16
 }
 
-func InfoEchoFromRaw(b util.RawBytes) (*InfoEcho, *util.Error) {
+func InfoEchoFromRaw(b common.RawBytes) (*InfoEcho, *common.Error) {
 	e := &InfoEcho{}
-	if err := restruct.Unpack(b, order, e); err != nil {
-		return nil, util.NewError("Failed to unpack SCMP ECHO info", "err", err)
+	if err := restruct.Unpack(b, common.Order, e); err != nil {
+		return nil, common.NewError("Failed to unpack SCMP ECHO info", "err", err)
 	}
 	return e, nil
 }
+
+func (e *InfoEcho) Copy() Info {
+	return &InfoEcho{Id: e.Id, Seq: e.Seq}
+}
+
+func (e *InfoEcho) Len() int {
+	l := 4
+	return l + util.CalcPadding(l, common.LineLen)
+}
+
+func (e *InfoEcho) Write(b common.RawBytes) (int, *common.Error) {
+	common.Order.PutUint16(b[0:], e.Id)
+	common.Order.PutUint16(b[2:], e.Seq)
+	return util.FillPadding(b, 4, common.LineLen), nil
+}
+
+func (e *InfoEcho) String() string {
+	return fmt.Sprintf("Id=%v Seq=%v", e.Id, e.Seq)
+}
+
+var _ Info = (*InfoPktSize)(nil)
 
 type InfoPktSize struct {
 	Size uint16
 	MTU  uint16
 }
 
-func InfoPktSizeFromRaw(b util.RawBytes) (*InfoPktSize, *util.Error) {
+func InfoPktSizeFromRaw(b common.RawBytes) (*InfoPktSize, *common.Error) {
 	p := &InfoPktSize{}
-	if err := restruct.Unpack(b, order, p); err != nil {
-		return nil, util.NewError("Failed to unpack SCMP Pkt Size info", "err", err)
+	if err := restruct.Unpack(b, common.Order, p); err != nil {
+		return nil, common.NewError("Failed to unpack SCMP Pkt Size info", "err", err)
 	}
 	return p, nil
 }
+
+func (p *InfoPktSize) Copy() Info {
+	return &InfoPktSize{Size: p.Size, MTU: p.MTU}
+}
+
+func (p *InfoPktSize) Len() int {
+	l := 4
+	return l + util.CalcPadding(l, common.LineLen)
+}
+
+func (p *InfoPktSize) Write(b common.RawBytes) (int, *common.Error) {
+	common.Order.PutUint16(b[0:], p.Size)
+	common.Order.PutUint16(b[2:], p.MTU)
+	return util.FillPadding(b, 4, common.LineLen), nil
+}
+
+func (p *InfoPktSize) String() string {
+	return fmt.Sprintf("Size=%v MTU=%v", p.Size, p.MTU)
+}
+
+var _ Info = (*InfoPathOffsets)(nil)
 
 type InfoPathOffsets struct {
 	InfoF   uint16
@@ -56,33 +132,111 @@ type InfoPathOffsets struct {
 	Ingress bool
 }
 
-func InfoPathOffsetsFromRaw(b util.RawBytes) (*InfoPathOffsets, *util.Error) {
+func InfoPathOffsetsFromRaw(b common.RawBytes) (*InfoPathOffsets, *common.Error) {
 	p := &InfoPathOffsets{}
-	if err := restruct.Unpack(b, order, p); err != nil {
-		return nil, util.NewError("Failed to unpack SCMP Path Offsets info", "err", err)
+	if err := restruct.Unpack(b, common.Order, p); err != nil {
+		return nil, common.NewError("Failed to unpack SCMP Path Offsets info", "err", err)
 	}
 	return p, nil
+}
+
+func (p *InfoPathOffsets) Copy() Info {
+	return &InfoPathOffsets{InfoF: p.InfoF, HopF: p.HopF, IfID: p.IfID, Ingress: p.Ingress}
+}
+
+func (p *InfoPathOffsets) Len() int {
+	l := 7
+	return l + util.CalcPadding(l, common.LineLen)
+}
+
+func (p *InfoPathOffsets) Write(b common.RawBytes) (int, *common.Error) {
+	common.Order.PutUint16(b[0:], p.InfoF)
+	common.Order.PutUint16(b[2:], p.HopF)
+	common.Order.PutUint16(b[4:], p.IfID)
+	if p.Ingress {
+		b[6] = 1
+	} else {
+		b[6] = 0
+	}
+	return util.FillPadding(b, 7, common.LineLen), nil
 }
 
 func (p *InfoPathOffsets) String() string {
 	return fmt.Sprintf("InfoF=%d HopF=%d IfID=%d Ingress=%v", p.InfoF, p.HopF, p.IfID, p.Ingress)
 }
 
+var _ Info = (*InfoRevocation)(nil)
+
 type InfoRevocation struct {
-	InfoPathOffsets
-	RevToken util.RawBytes
+	*InfoPathOffsets
+	RevToken common.RawBytes
 }
 
-func InfoRevocationFromRaw(b util.RawBytes) (*InfoRevocation, *util.Error) {
+func NewInfoRevocation(infoF, hopF, ifID uint16, ingress bool,
+	revToken common.RawBytes) *InfoRevocation {
+	return &InfoRevocation{
+		InfoPathOffsets: &InfoPathOffsets{InfoF: infoF, HopF: hopF, IfID: ifID, Ingress: ingress},
+		RevToken:        revToken,
+	}
+}
+
+func InfoRevocationFromRaw(b common.RawBytes) (*InfoRevocation, *common.Error) {
 	p := &InfoRevocation{}
-	if err := restruct.Unpack(b, order, &p.InfoPathOffsets); err != nil {
-		return nil, util.NewError("Failed to unpack SCMP Revocation info", "err", err)
+	if err := restruct.Unpack(b, common.Order, &p.InfoPathOffsets); err != nil {
+		return nil, common.NewError("Failed to unpack SCMP Revocation info", "err", err)
 	}
 	p.RevToken = b[8:]
 	return p, nil
+}
+func (r *InfoRevocation) Copy() Info {
+	return &InfoRevocation{
+		r.InfoPathOffsets.Copy().(*InfoPathOffsets),
+		append(common.RawBytes(nil), r.RevToken...),
+	}
+}
+
+func (r *InfoRevocation) Len() int {
+	l := r.InfoPathOffsets.Len() + len(r.RevToken)
+	return l + util.CalcPadding(l, common.LineLen)
+}
+
+func (r *InfoRevocation) Write(b common.RawBytes) (int, *common.Error) {
+	count, err := r.InfoPathOffsets.Write(b)
+	if err != nil {
+		return 0, nil
+	}
+	count += copy(b[count:], r.RevToken)
+	return util.FillPadding(b, count, common.LineLen), nil
 }
 
 func (r *InfoRevocation) String() string {
 	return fmt.Sprintf("InfoF=%d HopF=%d IfID=%d Ingress=%v RevToken=%v",
 		r.InfoF, r.HopF, r.IfID, r.Ingress, r.RevToken)
+}
+
+var _ Info = (*InfoExtIdx)(nil)
+
+type InfoExtIdx struct {
+	Idx uint8
+}
+
+func InfoExtIdxFromRaw(b common.RawBytes) (*InfoExtIdx, *common.Error) {
+	return &InfoExtIdx{Idx: b[0]}, nil
+}
+
+func (e *InfoExtIdx) Copy() Info {
+	return &InfoExtIdx{Idx: e.Idx}
+}
+
+func (r *InfoExtIdx) Len() int {
+	return 1 + util.CalcPadding(1, common.LineLen)
+}
+
+func (e *InfoExtIdx) Write(b common.RawBytes) (int, *common.Error) {
+	b[0] = e.Idx
+	return util.FillPadding(b, 1, common.LineLen), nil
+}
+
+func (e *InfoExtIdx) String() string {
+	return fmt.Sprintf("Idx=%v", e.Idx)
 }

--- a/go/lib/scmp/meta.go
+++ b/go/lib/scmp/meta.go
@@ -21,7 +21,6 @@ import (
 	"gopkg.in/restruct.v1"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
 type Meta struct {
@@ -38,20 +37,29 @@ const (
 	MetaLen = 8
 )
 
-func MetaFromRaw(b []byte) (*Meta, *util.Error) {
+func MetaFromRaw(b []byte) (*Meta, *common.Error) {
 	m := &Meta{}
 	if err := restruct.Unpack(b, binary.BigEndian, m); err != nil {
-		return nil, util.NewError("Failed to unpack SCMP Metadata", "err", err)
+		return nil, common.NewError("Failed to unpack SCMP Metadata", "err", err)
 	}
 	return m, nil
 }
 
-func (m *Meta) Pack() (util.RawBytes, *util.Error) {
-	out, err := restruct.Pack(order, m)
-	if err != nil {
-		return nil, util.NewError("Error packing SCMP Metadata", "err", err)
+func (m *Meta) Copy() *Meta {
+	return &Meta{
+		InfoLen: m.InfoLen, CmnHdrLen: m.CmnHdrLen, AddrHdrLen: m.AddrHdrLen,
+		PathHdrLen: m.PathHdrLen, ExtHdrsLen: m.ExtHdrsLen,
+		L4HdrLen: m.L4HdrLen, L4Proto: m.L4Proto,
 	}
-	return out, nil
+}
+
+func (m *Meta) Write(b common.RawBytes) *common.Error {
+	out, err := restruct.Pack(common.Order, m)
+	if err != nil {
+		return common.NewError("Error packing SCMP Metadata", "err", err)
+	}
+	copy(b, out)
+	return nil
 }
 
 func (m *Meta) String() string {

--- a/go/lib/scmp/pld.go
+++ b/go/lib/scmp/pld.go
@@ -21,30 +21,29 @@ import (
 	log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
+var _ common.Payload = (*Payload)(nil)
+
 type Payload struct {
-	hdr     *Hdr
+	ct      ClassType
 	Meta    *Meta
 	Info    Info
-	CmnHdr  util.RawBytes
-	AddrHdr util.RawBytes
-	PathHdr util.RawBytes
-	ExtHdrs util.RawBytes
-	L4Hdr   util.RawBytes
+	CmnHdr  common.RawBytes
+	AddrHdr common.RawBytes
+	PathHdr common.RawBytes
+	ExtHdrs common.RawBytes
+	L4Hdr   common.RawBytes
 }
 
-type Info interface{}
-
-func PldFromRaw(b util.RawBytes, hdr *Hdr) (*Payload, *util.Error) {
-	var err *util.Error
-	p := &Payload{hdr: hdr}
+func PldFromRaw(b common.RawBytes, ct ClassType) (*Payload, *common.Error) {
+	var err *common.Error
+	p := &Payload{ct: ct}
 	buf := bytes.NewBuffer(b)
 	if p.Meta, err = MetaFromRaw(buf.Next(MetaLen)); err != nil {
 		return nil, err
 	}
-	if err = p.parseInfo(buf.Next(int(p.Meta.InfoLen) * common.LineLen)); err != nil {
+	if p.Info, err = ParseInfo(buf.Next(int(p.Meta.InfoLen)*common.LineLen), p.ct); err != nil {
 		return nil, err
 	}
 	p.CmnHdr = buf.Next(int(p.Meta.CmnHdrLen) * common.LineLen)
@@ -56,49 +55,91 @@ func PldFromRaw(b util.RawBytes, hdr *Hdr) (*Payload, *util.Error) {
 	return p, nil
 }
 
-func (p *Payload) parseInfo(b util.RawBytes) *util.Error {
-	var err *util.Error
-	switch p.hdr.Class {
-	case C_General:
-		if p.hdr.Type == T_G_Unspecified {
-			p.Info = string(b)
-			return nil
+type QuoteFunc func(RawBlock) common.RawBytes
+
+func PldFromQuotes(ct ClassType, info Info, l4 common.L4ProtocolType, f QuoteFunc) *Payload {
+	p := &Payload{ct: ct, Info: info}
+	for _, blk := range classTypeQuotes(p.ct) {
+		q := f(blk)
+		switch blk {
+		case RawCmnHdr:
+			p.CmnHdr = q
+		case RawAddrHdr:
+			p.AddrHdr = q
+		case RawPathHdr:
+			p.PathHdr = q
+		case RawExtHdrs:
+			p.ExtHdrs = q
+		case RawL4Hdr:
+			p.L4Hdr = q
 		}
-		p.Info, err = InfoEchoFromRaw(b)
-		return err
-	case C_Routing:
-		if p.hdr.Type == T_R_OversizePkt {
-			p.Info, err = InfoPktSizeFromRaw(b)
-			return err
-		}
-	case C_CmnHdr:
-		if p.hdr.Type == T_C_BadPktLen {
-			p.Info, err = InfoPktSizeFromRaw(b)
-			return err
-		}
-	case C_Path:
-		switch p.hdr.Type {
-		case T_P_PathRequired:
-			return nil
-		case T_P_RevokedIF:
-			p.Info, err = InfoRevocationFromRaw(b)
-			return err
-		default:
-			p.Info, err = InfoPathOffsetsFromRaw(b)
-			return err
-		}
-		/*
-			TODO(kormat): Ext and SIBRA errors not handled yet.
-			case C_Ext:
-				return InfoExtIdxFromRaw(b)
-		*/
 	}
-	return nil
+	p.Meta = &Meta{
+		CmnHdrLen:  uint8(len(p.CmnHdr) / common.LineLen),
+		AddrHdrLen: uint8(len(p.AddrHdr) / common.LineLen),
+		PathHdrLen: uint8(len(p.PathHdr) / common.LineLen),
+		ExtHdrsLen: uint8(len(p.ExtHdrs) / common.LineLen),
+		L4HdrLen:   uint8(len(p.L4Hdr) / common.LineLen),
+		L4Proto:    l4,
+	}
+	if info != nil {
+		p.Meta.InfoLen = uint8(p.Info.Len() / common.LineLen)
+	}
+	return p
+}
+
+func (p *Payload) Copy() (common.Payload, *common.Error) {
+	c := &Payload{ct: p.ct}
+	c.Meta = p.Meta.Copy()
+	c.Info = p.Info
+	c.CmnHdr = append(common.RawBytes(nil), p.CmnHdr...)
+	c.AddrHdr = append(common.RawBytes(nil), p.AddrHdr...)
+	c.PathHdr = append(common.RawBytes(nil), p.PathHdr...)
+	c.ExtHdrs = append(common.RawBytes(nil), p.ExtHdrs...)
+	c.L4Hdr = append(common.RawBytes(nil), p.L4Hdr...)
+	return c, nil
+}
+
+func (p *Payload) Write(b common.RawBytes) (int, *common.Error) {
+	offset := 0
+	if err := p.Meta.Write(b[offset:]); err != nil {
+		return 0, err
+	}
+	offset += MetaLen
+	if p.Info != nil {
+		if count, err := p.Info.Write(b[offset:]); err != nil {
+			return 0, err
+		} else {
+			offset += count
+		}
+	}
+	copy(b[offset:], p.CmnHdr)
+	offset += len(p.CmnHdr)
+	copy(b[offset:], p.AddrHdr)
+	offset += len(p.AddrHdr)
+	copy(b[offset:], p.PathHdr)
+	offset += len(p.PathHdr)
+	copy(b[offset:], p.ExtHdrs)
+	offset += len(p.ExtHdrs)
+	copy(b[offset:], p.L4Hdr)
+	return p.Len(), nil
+}
+
+func (p *Payload) Len() int {
+	l := MetaLen
+	if p.Info != nil {
+		l += p.Info.Len()
+	}
+	l += int(p.Meta.CmnHdrLen) * common.LineLen
+	l += int(p.Meta.AddrHdrLen) * common.LineLen
+	l += int(p.Meta.PathHdrLen) * common.LineLen
+	l += int(p.Meta.ExtHdrsLen) * common.LineLen
+	l += int(p.Meta.L4HdrLen) * common.LineLen
+	return l
 }
 
 func (p *Payload) String() string {
 	buf := &bytes.Buffer{}
-	fmt.Fprintf(buf, "Hdr: %v\n", p.hdr)
 	fmt.Fprintf(buf, "Meta: %v\n", p.Meta)
 	if p.Info != nil {
 		fmt.Fprintf(buf, "Info: %v\n", p.Info)

--- a/go/lib/scmp/scmp.go
+++ b/go/lib/scmp/scmp.go
@@ -15,14 +15,11 @@
 package scmp
 
 import (
-	"encoding/binary"
 	"fmt"
 	//log "github.com/inconshreveable/log15"
 )
 
 // https://github.com/netsec-ethz/scion/blob/master/lib/packet/scmp/types.py
-
-var order = binary.BigEndian
 
 type Class uint16
 
@@ -120,4 +117,38 @@ func (t Type) Name(c Class) string {
 		return fmt.Sprintf("Type(%d)", t)
 	}
 	return fmt.Sprintf("%s(%d)", names[t], t)
+}
+
+type ClassType struct {
+	Class Class
+	Type  Type
+}
+
+func (ct ClassType) String() string {
+	return fmt.Sprintf("%v:%v", ct.Class, ct.Type.Name(ct.Class))
+}
+
+// Used to specify parts of packets to quote
+type RawBlock int
+
+const (
+	RawCmnHdr RawBlock = iota
+	RawAddrHdr
+	RawPathHdr
+	RawExtHdrs
+	RawL4Hdr
+)
+
+// Used as part of common.NewErrorData to indicate which SCMP error should be generated.
+type ErrData struct {
+	CT   ClassType
+	Info Info
+}
+
+func NewErrData(class Class, type_ Type, info Info) *ErrData {
+	return &ErrData{CT: ClassType{class, type_}, Info: info}
+}
+
+func (e *ErrData) String() string {
+	return fmt.Sprintf("CT: %v Info: %v", e.CT, e.Info)
 }

--- a/go/lib/scmp/util.go
+++ b/go/lib/scmp/util.go
@@ -1,0 +1,65 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scmp
+
+import (
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+var (
+	quoteBasic = []RawBlock{RawCmnHdr, RawAddrHdr, RawL4Hdr}
+	quoteAll   = append(quoteBasic, RawPathHdr, RawExtHdrs)
+	quotePath  = append(quoteBasic, RawPathHdr)
+	quoteExts  = append(quoteBasic, RawExtHdrs)
+)
+
+func classTypeQuotes(ct ClassType) []RawBlock {
+	switch {
+	case ct == ClassType{C_General, T_G_Unspecified}:
+		return quoteAll
+	case ct.Class == C_Routing || ct.Class == C_CmnHdr:
+		return quoteBasic
+	case ct == ClassType{C_Path, T_P_PathRequired}:
+		return quoteBasic
+	case ct.Class == C_Path:
+		return quotePath
+	case ct.Class == C_Ext:
+		return quoteExts
+	default:
+		return nil
+	}
+}
+
+func ParseInfo(b common.RawBytes, ct ClassType) (Info, *common.Error) {
+	switch {
+	case ct == ClassType{C_General, T_G_Unspecified}:
+		return InfoString(b), nil
+	case ct.Class == C_General:
+		return InfoEchoFromRaw(b)
+	case ct == ClassType{C_Routing, T_R_OversizePkt} || ct == ClassType{C_CmnHdr, T_C_BadPktLen}:
+		return InfoPktSizeFromRaw(b)
+	case ct == ClassType{C_Path, T_P_PathRequired}:
+		return nil, nil
+	case ct == ClassType{C_Path, T_P_RevokedIF}:
+		return InfoRevocationFromRaw(b)
+	case ct.Class == C_Path:
+		return InfoPathOffsetsFromRaw(b)
+	case ct.Class == C_Ext:
+		return InfoExtIdxFromRaw(b)
+	case ct.Class == C_Sibra:
+		// TODO(kormat): not defined/handled yet.
+	}
+	return nil, nil
+}

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -26,7 +26,7 @@ import (
 )
 
 type HopField struct {
-	data        util.RawBytes
+	data        common.RawBytes
 	Xover       bool
 	VerifyOnly  bool
 	ForwardOnly bool
@@ -34,7 +34,7 @@ type HopField struct {
 	ExpTime     uint8
 	Ingress     IntfID
 	Egress      IntfID
-	Mac         util.RawBytes
+	Mac         common.RawBytes
 }
 
 const (
@@ -46,7 +46,7 @@ const (
 	ErrorHopFBadMac     = "Bad HopF MAC"
 )
 
-func NewHopField(b util.RawBytes, in IntfID, out IntfID) *HopField {
+func NewHopField(b common.RawBytes, in IntfID, out IntfID) *HopField {
 	h := &HopField{}
 	h.data = b
 	h.ExpTime = DefaultHopFExpiry
@@ -56,9 +56,9 @@ func NewHopField(b util.RawBytes, in IntfID, out IntfID) *HopField {
 	return h
 }
 
-func HopFFromRaw(b []byte) (*HopField, *util.Error) {
+func HopFFromRaw(b []byte) (*HopField, *common.Error) {
 	if len(b) < HopFieldLength {
-		return nil, util.NewError(ErrorHopFTooShort, "min", HopFieldLength, "actual", len(b))
+		return nil, common.NewError(ErrorHopFTooShort, "min", HopFieldLength, "actual", len(b))
 	}
 	h := &HopField{}
 	h.data = b[:HopFieldLength]
@@ -107,19 +107,19 @@ func (h *HopField) String() string {
 		h.Ingress, h.Egress, h.ExpTime, h.Xover, h.VerifyOnly, h.ForwardOnly, h.Mac)
 }
 
-func (h *HopField) Verify(block cipher.Block, tsInt uint32, prev util.RawBytes) *util.Error {
+func (h *HopField) Verify(block cipher.Block, tsInt uint32, prev common.RawBytes) *common.Error {
 	if mac, err := h.CalcMac(block, tsInt, prev); err != nil {
 		return err
 	} else if !bytes.Equal(h.Mac, mac) {
-		return util.NewError(ErrorHopFBadMac, "expected", h.Mac, "actual", mac)
+		return common.NewError(ErrorHopFBadMac, "expected", h.Mac, "actual", mac)
 	}
 	return nil
 }
 
 func (h *HopField) CalcMac(block cipher.Block, tsInt uint32,
-	prev util.RawBytes) (util.RawBytes, *util.Error) {
-	all := make(util.RawBytes, macInputLen)
-	order.PutUint32(all, tsInt)
+	prev common.RawBytes) (common.RawBytes, *common.Error) {
+	all := make(common.RawBytes, macInputLen)
+	common.Order.PutUint32(all, tsInt)
 	all[4] = h.data[0] & HopFieldVerifyFlags
 	copy(all[5:], h.data[1:5])
 	copy(all[9:], prev)

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -21,7 +21,6 @@ import (
 	//log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
 const (
@@ -38,9 +37,9 @@ type InfoField struct {
 	Hops     uint8
 }
 
-func InfoFFromRaw(b []byte) (*InfoField, *util.Error) {
+func InfoFFromRaw(b []byte) (*InfoField, *common.Error) {
 	if len(b) < InfoFieldLength {
-		return nil, util.NewError(ErrorInfoFTooShort, "min", InfoFieldLength, "actual", len(b))
+		return nil, common.NewError(ErrorInfoFTooShort, "min", InfoFieldLength, "actual", len(b))
 	}
 	inf := &InfoField{}
 	flags := b[0]
@@ -48,15 +47,15 @@ func InfoFFromRaw(b []byte) (*InfoField, *util.Error) {
 	inf.Shortcut = flags&0x2 != 0
 	inf.Peer = flags&0x4 != 0
 	offset := 1
-	inf.TsInt = order.Uint32(b[offset:])
+	inf.TsInt = common.Order.Uint32(b[offset:])
 	offset += 4
-	inf.ISD = order.Uint16(b[offset:])
+	inf.ISD = common.Order.Uint16(b[offset:])
 	offset += 2
 	inf.Hops = b[offset]
 	return inf, nil
 }
 
-func (inf *InfoField) Write(b util.RawBytes) {
+func (inf *InfoField) Write(b common.RawBytes) {
 	b[0] = 0
 	if inf.Up {
 		b[0] |= 0x1
@@ -68,9 +67,9 @@ func (inf *InfoField) Write(b util.RawBytes) {
 		b[0] |= 0x4
 	}
 	offset := 1
-	order.PutUint32(b[offset:], inf.TsInt)
+	common.Order.PutUint32(b[offset:], inf.TsInt)
 	offset += 4
-	order.PutUint16(b[offset:], inf.ISD)
+	common.Order.PutUint16(b[offset:], inf.ISD)
 	offset += 2
 	b[offset] = inf.Hops
 }

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -15,11 +15,9 @@
 package spath
 
 import (
-	"encoding/binary"
-
 	//log "github.com/inconshreveable/log15"
 
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 type IntfID uint16
@@ -30,15 +28,17 @@ const (
 	macInputLen = 16
 )
 
-var order = binary.BigEndian
-
 type Path struct {
-	Raw    util.RawBytes
+	Raw    common.RawBytes
 	InfOff uint8 // Offset of current Info Field
 	HopOff uint8 // Offset of current Hop Field
 }
 
-func (p *Path) Reverse() *util.Error {
+func (p *Path) Copy() *Path {
+	return &Path{append(common.RawBytes(nil), p.Raw...), p.InfOff, p.HopOff}
+}
+
+func (p *Path) Reverse() *common.Error {
 	if len(p.Raw) == 0 {
 		// Empty path doesn't need reversal.
 		return nil
@@ -58,11 +58,11 @@ func (p *Path) Reverse() *util.Error {
 		if origOff == len(p.Raw) {
 			break
 		} else if origOff > len(p.Raw) {
-			return util.NewError("Unable to reverse corrupt path",
+			return common.NewError("Unable to reverse corrupt path",
 				"currOff", origOff, "max", len(p.Raw))
 		}
 	}
-	revRaw := make(util.RawBytes, len(p.Raw))
+	revRaw := make(common.RawBytes, len(p.Raw))
 	revOff := 0
 	newInfIdx := 0
 	switch {

--- a/go/lib/spath/path_test.go
+++ b/go/lib/spath/path_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 type pathCase struct {
@@ -115,7 +115,7 @@ func mkPathRevCase(in []pathCase, inInfOff, inHopfOff uint8) *Path {
 	for _, seg := range in {
 		plen += InfoFieldLength + len(seg.hops)*HopFieldLength
 	}
-	path.Raw = make(util.RawBytes, plen)
+	path.Raw = make(common.RawBytes, plen)
 	offset := 0
 	for i, seg := range in {
 		makeSeg(path.Raw[offset:], seg.up, uint16(i), seg.hops)
@@ -124,7 +124,7 @@ func mkPathRevCase(in []pathCase, inInfOff, inHopfOff uint8) *Path {
 	return path
 }
 
-func makeSeg(b util.RawBytes, up bool, isd uint16, hops []uint8) {
+func makeSeg(b common.RawBytes, up bool, isd uint16, hops []uint8) {
 	infof := InfoField{Up: up, ISD: isd, Hops: uint8(len(hops))}
 	infof.Write(b)
 	for i, hop := range hops {

--- a/go/lib/spkt/extn_onehoppath.go
+++ b/go/lib/spkt/extn_onehoppath.go
@@ -1,0 +1,63 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spkt
+
+import (
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+var _ common.Extension = (*OneHopPath)(nil)
+
+type OneHopPath struct{}
+
+const OneHopPathLen = common.ExtnFirstLineLen
+
+func (o OneHopPath) Write(b common.RawBytes) *common.Error {
+	copy(b, make(common.RawBytes, OneHopPathLen))
+	return nil
+}
+
+func (o OneHopPath) Pack() (common.RawBytes, *common.Error) {
+	b := make(common.RawBytes, o.Len())
+	if err := o.Write(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (o OneHopPath) Copy() common.Extension {
+	return &OneHopPath{}
+}
+
+func (o OneHopPath) Reverse() (bool, *common.Error) {
+	// Reversing removes the extension.
+	return false, nil
+}
+
+func (o OneHopPath) Len() int {
+	return OneHopPathLen
+}
+
+func (o OneHopPath) Class() common.L4ProtocolType {
+	return common.HopByHopClass
+}
+
+func (o OneHopPath) Type() common.ExtnType {
+	return common.ExtnOneHopPathType
+}
+
+func (o *OneHopPath) String() string {
+	return "OneHopPath"
+}

--- a/go/lib/spkt/extn_traceroute.go
+++ b/go/lib/spkt/extn_traceroute.go
@@ -1,0 +1,122 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spkt
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+var _ common.Extension = (*Traceroute)(nil)
+
+const (
+	TracerouteEntryLen = 8
+)
+
+type Traceroute struct {
+	Hops []*TracerouteEntry
+}
+
+func NewTraceroute(totalHops int) *Traceroute {
+	t := &Traceroute{}
+	t.Hops = make([]*TracerouteEntry, 0, totalHops)
+	return t
+}
+
+func (t *Traceroute) NumHops() int {
+	return len(t.Hops)
+}
+
+func (t *Traceroute) TotalHops() int {
+	return int(cap(t.Hops))
+}
+
+func (t *Traceroute) Write(b common.RawBytes) *common.Error {
+	if len(b) < t.Len() {
+		return common.NewError("Buffer too short", "method", "Traceroute.Write")
+	}
+	b[0] = uint8(t.NumHops())
+	offset := common.ExtnSubHdrLen
+	for _, h := range t.Hops {
+		h.Write(b[offset:])
+		offset += TracerouteEntryLen
+	}
+	return nil
+}
+
+func (t *Traceroute) Pack() (common.RawBytes, *common.Error) {
+	b := make(common.RawBytes, t.Len())
+	if err := t.Write(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (t *Traceroute) Copy() common.Extension {
+	c := NewTraceroute(t.TotalHops())
+	for _, h := range t.Hops {
+		c.Hops = append(c.Hops, h.Copy())
+	}
+	return c
+}
+
+func (t *Traceroute) Reverse() (bool, *common.Error) {
+	// Nothing to do.
+	return true, nil
+}
+
+func (t *Traceroute) Len() int {
+	return common.ExtnFirstLineLen + t.TotalHops()*common.LineLen
+}
+
+func (t *Traceroute) Class() common.L4ProtocolType {
+	return common.HopByHopClass
+}
+
+func (t *Traceroute) Type() common.ExtnType {
+	return common.ExtnTracerouteType
+}
+
+func (t *Traceroute) String() string {
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "Traceroute (%dB): Hops filled/total: %d/%d\n",
+		t.Len(), t.NumHops(), t.TotalHops())
+	for i, h := range t.Hops {
+		fmt.Fprintf(buf, "  %d. %v\n", i, h)
+	}
+	return buf.String()
+}
+
+type TracerouteEntry struct {
+	IA        addr.ISD_AS
+	IfID      uint16
+	TimeStamp uint16
+}
+
+func (t *TracerouteEntry) Copy() *TracerouteEntry {
+	return &TracerouteEntry{IA: t.IA, IfID: t.IfID, TimeStamp: t.TimeStamp}
+}
+
+func (t *TracerouteEntry) Write(b common.RawBytes) {
+	offset := 0
+	t.IA.Write(b[offset:])
+	offset += addr.IABytes
+	common.Order.PutUint16(b[offset:], t.IfID)
+	offset += 2
+	common.Order.PutUint16(b[offset:], t.TimeStamp)
+}

--- a/go/lib/spkt/pld_ctrl.go
+++ b/go/lib/spkt/pld_ctrl.go
@@ -1,0 +1,95 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spkt
+
+import (
+	"bytes"
+
+	//log "github.com/inconshreveable/log15"
+	"zombiezen.com/go/capnproto2"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+var _ common.Payload = (*CtrlPld)(nil)
+
+type CtrlPld struct {
+	*proto.SCION
+}
+
+func NewCtrlPldFromRaw(b common.RawBytes) (*CtrlPld, *common.Error) {
+	rawPld := b
+	pldLen := common.Order.Uint32(rawPld)
+	rawPld = rawPld[4:]
+	if int(pldLen) != len(rawPld) {
+		return nil, common.NewError("Ctrl payload length incorrect",
+			"expected", pldLen, "actual", len(rawPld))
+	}
+	buf := bytes.NewBuffer(rawPld)
+	msg, err := capnp.NewPackedDecoder(buf).Decode()
+	if err != nil {
+		return nil, common.NewError("Ctrl payload decoding failed", "err", err)
+	}
+	// Handle any panics while parsing
+	defer func() *common.Error {
+		if err := recover(); err != nil {
+			return common.NewError("Ctrl payload parsing failed", "err", err)
+		}
+		return nil
+	}()
+	pld, err := proto.ReadRootSCION(msg)
+	if err != nil {
+		return nil, common.NewError("Ctrl payload parsing failed", "err", err)
+	}
+	return &CtrlPld{SCION: &pld}, nil
+}
+
+func (c *CtrlPld) Len() int {
+	// The length can't be calculated until the payload is packed.
+	return -1
+}
+
+func (c *CtrlPld) Copy() (common.Payload, *common.Error) {
+	rawPld, err := c.Pack()
+	if err != nil {
+		return nil, err
+	}
+	return NewCtrlPldFromRaw(rawPld)
+}
+
+func (c *CtrlPld) Write(b common.RawBytes) (int, *common.Error) {
+	raw := &util.Raw{B: b, Offset: 4}
+	enc := capnp.NewPackedEncoder(raw)
+	if err := enc.Encode(c.SCION.Segment().Message()); err != nil {
+		return 0, common.NewError("Ctrl payload encoding failed", "err", err)
+	}
+	// Set payload length
+	common.Order.PutUint32(b, uint32(raw.Offset-4))
+	return raw.Offset, nil
+}
+
+func (c *CtrlPld) Pack() (common.RawBytes, *common.Error) {
+	buf := bytes.NewBuffer(make(common.RawBytes, 4))
+	enc := capnp.NewPackedEncoder(buf)
+	if err := enc.Encode(c.SCION.Segment().Message()); err != nil {
+		return nil, common.NewError("Ctrl payload encoding failed", "err", err)
+	}
+	rawPld := buf.Bytes()
+	// Set payload length
+	common.Order.PutUint32(rawPld, uint32(len(rawPld)-4))
+	return rawPld, nil
+}

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -1,0 +1,111 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spkt
+
+import (
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/l4"
+	"github.com/netsec-ethz/scion/go/lib/spath"
+	"github.com/netsec-ethz/scion/go/lib/util"
+)
+
+// SCION Packet structure.
+type ScnPkt struct {
+	SrcIA   *addr.ISD_AS
+	SrcHost addr.HostAddr
+	DstIA   *addr.ISD_AS
+	DstHost addr.HostAddr
+	Path    *spath.Path
+	HBHExt  []common.Extension
+	E2EExt  []common.Extension
+	L4      l4.L4Header
+	Pld     common.Payload
+}
+
+func (s *ScnPkt) Copy() *ScnPkt {
+	c := &ScnPkt{}
+	if s.SrcIA != nil {
+		c.SrcIA = s.SrcIA.Copy()
+	}
+	if s.SrcHost != nil {
+		c.SrcHost = s.SrcHost.Copy()
+	}
+	if s.DstIA != nil {
+		c.DstIA = s.DstIA.Copy()
+	}
+	if s.DstHost != nil {
+		c.DstHost = s.DstHost.Copy()
+	}
+	if s.Path != nil {
+		c.Path = s.Path.Copy()
+	}
+	for _, e := range s.HBHExt {
+		c.HBHExt = append(c.HBHExt, e.Copy())
+	}
+	for _, e := range s.E2EExt {
+		c.E2EExt = append(c.E2EExt, e.Copy())
+	}
+	if s.L4 != nil {
+		c.L4 = s.L4.Copy()
+	}
+	// TODO(kormat): define payload interface, with Copy()
+	return c
+}
+
+func (s *ScnPkt) Reverse() *common.Error {
+	s.SrcIA, s.DstIA = s.DstIA, s.SrcIA
+	s.SrcHost, s.DstHost = s.DstHost, s.SrcHost
+	if s.Path != nil {
+		if err := s.Path.Reverse(); err != nil {
+			return err
+		}
+	}
+	// FIXME(kormat): handle reversing extensions
+	if s.L4 != nil {
+		s.L4.Reverse()
+	}
+	return nil
+}
+
+func (s *ScnPkt) AddrLen() int {
+	addrLen := addr.IABytes*2 + s.SrcHost.Size() + s.DstHost.Size()
+	return addrLen + util.CalcPadding(addrLen, common.LineLen)
+}
+
+func (s *ScnPkt) HdrLen() int {
+	l := CmnHdrLen + s.AddrLen()
+	if s.Path != nil {
+		l += len(s.Path.Raw)
+	}
+	return l
+}
+
+func (s *ScnPkt) TotalLen() int {
+	l := s.HdrLen()
+	for _, h := range s.HBHExt {
+		l += h.Len()
+	}
+	for _, e := range s.E2EExt {
+		l += e.Len()
+	}
+	if s.L4 != nil {
+		l += s.L4.L4Len()
+	}
+	if s.Pld != nil {
+		l += s.Pld.Len()
+	}
+	return l
+}

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
@@ -78,10 +79,10 @@ const (
 
 var Curr *TopoMeta
 
-func Load(path string) *util.Error {
+func Load(path string) *common.Error {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return util.NewError(ErrorOpen, "err", err)
+		return common.NewError(ErrorOpen, "err", err)
 	}
 	if err := Parse(b, path); err != nil {
 		return err
@@ -89,11 +90,11 @@ func Load(path string) *util.Error {
 	return nil
 }
 
-func Parse(data []byte, path string) *util.Error {
+func Parse(data []byte, path string) *common.Error {
 	tm := &TopoMeta{}
 	tm.IFMap = make(map[int]TopoBR)
 	if err := yaml.Unmarshal(data, &tm.T); err != nil {
-		return util.NewError(ErrorParse, "err", err, "path", path)
+		return common.NewError(ErrorParse, "err", err, "path", path)
 	}
 	tm.populateMeta()
 	Curr = tm

--- a/go/lib/util/mac.go
+++ b/go/lib/util/mac.go
@@ -19,6 +19,8 @@ import (
 	"crypto/cipher"
 
 	log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 const (
@@ -26,18 +28,18 @@ const (
 	ErrorCiphertextLen = "Ciphertext isn't a multiple of the block size"
 )
 
-func InitAES(key RawBytes) (cipher.Block, *Error) {
+func InitAES(key common.RawBytes) (cipher.Block, *common.Error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, NewError(ErrorCipherFailure, log.Ctx{"err": err})
+		return nil, common.NewError(ErrorCipherFailure, log.Ctx{"err": err})
 	}
 	return block, nil
 }
 
-func CBCMac(block cipher.Block, msg RawBytes) (RawBytes, *Error) {
+func CBCMac(block cipher.Block, msg common.RawBytes) (common.RawBytes, *common.Error) {
 	blkSize := block.BlockSize()
 	if len(msg)%blkSize != 0 {
-		return nil, NewError(ErrorCiphertextLen, log.Ctx{"textLen": len(msg), "blkSize": blkSize})
+		return nil, common.NewError(ErrorCiphertextLen, "textLen", len(msg), "blkSize", blkSize)
 	}
 	iv := make([]byte, blkSize, blkSize)
 	mode := cipher.NewCBCEncrypter(block, iv)

--- a/go/proto/pcb.go
+++ b/go/proto/pcb.go
@@ -15,7 +15,7 @@
 package proto
 
 import (
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
 const (
@@ -26,22 +26,22 @@ const (
 	ErrorPathSegHopF    = "Unable to get Hop Field from PCB Marking"
 )
 
-func (s PCBMarking) HopF() (util.RawBytes, *util.Error) {
+func (s PCBMarking) HopF() (common.RawBytes, *common.Error) {
 	rawH, err := s.Hof()
 	if err != nil {
-		return nil, util.NewError(ErrorPathSegHopF, "err", err)
+		return nil, common.NewError(ErrorPathSegHopF, "err", err)
 	}
 	return rawH, nil
 }
 
-func (s ASMarking) PCBM(idx int) (*PCBMarking, *util.Error) {
+func (s ASMarking) PCBM(idx int) (*PCBMarking, *common.Error) {
 	pcbms, err := s.Pcbms()
 	if err != nil {
-		return nil, util.NewError(ErrorPathSegPCBMs, "err", err)
+		return nil, common.NewError(ErrorPathSegPCBMs, "err", err)
 	}
 	maxIdx := pcbms.Len() - 1
 	if idx < -1 || idx > maxIdx {
-		return nil, util.NewError(ErrorPathSegASMIdx, "max", maxIdx, "actual", idx)
+		return nil, common.NewError(ErrorPathSegASMIdx, "max", maxIdx, "actual", idx)
 	}
 	if idx == -1 {
 		idx = maxIdx
@@ -50,14 +50,14 @@ func (s ASMarking) PCBM(idx int) (*PCBMarking, *util.Error) {
 	return &pcbm, nil
 }
 
-func (s PathSegment) ASM(idx int) (*ASMarking, *util.Error) {
+func (s PathSegment) ASM(idx int) (*ASMarking, *common.Error) {
 	asms, err := s.Asms()
 	if err != nil {
-		return nil, util.NewError(ErrorPathSegASMs, "err", err)
+		return nil, common.NewError(ErrorPathSegASMs, "err", err)
 	}
 	maxIdx := asms.Len() - 1
 	if idx < -1 || idx > maxIdx {
-		return nil, util.NewError(ErrorPathSegASMIdx, "max", maxIdx, "actual", idx)
+		return nil, common.NewError(ErrorPathSegASMIdx, "max", maxIdx, "actual", idx)
 	}
 	if idx == -1 {
 		idx = maxIdx
@@ -66,7 +66,7 @@ func (s PathSegment) ASM(idx int) (*ASMarking, *util.Error) {
 	return &asm, nil
 }
 
-func (s PathSegment) LastHopF() (util.RawBytes, *util.Error) {
+func (s PathSegment) LastHopF() (common.RawBytes, *common.Error) {
 	asm, err := s.ASM(-1)
 	if err != nil {
 		return nil, err

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -222,10 +222,28 @@
 			"revisionTime": "2016-10-22T18:22:21Z"
 		},
 		{
+			"checksumSHA1": "1zpt0fHadgwtjKfBJA0I3YiffYs=",
+			"path": "golang.org/x/tools/cmd/goimports",
+			"revision": "5e2ae75eb72a62985e086eed33a5982a929e4fff",
+			"revisionTime": "2016-11-11T21:39:39Z"
+		},
+		{
 			"checksumSHA1": "O5eYI3n1WdaC30AxQjETe3dAQHU=",
 			"path": "golang.org/x/tools/cover",
 			"revision": "0db92ca630c08f00e3ba4b5abea93836ca04b42e",
 			"revisionTime": "2016-10-25T20:43:39Z"
+		},
+		{
+			"checksumSHA1": "SoOfjYDw7R1N1P2aHxIjXYFmWUo=",
+			"path": "golang.org/x/tools/go/ast/astutil",
+			"revision": "5e2ae75eb72a62985e086eed33a5982a929e4fff",
+			"revisionTime": "2016-11-11T21:39:39Z"
+		},
+		{
+			"checksumSHA1": "+mjMyJPLBPu7vIHaXkDuvqcDk0s=",
+			"path": "golang.org/x/tools/imports",
+			"revision": "5e2ae75eb72a62985e086eed33a5982a929e4fff",
+			"revisionTime": "2016-11-11T21:39:39Z"
 		},
 		{
 			"checksumSHA1": "dsQ5n+qfjPnd1P5wA0y9LSwbs4A=",

--- a/lib/packet/path.py
+++ b/lib/packet/path.py
@@ -310,7 +310,7 @@ class SCIONPath(Serializable):
 
     def __str__(self):
         s = []
-        s.append("<SCION-Path>")
+        s.append("<SCION-Path(%sB)>" % len(self))
 
         for name, iof_label, hofs_label in (
             ("A", self.A_IOF, self.A_HOFS), ("B", self.B_IOF, self.B_HOFS),

--- a/scion.sh
+++ b/scion.sh
@@ -101,15 +101,8 @@ cmd_lint() {
     return $ret
 }
 
-cmd_gofmt() {
-    echo "Running gofmt"
-    echo "============================================="
-    local fmtout=$(cd go && make -s fmt)
-    if [ -n "$fmtout" ]; then
-        echo "$fmtout"
-        return 1
-    fi
-    return 0
+cmd_golint() {
+    ( cd go && make -s lint )
 }
 
 cmd_version() {
@@ -185,7 +178,7 @@ COMMAND="$1"
 shift
 
 case "$COMMAND" in
-    coverage|help|lint|gofmt|run|stop|status|test|topology|version|build|clean|sciond)
+    coverage|help|lint|golint|run|stop|status|test|topology|version|build|clean|sciond)
         "cmd_$COMMAND" "$@" ;;
     *)  cmd_help; exit 1 ;;
 esac

--- a/test/integration/scmp_error_test.py
+++ b/test/integration/scmp_error_test.py
@@ -93,7 +93,6 @@ class ErrorGenBase(TestClientBase):
 #        padding = self.path.mtu - len(spkt) - len(self.data) + 1
 #        return PayloadRaw(self.data + bytes(padding))
 
-
 class ErrorGenBadHost(ErrorGenBase):
     CLASS = SCMPClass.ROUTING
     TYPE = SCMPRoutingClass.BAD_HOST
@@ -104,6 +103,36 @@ class ErrorGenBadHost(ErrorGenBase):
         pkt.set_payload(IFIDPayload.from_values(77))
         pkt.addrs.dst.host = HostAddrSVC(99, raw=False)
         return pkt
+
+
+class ErrorGenBadVersion(ErrorGenBase):
+    DESC = "bad version"
+
+    def _send_pkt(self, spkt):
+        next_hop, port = self.sd.get_first_hop(spkt)
+        raw = bytearray(spkt.pack())
+        raw[0] |= 0x80
+        self._send_raw_pkt(raw, next_hop, port)
+
+
+class ErrorGenBadSrcType(ErrorGenBase):
+    DESC = "bad src type"
+
+    def _send_pkt(self, spkt):
+        next_hop, port = self.sd.get_first_hop(spkt)
+        raw = bytearray(spkt.pack())
+        raw[0] |= 0x1
+        self._send_raw_pkt(raw, next_hop, port)
+
+
+class ErrorGenBadDstType(ErrorGenBase):
+    DESC = "bad dst type"
+
+    def _send_pkt(self, spkt):
+        next_hop, port = self.sd.get_first_hop(spkt)
+        raw = bytearray(spkt.pack())
+        raw[1] |= 0x4
+        self._send_raw_pkt(raw, next_hop, port)
 
 
 class ErrorGenBadPktLenShort(ErrorGenBase):
@@ -305,6 +334,9 @@ class ErrorGenBadHopByHop(ErrorGenBase):
 GEN_LIST = (
     # ErrorGenOversizePkt,
     ErrorGenBadHost,
+    ErrorGenBadVersion,
+    ErrorGenBadSrcType,
+    ErrorGenBadDstType,
     ErrorGenBadPktLenShort,
     ErrorGenBadPktLenLong,
     ErrorGenBadHdrLenShort,

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -94,7 +94,7 @@ INITIAL_TRC_VERSION = 0
 
 DEFAULT_NETWORK = "127.0.0.0/8"
 DEFAULT_MININET_NETWORK = "100.64.0.0/10"
-DEFAULT_ROUTER = "py"
+DEFAULT_ROUTER = "go"
 
 SCION_SERVICE_NAMES = (
     "BeaconServers",
@@ -890,7 +890,7 @@ def main():
     parser.add_argument('-z', '--zk-config', default=DEFAULT_ZK_CONFIG,
                         help='Zookeeper configuration file')
     parser.add_argument('-r', '--router', default=DEFAULT_ROUTER,
-                        help='Router implementation to use ("py" or "go"')
+                        help='Router implementation to use ("go" or "py")')
     args = parser.parse_args()
     confgen = ConfigGenerator(
         args.output_dir, args.topo_config, args.path_policy, args.zk_config,


### PR DESCRIPTION
- This change adds SCMP error handling for the Go router. Any error
  that's raised that corresponds to an SCMP error has the SCMP class,
  type, and any required info, embedded in it, allowing for generic
  handling and processing.
- SIBRA integration tests are no longer run by default, as the Go router
  does not yet have SIBRA support.

Major refactorings:
- Move `RawBytes` and `Error` from go/lib/util to go/lib/common, as
  they're used in ~all go code.
- Rename go/border/packet.packet to go/border/rpkt.RtrPkt (for Router
  Packet), and add go/lib/spkt.ScnPkt (for SCION Packet), and functions
  for converting between them.
  - RtrPkt is a high-performance representation that's tied to a single
    underlying byte slice. It only parses exactly the bytes required, on
    demand. As such it only allows very minimal, in-place, packet
    modification.
  - ScnPkt is a high-level representation that has no underlying storage,
    allowing it to be easily maniuplated (e.g. reversing,
    adding/changing/removing extensions, etc).
- Split up go/border/rpkt/extn_* into router-specific logic (stays in
  the original dir) and non-router-specific logic in go/lib/spkt/extn_*.
  The router specific types have an `R` prefix to help distinguish them.
- Defined interfaces for extensions, l4 headers, and payloads, so they
  can be handled generically.

Also:
- Replace scion.sh's gofmt and govet commands with a unified golint
  command.
- Update govendor now that
  kardianos/govendor#242 is merged.
- Added go/lib/assert to make it easier to check prereqs/assumptions in
  code. It's turned on by default, and can be disabled via
  `make GOTAGS= all` in `go/`.
- Add goimports tool as a dependency, to find formatting issues with
  imports.
- Improve goconvey console text output by using the `story` reporter.
- Store raw RevInfo messages in the go router for use in SCMP revocation
  messages.
- Set a maximum virtual memory size for the go router, to help catch
  run-away memory leaks before the machine starts swap thrashing.
- Create all RtrPkt's with maximum-sized buffers, which means they can all
  be reused.
- Moved all the binary `order` variables to a single entry in
  go/lib/common
- Add scmp revocation handling to the path server.
- Add some tests to scmp_error_test.py that don't expect a reply, just
  to make sure the router doesn't crash because of them.
- Only run goimport on local non-generated files, to avoid errors from
  go/proto/*.capnp.go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/934)
<!-- Reviewable:end -->
