### PR TITLE
Circleci now supplies go1.7, which breaks things.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ checkout:
         echo '
         export GOPATH=$GOPATH:$HOME/go
         export GOBIN=${GOPATH%%:*}/bin
-        export PATH=$GOBIN:$PATH
+        export PATH=/usr/lib/go-1.6/bin:$GOBIN:$PATH
         ' >> ~/.circlerc
       - git submodule sync
       - git submodule update --init sub/web sub/lwip sub/lwip-contrib/

--- a/deps.sh
+++ b/deps.sh
@@ -63,14 +63,14 @@ cmd_zlog() {
 }
 
 cmd_golang() {
-    if ! check_path go git; then
-        echo "Installing go from apt"
+    if ! check_path go git || ! go version | grep -q ' go1\.6\>'; then
+        echo "Installing go 1.6 from apt"
         # Include git, as it's needed for fetching go deps. Relevant for
         # testing building Go code inside docker.
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends golang git
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends golang golang-1.6 git
     fi
-    if ! go version | grep -vq ' go1\.[0-5]\.'; then
-        echo "ERROR: Unsupported go version - requires at least go 1.6: $(go version)"
+    if ! go version | grep -q ' go1\.6\>'; then
+        echo "ERROR: Go version 1.6 required. Unsupported go version found ($(type -p go)): $(go version)"
         exit 1
     fi
     echo "Installing/updating govendor dep manager"


### PR DESCRIPTION
Compiling with go1.7 causes our vendored dependencies to fail to build:

vendor/golang.org/x/net/context/context.go:141: undefined: background
vendor/golang.org/x/net/context/context.go:150: undefined: todo

This change adds the ubuntu-specific go 1.6 path to $PATH for circleci,
and checks to make sure the go version is 1.6 (and disallows 1.7 which
was previously accepted).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/958)
<!-- Reviewable:end -->
