### PR TITLE
Disable TCP for now.

### DIFF
--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -107,7 +107,7 @@ class SCIONElement(object):
     """
     SERVICE_TYPE = None
     STARTUP_QUIET_PERIOD = STARTUP_QUIET_PERIOD
-    USE_TCP = True
+    USE_TCP = False
 
     def __init__(self, server_id, conf_dir, host_addr=None, port=None):
         """


### PR DESCRIPTION
The infrastructure's use of TCP is fundamentally broken, as TCP
connections are made in the middle of the main processing threads. This
means that if any TCP connection attempt doesn't immediately succeed,
the thread is blocked. E.g. beacon servers trying to register downpaths
can block the entire main worker loop.

Also, TCP spews vast amount of noise into the logs, making it very
difficult to debug anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/944)
<!-- Reviewable:end -->
