### PR TITLE
Revocation E2E test

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -63,8 +63,7 @@ test/integration/cert_req_test.py -l ERROR
 EOF
 result=$?
 
-run Revocation test/integration/revocation_test.sh \
-${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}
+run Revocation test/integration/revocation_test.sh ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}
 result=$((result+$?))
 
 shutdown

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -63,7 +63,8 @@ test/integration/cert_req_test.py -l ERROR
 EOF
 result=$?
 
-run Revocation test/integration/revocation_test.sh ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}
+run Revocation "test/integration/revocation_test.sh\
+ ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}"
 result=$((result+$?))
 
 shutdown

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -63,8 +63,7 @@ test/integration/cert_req_test.py -l ERROR
 EOF
 result=$?
 
-run Revocation "test/integration/revocation_test.sh\
- ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}"
+run Revocation "test/integration/revocation_test.sh ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}"
 result=$((result+$?))
 
 shutdown

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -64,7 +64,7 @@ EOF
 result=$?
 
 run Revocation test/integration/revocation_test.sh \
-    ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}
+${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}
 result=$((result+$?))
 
 shutdown

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -63,7 +63,8 @@ test/integration/cert_req_test.py -l ERROR
 EOF
 result=$?
 
-run Revocation test/integration/revocation_test.sh as1-11:br1-11-3 as2-26:br2-26-2
+run Revocation test/integration/revocation_test.sh \
+    ${REV_BRS:-as1-11:br1-11-3 as2-26:br2-26-2}
 result=$((result+$?))
 
 shutdown

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -64,7 +64,7 @@ EOF
 result=$?
 
 run Revocation test/integration/revocation_test.sh
-result=${result} + $?
+result=$((${result}+$?))
 
 shutdown
 

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -63,6 +63,9 @@ test/integration/cert_req_test.py -l ERROR
 EOF
 result=$?
 
+run Revocation test/integration/revocation_test.sh
+result=${result} + $?
+
 shutdown
 
 if [ $result -eq 0 ]; then

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -63,8 +63,8 @@ test/integration/cert_req_test.py -l ERROR
 EOF
 result=$?
 
-run Revocation test/integration/revocation_test.sh
-result=$((${result}+$?))
+run Revocation test/integration/revocation_test.sh as1-11:br1-11-3 as2-26:br2-26-2
+result=$((result+$?))
 
 shutdown
 

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -264,7 +264,7 @@ class SCIONDaemon(SCIONElement):
                           "current epoch %d." %
                           (rev_info.p.epoch,
                            ConnectedHashTree.get_current_epoch()))
-            return
+            return 0
 
         to_remove = []
         for segment in db(full=True):

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -737,7 +737,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 to_remove.append(cand.id)
 
             for asm in cand.pcb.iter_asms():
-                if self.verify_asm(asm, rev_info):
+                if self.verify_revocation_for_asm(asm, rev_info):
                     to_remove.append(cand.id)
 
         return to_remove

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -717,7 +717,7 @@ class SCIONElement(object):
             raise SCIONServiceLookupError("No %s servers found" % qname)
         return results
 
