### PR TITLE
Updating/generalizing/fixing PathReversal.md

### DIFF
--- a/doc/PathReversal.md
+++ b/doc/PathReversal.md
@@ -1,17 +1,15 @@
 Handling path reversal correctly in all cases is rather complex. This is a
-short document to describe various cases, and the correct processing required,
-specifically in the context of a router responding to a packet that is heading
-to a revoked link. The aim in all cases is to set the current Hop Field index
-to the appropriate entry for the next router.
+short document to describe various cases, and the correct processing required
+to handle reversing a path in the middle (i.e. a router is doing the reversal).
+The aim in all cases is to set the current Hop Field index to the appropriate
+entry for the next router.
 
 The table fields below are as follows:
 - Router: This specifies the direction of the original packet relative to the
   local AS. E.g. `Egress` means the packet was sent to the router by the local
   AS.
-- Revoked IF: This specifies which interface is revoked, relative to the
-  direction of the original packet. E.g. `Ingress` means the interface the
-  packet arrived over is revoked.
-- Incremented: True if this router has already incremented the packet's path.
+- Action: This specifies which action the router is meant to do.
+- Incremented: True if this router has incremented the packet's path.
 - Segment changed: True if the path increment changed from one segment to the
   next.
 - Xover: True if the current Hop Field has the XOVER bit set.
@@ -23,19 +21,35 @@ The table fields below are as follows:
 The router is not at an Xover point in the path (i.e. it is in the middle of
 the path segment, or at the start/end of the path as a whole).
 
-| Router  | Revoked IF | Incremented? | Segment changed? | Xover? | Rev incs |
-|---------|------------|--------------|------------------|--------|----------|
-| Ingress | Ingress    |              |                  |        | 1        |
-| Ingress | Egress     | X            |                  |        | 1        |
-| Egress  | Egress     |              |                  |        | 0        |
+| Router  | Action          | Incremented? | Segment changed? | Xover? | Rev incs |
+|---------|-----------------|--------------|------------------|--------|----------|
+| Ingress | Forward/Deliver |              |                  |        | 1        |
+| Egress  | Forward         |              |                  |        | 0        |
 
-### Core/Shortcut/Peering change over
+### Core/Shortcut change over
 
-The router is at an Xover point (i.e. the path is switching from one segment.
-to the next).
+The router is at an non-peering Xover point. Note that a local destination is
+illegal in these cases, so the deliver case is left out.
 
-| Router  | Revoked IF | Incremented? | Segment changed? | Xover? | Rev incs |
-|---------|------------|--------------|------------------|--------|----------|
-| Ingress | Ingress    |              |                  | X      | 1        |
-| Ingress | Egress     | X            | X                | X      | 2        |
-| Egress  | Egress     |              |                  | X      | 1        |
+| Router  | Action          | Incremented? | Segment changed? | Xover? | Rev incs |
+|---------|-----------------|--------------|------------------|--------|----------|
+| Ingress | Forward         |              |                  | X      | 1        |
+| Ingress | Forward         | X            | X                | X      | 2        |
+| Egress  | Forward         |              |                  | X      | 1        |
+
+### Peer change over
+The router is at a peering Xover point. This differs from the other Xover
+points in that local delivery is legal, and no segment change is happening.
+
+| Router  | Action          | Incremented? | Segment changed? | Xover? | Rev incs |
+|---------|-----------------|--------------|------------------|--------|----------|
+| Ingress | Forward/Deliver |              |                  | X      | 1        |
+| Ingress | Forward         | X            |                  | X      | 2        |
+| Egress  | Forward         |              |                  | X      | 1        |
+
+### Processing summary
+
+The rules can be simplified to:
+- If the packet is at an egress non-Xover point, stop here.
+- Increment the reversed path one step.
+- Increment the reversed path if it was incremented in the forward direction.

--- a/doc/PathReversal.md
+++ b/doc/PathReversal.md
@@ -9,7 +9,9 @@ The table fields below are as follows:
   local AS. E.g. `Egress` means the packet was sent to the router by the local
   AS.
 - Action: This specifies which action the router is meant to do.
-- Incremented: True if this router has incremented the packet's path.
+- Incremented: True if this router has incremented the packet's path, meaning
+  the common header is updated to point to the next routeable (i.e. not
+  VERIFY_ONLY) Hop Field
 - Segment changed: True if the path increment changed from one segment to the
   next.
 - Xover: True if the current Hop Field has the XOVER bit set.


### PR DESCRIPTION
The previous version had two mistakes (the normal Ingress->Egress case
claimed the path was incremented, and the peering ingress->egress case
was treated the same as core/shortcut cases). In addition to fixing
that, the wording is now more general than just revocation handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/953)
<!-- Reviewable:end -->
