### PR TITLE
Fix packet recycling with libhsr in the go router.

### DIFF
--- a/go/border/hsr/hsr.go
+++ b/go/border/hsr/hsr.go
@@ -93,9 +93,9 @@ func Init(zlog_cfg string, args []string, addrMs []AddrMeta) *common.Error {
 	AddrMs = addrMs
 	// Calculate the C address structure from the Go address structure.
 	cAddrs := make([]C.saddr_storage, len(AddrMs))
-	for i, addrM := range AddrMs {
-		udpAddrToSaddr(addrM.GoAddr, &addrM.CAddr)
-		cAddrs[i] = addrM.CAddr
+	for i := range AddrMs {
+		udpAddrToSaddr(AddrMs[i].GoAddr, &AddrMs[i].CAddr)
+		cAddrs[i] = AddrMs[i].CAddr
 	}
 	// Configure network ports
 	if C.setup_network(&cAddrs[0], C.int(len(cAddrs))) != 0 {

--- a/go/border/io-hsr.go
+++ b/go/border/io-hsr.go
@@ -69,8 +69,8 @@ func (r *Router) readHSRInput(_ chan *rpkt.RtrPkt) {
 			// Process packet.
 			r.processPacket(rp)
 			metrics.PktProcessTime.Add(time.Now().Sub(rp.TimeIn).Seconds())
-			// Recycle packet.
-			r.recyclePkt(rp)
+			// Reset packet.
+			rp.Reset()
 		}
 		// Update port metrics
 		duration := timeIn.Sub(start).Seconds()

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -50,12 +50,6 @@ func main() {
 		profile.Start(*id)
 	}
 	setupSignals()
-	// Set max virtual memory size to 1GiB in bytes.
-	rLimit := &syscall.Rlimit{Max: 1 << 30, Cur: 1 << 30}
-	if err := syscall.Setrlimit(syscall.RLIMIT_AS, rLimit); err != nil {
-		log.Crit("Setting RLIMIT_AS failed", "err", err)
-		os.Exit(1)
-	}
 	r, err := NewRouter(*id, *confDir)
 	if err != nil {
 		log.Crit("Startup failed", err.Ctx...)


### PR DESCRIPTION
readHSRInput was changed to keep a static set of packet buffers for
re-use recently, but the packets were still recycled, meaning they were
available for other parts of the router to reuse. This leads to an
interesting and wide variety of strange errors. This change resets the
packet buffers instead, which clears the contents.

Also:
- Fix a ~cosmetic with how hsr.AddrMs is updated that made debugging
  much harder than it needed to be. The old version takes a /copy/ of
  each element of AddrMs, and modifies the copy, leaving the original
  untouched. The new version fixes that.
- Remove the VSS ulimit, as it causes the hsr library to die fatally on
  startup without much useful information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/943)
<!-- Reviewable:end -->
