### PR TITLE
Find the border router by it's ID instead of the host address.

### DIFF
--- a/infrastructure/router/main.py
+++ b/infrastructure/router/main.py
@@ -108,7 +108,7 @@ class Router(SCIONElement):
         super().__init__(server_id, conf_dir, )
         self.interface = None
         for border_router in self.topology.get_all_border_routers():
-            if border_router.addr == self.addr.host:
+            if border_router.name == self.id:
                 self.interface = border_router.interface
                 break
         assert self.interface is not None


### PR DESCRIPTION
Otherwise it will may get the wrong interface in case there are multiple
border routers running on the same IP.

Fixes https://github.com/netsec-ethz/scion/issues/932

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/940)
<!-- Reviewable:end -->