-    def verify_asm(self, asm, rev_info):
+    def verify_revocation_for_asm(self, asm, rev_info):
         # FIXME(siva): We are removing the PCB only if any of up/downstream
         # interfaces are down, and not peer interfaces. If you do it for
         # peer interfaces too, you will end up removing some PCBs which are

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -55,6 +55,12 @@ from lib.util import (
 API_TOUT = 15
 
 
+class ResponseRV:
+    FAILURE = 0
+    SUCCESS = 1
+    RETRY = 2
+
+
 class TestBase(object, metaclass=ABCMeta):
     def __init__(self, sd, data, finished, addr, timeout=1.0):
         self.sd = sd
@@ -97,12 +103,13 @@ class TestClientBase(TestBase):
     Base client app
     """
     def __init__(self, sd, data, finished, addr, dst, dport, api=True,
-                 timeout=3.0):
+                 timeout=3.0, retries=0):
         self.dst = dst
         self.dport = dport
         self.api = api
         self.path = None
         self.iflist = []
+        self.retries = retries
         super().__init__(sd, data, finished, addr, timeout)
         self._get_path(api)
 
@@ -125,6 +132,7 @@ class TestClientBase(TestBase):
         data.pop(2)  # port number, unused here
         self.path.mtu = struct.unpack("!H", data.pop(2))[0]
         ifcount = data.pop(1)
+        self.iflist = []
         for i in range(ifcount):
             isd_as = ISD_AS(data.pop(ISD_AS.LEN))
             ifid = struct.unpack("!H", data.pop(2))[0]
@@ -172,13 +180,31 @@ class TestClientBase(TestBase):
     def run(self):
         while not self.finished.is_set():
             self._send()
+            start = time.time()
             spkt = self._recv()
-            if not spkt or not self._handle_response(spkt):
-                if not spkt:
-                    logging.error("Timeout waiting for response")
-                self.success = False
-                self.finished.set()
+            recv_dur = time.time() - start
+            if not spkt:
+                if self.retries:
+                    logging.info("Timeout waiting for response. Retrying...")
+                    self.retries -= 1
+                    self._get_path(self.api)
+                else:
+                    logging.error("Timeout waiting for response.")
+                    self._stop(success=False)
+            else:
+                r_code = self._handle_response(spkt)
+                if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
+                    self._stop(success=bool(r_code))
+                else:
+                    sleep_dur = max(0, 1.0 - recv_dur)
+                    logging.info("Retrying request in %.2fs." % sleep_dur)
+                    time.sleep(sleep_dur)
+                    self._get_path(self.api)
         self._shutdown()
+
+    def _stop(self, success=False):
+        self.success = success
+        self.finished.set()
 
     def _send(self):
         self._send_pkt(self._build_pkt())
@@ -240,7 +266,7 @@ class TestClientServerBase(object):
     NAME = ""
 
     def __init__(self, client, server, sources, destinations, local=True,
-                 max_runs=None):
+                 max_runs=None, retries=0):
         assert self.NAME
         t = threading.current_thread()
         t.name = self.NAME
@@ -251,6 +277,7 @@ class TestClientServerBase(object):
         self.local = local
         self.scionds = {}
         self.max_runs = max_runs
+        self.retries = retries
 
     def run(self):
         try:
@@ -328,7 +355,7 @@ class TestClientServerBase(object):
         Instantiate client app
         """
         return TestClientBase(self._run_sciond(src), data, finished, src, dst,
-                              port)
+                              port, retries=self.retries)
 
     def _run_sciond(self, addr):
         if addr.isd_as not in self.scionds:
@@ -380,6 +407,8 @@ def setup_main(name, parser=None):
                         help="Limit the number of pairs tested")
     parser.add_argument("-w", "--wait", type=float, default=0.0,
                         help="Time in seconds to wait before running")
+    parser.add_argument("--retries", type=int, default=0,
+                        help="Number of retries before giving up.")
     parser.add_argument('src_ia', nargs='?', help='Src isd-as')
     parser.add_argument('dst_ia', nargs='?', help='Dst isd-as')
     args = parser.parse_args()

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -197,7 +197,7 @@ class TestClientBase(TestBase):
                     self._stop(success=bool(r_code))
                 else:
                     sleep_dur = max(0, 1.0 - recv_dur)
-                    logging.info("Retrying request in %.2fs." % sleep_dur)
+                    logging.info("Retrying request in %.1fs." % sleep_dur)
                     time.sleep(sleep_dur)
                     self._get_path(self.api)
         self._shutdown()

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -186,12 +186,13 @@ class TestClientBase(TestBase):
             if not spkt:
                 logging.info("Timeout waiting for response")
                 self._retry_or_stop()
+                continue
+            r_code = self._handle_response(spkt)
+            if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
+                self._stop(success=bool(r_code))
             else:
-                r_code = self._handle_response(spkt)
-                if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
-                    self._stop(success=bool(r_code))
-                else:
-                    self._retry_or_stop(1.0 - recv_dur)
+                # Rate limit retries to 1 request per second.
+                self._retry_or_stop(1.0 - recv_dur)
         self._shutdown()
 
     def _retry_or_stop(self, delay=0.0):

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -22,8 +22,11 @@ import logging
 # SCION
 from lib.main import main_wrapper
 from lib.packet.packet_base import PayloadRaw
+from lib.packet.path_mgmt.rev_info import RevocationInfo
+from lib.packet.scmp.types import SCMPClass, SCMPPathClass
 from lib.types import L4Proto
 from test.integration.base_cli_srv import (
+    ResponseRV,
     setup_main,
     TestClientBase,
     TestClientServerBase,
@@ -46,29 +49,40 @@ class E2EClient(TestClientBase):
 
     def _handle_response(self, spkt):
         if spkt.l4_hdr.TYPE == L4Proto.SCMP:
-            self._handle_scmp(spkt)
-            return False
+            return self._handle_scmp(spkt)
         logging.debug("Received:\n%s", spkt)
         if len(spkt) != self.path.mtu:
             logging.error("Packet length (%sB) != MTU (%sB)",
                           len(spkt), self.path.mtu)
-            return False
+            return ResponseRV.FAILURE
         payload = spkt.get_payload()
         pong = self._gen_max_pld(b"pong " + self.data, len(payload))
         if payload == pong:
             logging.debug('%s:%d: pong received.', self.addr.host,
                           self.sock.port)
-            self.success = True
-            self.finished.set()
-            return True
+            return ResponseRV.SUCCESS
         logging.error(
             "Unexpected payload:\n  Received (%dB): %s\n  "
             "Expected (%dB): %s", len(payload), payload, len(pong), pong)
         return False
 
     def _handle_scmp(self, spkt):
+        scmp_hdr = spkt.l4_hdr
         spkt.parse_payload()
-        logging.error("Received SCMP error:\n%s", spkt)
+        if (scmp_hdr.class_ == SCMPClass.PATH and
+                    scmp_hdr.type == SCMPPathClass.REVOKED_IF):
+            scmp_pld = spkt.get_payload()
+            rev_info = RevocationInfo.from_raw(scmp_pld.info.rev_info)
+            logging.info("Received revocation for IF %d." % rev_info.p.ifID)
+
+            self.sd.handle_revocation(rev_info, None)
+            if not self.retries:
+                return ResponseRV.FAILURE
+            self.retries -= 1
+            return ResponseRV.RETRY
+        else:
+            logging.error("Received SCMP error:\n%s", spkt)
+            return ResponseRV.FAILURE
 
 
 class E2EServer(TestServerBase):
@@ -108,12 +122,14 @@ class TestEnd2End(TestClientServerBase):
         return E2EServer(self._run_sciond(addr), data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
-        return E2EClient(self._run_sciond(src), data, finished, src, dst, port)
+        return E2EClient(self._run_sciond(src), data, finished, src, dst, port,
+                         retries=self.retries)
 
 
 def main():
     args, srcs, dsts = setup_main("end2end")
-    TestEnd2End(args.client, args.server, srcs, dsts, max_runs=args.runs).run()
+    TestEnd2End(args.client, args.server, srcs, dsts, max_runs=args.runs,
+                retries=args.retries).run()
 
 
 if __name__ == "__main__":

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -70,7 +70,7 @@ class E2EClient(TestClientBase):
         scmp_hdr = spkt.l4_hdr
         spkt.parse_payload()
         if (scmp_hdr.class_ == SCMPClass.PATH and
-                    scmp_hdr.type == SCMPPathClass.REVOKED_IF):
+                scmp_hdr.type == SCMPPathClass.REVOKED_IF):
             scmp_pld = spkt.get_payload()
             rev_info = RevocationInfo.from_raw(scmp_pld.info.rev_info)
             logging.info("Received revocation for IF %d." % rev_info.p.ifID)

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -74,11 +74,7 @@ class E2EClient(TestClientBase):
             scmp_pld = spkt.get_payload()
             rev_info = RevocationInfo.from_raw(scmp_pld.info.rev_info)
             logging.info("Received revocation for IF %d." % rev_info.p.ifID)
-
             self.sd.handle_revocation(rev_info, None)
-            if not self.retries:
-                return ResponseRV.FAILURE
-            self.retries -= 1
             return ResponseRV.RETRY
         else:
             logging.error("Received SCMP error:\n%s", spkt)

--- a/test/integration/revocation_test.sh
+++ b/test/integration/revocation_test.sh
@@ -15,15 +15,14 @@ if [ $result -ne 0 ]; then
     exit ${result}
 fi
 # Bring down routers.
-SLEEP=5
+SLEEP=10
 log "Stopping routers and waiting for ${SLEEP}s."
-supervisorctl -s http://localhost:9011 stop as1-11:br1-11-3
-supervisorctl -s http://localhost:9011 stop as1-13:br1-13-2
-supervisorctl -s http://localhost:9011 stop as2-26:br2-26-2
+supervisorctl -s http://localhost:9011 stop as1-11:br1-11-3 > /dev/null
+supervisorctl -s http://localhost:9011 stop as2-26:br2-26-2 > /dev/null
 sleep ${SLEEP}s
 # Do another round of e2e test with retries
 log "Testing connectivity between all the hosts (with retries)."
-test/integration/end2end_test.py -l ERROR --retries 3
+test/integration/end2end_test.py -l INFO --retries 3
 result=$?
 if [ $result -ne 0 ]; then
     log "E2E test with failed routers failed."

--- a/test/integration/revocation_test.sh
+++ b/test/integration/revocation_test.sh
@@ -28,7 +28,6 @@ check_br_exists() {
 }
 
 for br in "$@"; do
-
     if ! check_br_exists "$br"; then
         log "${br} does not exist. Skipping revocation test."
         exit 0

--- a/test/integration/revocation_test.sh
+++ b/test/integration/revocation_test.sh
@@ -27,9 +27,9 @@ check_br_exists() {
     return 0
 }
 
-for br in $@; do
-    check_br_exists $@
-    if [ $? -eq 1 ]; then
+for br in "$@"; do
+
+    if ! check_br_exists "$br"; then
         log "${br} does not exist. Skipping revocation test."
         exit 0
     fi
@@ -46,7 +46,11 @@ fi
 # Bring down routers.
 SLEEP=10
 log "Stopping routers and waiting for ${SLEEP}s."
-./supervisor/supervisor.sh stop $@ > /dev/null
+./supervisor/supervisor.sh stop "$@"
+if [ $? -ne 0 ]; then
+    log "Failed stopping routers."
+    exit 1
+fi
 sleep ${SLEEP}s
 # Do another round of e2e test with retries
 log "Testing connectivity between all the hosts (with retries)."

--- a/test/integration/revocation_test.sh
+++ b/test/integration/revocation_test.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -o pipefail
 
@@ -10,7 +23,7 @@ export PYTHONPATH=.
 log "Testing connectivity between all the hosts."
 test/integration/end2end_test.py -l ERROR
 result=$?
-if [ $result -ne 0 ]; then
+if [ ${result} -ne 0 ]; then
     log "E2E test failed."
     exit ${result}
 fi
@@ -22,7 +35,7 @@ supervisorctl -s http://localhost:9011 stop as2-26:br2-26-2 > /dev/null
 sleep ${SLEEP}s
 # Do another round of e2e test with retries
 log "Testing connectivity between all the hosts (with retries)."
-test/integration/end2end_test.py -l INFO --retries 3
+test/integration/end2end_test.py -l ERROR --retries 3
 result=$?
 if [ $result -ne 0 ]; then
     log "E2E test with failed routers failed."

--- a/test/integration/revocation_test.sh
+++ b/test/integration/revocation_test.sh
@@ -15,10 +15,17 @@ if [ $result -ne 0 ]; then
     exit ${result}
 fi
 # Bring down routers.
-log "Stopping routers."
+SLEEP=5
+log "Stopping routers and waiting for ${SLEEP}s."
 supervisorctl -s http://localhost:9011 stop as1-11:br1-11-3
-sleep 5
+supervisorctl -s http://localhost:9011 stop as1-13:br1-13-2
+supervisorctl -s http://localhost:9011 stop as2-26:br2-26-2
+sleep ${SLEEP}s
 # Do another round of e2e test with retries
 log "Testing connectivity between all the hosts (with retries)."
 test/integration/end2end_test.py -l ERROR --retries 3
-exit $?
+result=$?
+if [ $result -ne 0 ]; then
+    log "E2E test with failed routers failed."
+fi
+exit ${result}

--- a/test/integration/revocation_test.sh
+++ b/test/integration/revocation_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o pipefail
+
+log() {
+    echo "========> ($(date -u --rfc-3339=seconds)) $@"
+}
+
+export PYTHONPATH=.
+log "Testing connectivity between all the hosts."
+test/integration/end2end_test.py -l ERROR
+result=$?
+if [ $result -ne 0 ]; then
+    log "E2E test failed."
+    exit ${result}
+fi
+# Bring down routers.
+log "Stopping routers."
+supervisorctl -s http://localhost:9011 stop as1-11:br1-11-3
+sleep 5
+# Do another round of e2e test with retries
+log "Testing connectivity between all the hosts (with retries)."
+test/integration/end2end_test.py -l ERROR --retries 3
+exit $?


### PR DESCRIPTION
This PR adds an integration test for revocation. To that end, the test clients have been extended to handle revocations and optionally retry the test packet up to N times with different paths. The test first runs one round of the e2e integration test between all pairs (without any retries of packets), then introduces link failures between 2-23 <-> 2-26 and 1-11 <-> 2-21 (by stopping br2-26-2 and br1-11-3) and runs another round of the e2e integration test between all pairs, retrying a test packet up to 3 times. The failed links are chosen in a way that ensures at least one working path between any two ASes. The test is thus successful, if every AS can still communicate with every other AS (like with the e2e integration test). 

Note: This test is specifically tailored to our default test topo and probably has to be changed if the topo ever changes.

It's not a perfect test, but it's better than having nothing at all for a core functionality of SCION.

depends on #947

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/950)
<!-- Reviewable:end -->
