### PR TITLE
Request missing tr cs certs

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -24,6 +24,7 @@ from itertools import product
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
+from lib.crypto.certificate_chain import verify_sig_chain_trc
 from lib.crypto.hash_tree import ConnectedHashTree
 from lib.defines import (
     PATH_FLAG_SIBRA,
@@ -46,6 +47,7 @@ from lib.sibra.ext.resv import ResvBlockSteady
 from lib.socket import ReliableSocket
 from lib.thread import thread_safety_net
 from lib.types import (
+    CertMgmtType,
     PathMgmtType as PMT,
     PathSegmentType as PST,
     PayloadClass,
@@ -89,12 +91,17 @@ class SCIONDaemon(SCIONElement):
         self.api_addr = (api_addr or
                          os.path.join(SCIOND_API_SOCKDIR,
                                       "%s.sock" % self.addr.isd_as))
-
         self.CTRL_PLD_CLASS_MAP = {
             PayloadClass.PATH: {
                 PMT.REPLY: self.handle_path_reply,
                 PMT.REVOCATION: self.handle_revocation,
-            }
+            },
+            PayloadClass.CERT: {
+                CertMgmtType.CERT_CHAIN_REQ: self.process_cert_chain_request,
+                CertMgmtType.CERT_CHAIN_REPLY: self.process_cert_chain_reply,
+                CertMgmtType.TRC_REPLY: self.process_trc_reply,
+                CertMgmtType.TRC_REQ: self.process_trc_request,
+            },
         }
 
         self.SCMP_PLD_CLASS_MAP = {
@@ -143,6 +150,10 @@ class SCIONDaemon(SCIONElement):
         """
         Handle path reply from local path server.
         """
+    #     if self.verify_path(path_reply, meta):
+    #         self.continue_path_processing(path_reply, meta)
+
+    # def continue_path_processing(self, path_reply, meta):
         added = set()
         map_ = {
             PST.UP: self._handle_up_seg,
@@ -162,6 +173,25 @@ class SCIONDaemon(SCIONElement):
             self.requests.put(((dst_ia, flags), None))
         logging.debug("Closing meta")
         meta.close()
+
+    def _verify_path(self, paths):
+        for _, pcb in paths.iter_pcbs():
+            logging.error("PCB")
+            logging.error(pcb)
+            asm = pcb.asm(-1)
+            logging.error("ASM")
+            logging.error(asm)
+            cert_ia = asm.isd_as()
+            trc = self.trust_store.get_trc(cert_ia[0], asm.p.trcVer)
+            logging.error(asm.isd_as())
+            logging.error(asm.cert_ver())
+            chain = self.trust_store.get_cert(asm.isd_as(), asm.cert_ver())
+            logging.error(chain)
+            if not verify_sig_chain_trc(
+                    pcb.sig_pack(), asm.p.sig, str(cert_ia), chain, trc,
+                    asm.p.trcVer):
+                return False
+        return True
 
     def _handle_up_seg(self, pcb):
         if self.addr.isd_as != pcb.last_ia():

--- a/infrastructure/beacon_server/core.py
+++ b/infrastructure/beacon_server/core.py
@@ -104,7 +104,6 @@ class CoreBeaconServer(BeaconServer):
         Register the core segment contained in 'pcb' with the local core path
         server.
         """
-        pcb.remove_crypto()
         pcb.sign(self.signing_key)
         # Register core path with local core path server.
         try:
@@ -134,7 +133,7 @@ class CoreBeaconServer(BeaconServer):
             if not self._filter_pcb(pcb):
                 count += 1
                 continue
-            self._try_to_verify_beacon(pcb)
+            # self._try_to_verify_beacon(pcb)
             self.handle_ext(pcb)
         if count:
             logging.debug("Dropped %d looping Core Segment PCBs", count)

--- a/infrastructure/beacon_server/local.py
+++ b/infrastructure/beacon_server/local.py
@@ -112,7 +112,7 @@ class LocalBeaconServer(BeaconServer):
                     logging.error("Unable to parse raw pcb: %s", e)
                     continue
             if self.path_policy.check_filters(pcb):
-                self._try_to_verify_beacon(pcb)
+                # self._try_to_verify_beacon(pcb)
                 self.handle_ext(pcb)
 
     def process_cert_chain_rep(self, rep, meta):
@@ -165,7 +165,6 @@ class LocalBeaconServer(BeaconServer):
             pcb = self._terminate_pcb(pcb)
             if not pcb:
                 continue
-            pcb.remove_crypto()
             pcb.sign(self.signing_key)
             try:
                 self.register_up_segment(pcb)
@@ -183,7 +182,6 @@ class LocalBeaconServer(BeaconServer):
             pcb = self._terminate_pcb(pcb)
             if not pcb:
                 continue
-            pcb.remove_crypto()
             pcb.sign(self.signing_key)
             self.register_down_segment(pcb)
             logging.info("Down path registered: %s", pcb.short_desc())

--- a/infrastructure/cert_server/main.py
+++ b/infrastructure/cert_server/main.py
@@ -25,18 +25,13 @@ from Crypto.Hash import SHA256
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
-from lib.defines import CERTIFICATE_SERVICE, SCION_UDP_EH_DATA_PORT
+from lib.defines import CERTIFICATE_SERVICE
 from lib.main import main_default, main_wrapper
 from lib.packet.cert_mgmt import (
     CertChainReply,
-    CertChainRequest,
     TRCReply,
-    TRCRequest,
 )
 from lib.packet.scion import msg_from_raw
-from lib.packet.scion_addr import ISD_AS
-from lib.packet.svc import SVCType
-from lib.requests import RequestHandler
 from lib.thread import thread_safety_net
 from lib.types import CertMgmtType, PayloadClass
 from lib.util import (
@@ -65,12 +60,6 @@ class CertServer(SCIONElement):
         :param str conf_dir: configuration directory.
         """
         super().__init__(server_id, conf_dir)
-        self.cc_requests = RequestHandler.start(
-            "CC Requests", self._check_cc, self._fetch_cc, self._reply_cc,
-        )
-        self.trc_requests = RequestHandler.start(
-            "TRC Requests", self._check_trc, self._fetch_trc, self._reply_trc,
-        )
 
         self.CTRL_PLD_CLASS_MAP = {
             PayloadClass.CERT: {
@@ -146,148 +135,6 @@ class CertServer(SCIONElement):
             return
         logging.debug("%s stored in ZK: %s" % ("TRC" if is_trc else "CC",
                                                pld_hash))
-
-    def _send_reply(self, src, src_port, payload):
-        if src.isd_as == self.addr.isd_as:
-            # Local request
-            next_hop, port = src.host, SCION_UDP_EH_DATA_PORT
-            dst_addr = next_hop
-        else:
-            # Remote request
-            next_hop, port = self._get_next_hop(src.isd_as, False, True, True)
-            dst_addr = SVCType.CS_A
-        if next_hop:
-            rep_pkt = self._build_packet(
-                dst_addr, dst_ia=src.isd_as, payload=payload, dst_port=src_port)
-            self.send(rep_pkt, next_hop, port)
-        else:
-            logging.warning("Reply not sent: no destination found")
-
-    def process_cert_chain_request(self, req, meta):
-        """Process a certificate chain request."""
-        assert isinstance(req, CertChainRequest)
-        key = req.isd_as(), req.p.version
-        logging.info("Cert chain request received for %sv%s", *key)
-        local = meta.ia == self.addr.isd_as
-        if not self._check_cc(key) and not local:
-            logging.warning(
-                "Dropping CC request from %s for %sv%s: "
-                "CC not found && requester is not local)",
-                meta.get_addr(), *key)
-        self.cc_requests.put((key, meta))
-
-    def process_cert_chain_reply(self, rep, meta, from_zk=False):
-        """Process a certificate chain reply."""
-        assert isinstance(rep, CertChainReply)
-        ia_ver = rep.chain.get_leaf_isd_as_ver()
-        logging.info("Cert chain reply received for %sv%s (ZK: %s)" %
-                     (ia_ver[0], ia_ver[1], from_zk))
-        self.trust_store.add_cert(rep.chain)
-        if not from_zk:
-            self._share_object(rep, is_trc=False)
-        # Reply to all requests for this certificate chain
-        self.cc_requests.put((ia_ver, None))
-
-    def _check_cc(self, key):
-        cert_chain = self.trust_store.get_cert(*key)
-        if cert_chain:
-            return True
-        logging.debug('Cert chain not found for %sv%s', *key)
-        return False
-
-    def _fetch_cc(self, key, _):
-        isd_as, ver = key
-        req = CertChainRequest.from_values(isd_as, ver)
-        dst_addr, port = self._get_next_hop(isd_as, True)
-        req_pkt = self._build_packet(SVCType.CS_A, dst_ia=isd_as, payload=req)
-        if dst_addr:
-            self.send(req_pkt, dst_addr, port)
-            logging.info("Cert chain request sent: %s", req.short_desc())
-        else:
-            logging.warning("Cert chain request (for %s) not sent: "
-                            "no destination found", req.short_desc())
-
-    def _reply_cc(self, key, meta):
-        isd_as, ver = key
-        dst = meta.get_addr()
-        port = meta.port
-        cert_chain = self.trust_store.get_cert(isd_as, ver)
-        self._send_reply(dst, port, CertChainReply.from_values(cert_chain))
-        logging.info("Cert chain for %sv%s sent to %s:%s",
-                     isd_as, ver, dst, port)
-
-    def process_trc_request(self, req, meta):
-        """Process a TRC request."""
-        assert isinstance(req, TRCRequest)
-        key = req.isd_as()[0], req.p.version
-        logging.info("TRC request received for %sv%s", *key)
-        local = meta.ia == self.addr.isd_as
-        if not self._check_trc(key) and not local:
-            logging.warning(
-                "Dropping TRC request from %s for %sv%s: "
-                "TRC not found && requester is not local)",
-                meta.get_addr(), *key)
-        self.trc_requests.put((key, (meta, req.isd_as()[1]),))
-
-    def process_trc_reply(self, trc_rep, meta, from_zk=False):
-        """
-        Process a TRC reply.
-
-        :param trc_rep: TRC reply.
-        :type trc_rep: TRCReply
-        """
-        assert isinstance(trc_rep, TRCReply)
-        isd, ver = trc_rep.trc.get_isd_ver()
-        logging.info("TRCReply received for ISD %sv%s, ZK: %s",
-                     isd, ver, from_zk)
-        self.trust_store.add_trc(trc_rep.trc)
-        if not from_zk:
-            self._share_object(trc_rep, is_trc=True)
-        # Reply to all requests for this TRC
-        self.trc_requests.put(((isd, ver), None))
-
-    def _check_trc(self, key):
-        trc = self.trust_store.get_trc(*key)
-        if trc:
-            return True
-        logging.debug('TRC not found for %sv%s', *key)
-        return False
-
-    def _fetch_trc(self, key, info):
-        isd, ver = key
-        isd_as = ISD_AS.from_values(isd, info[2])
-        trc_req = TRCRequest.from_values(isd_as, ver)
-        req_pkt = self._build_packet(SVCType.CS_A, payload=trc_req)
-        next_hop, port = self._get_next_hop(isd_as, True, False, True)
-        if next_hop:
-            self.send(req_pkt, next_hop, port)
-            logging.info("TRC request sent for %sv%s.", *key)
-        else:
-            logging.warning("TRC request not sent for %sv%s: "
-                            "no destination found.", *key)
-
-    def _reply_trc(self, key, info):
-        isd, ver = key
-        meta = info[0]
-        dst = meta.get_addr()
-        port = meta.port
-        trc = self.trust_store.get_trc(isd, ver)
-        self._send_reply(dst, port, TRCReply.from_values(trc))
-        logging.info("TRC for %sv%s sent to %s:%s", isd, ver, dst, port)
-
-    def _get_next_hop(self, isd_as, parent=False, child=False, core=False):
-        routers = []
-        if parent:
-            routers += self.topology.parent_border_routers
-        if child:
-            routers += self.topology.child_border_routers
-        if core:
-            routers += self.topology.core_border_routers
-        for r in routers:
-            r_ia = r.interface.isd_as
-            if (isd_as == r_ia) or (isd_as[0] == r_ia[0] and isd_as[1] == 0):
-                return r.addr, r.port
-        return None, None
 
     def run(self):
         """

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -40,8 +40,14 @@ from lib.packet.scmp.types import SCMPClass, SCMPPathClass
 from lib.packet.svc import SVCType
 from lib.path_db import DBResult, PathSegmentDB
 from lib.rev_cache import RevCache
+from lib.requests import RequestHandler
 from lib.thread import thread_safety_net
-from lib.types import PathMgmtType as PMT, PathSegmentType as PST, PayloadClass
+from lib.types import (
+    CertMgmtType,
+    PathMgmtType as PMT,
+    PathSegmentType as PST,
+    PayloadClass,
+)
 from lib.util import SCIONTime, sleep_interval
 from lib.zk.cache import ZkSharedCache
 from lib.zk.errors import ZkNoConnection
@@ -88,6 +94,12 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
                 PMT.REG: self.handle_path_segment_record,
                 PMT.REVOCATION: self._handle_revocation,
                 PMT.SYNC: self.handle_path_segment_record,
+            },
+            PayloadClass.CERT: {
+                CertMgmtType.CERT_CHAIN_REQ: self.process_cert_chain_request,
+                CertMgmtType.CERT_CHAIN_REPLY: self.process_cert_chain_reply,
+                CertMgmtType.TRC_REPLY: self.process_trc_reply,
+                CertMgmtType.TRC_REQ: self.process_trc_request,
             },
         }
         self.SCMP_PLD_CLASS_MAP = {
@@ -322,6 +334,10 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             del self.pending_req[key]
 
     def handle_path_segment_record(self, seg_recs, meta):
+        # if self.verify_path(seg_recs, meta):
+        # self.continue_path_processing(seg_recs, meta)
+
+        # def continue_path_processing(self, seg_recs, meta):
         meta.close()  # FIXME(PSz): validate before
         params = self._dispatch_params(seg_recs, meta)
         added = set()
@@ -333,6 +349,26 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         # Handling pending requests, basing on added segments.
         for dst_ia, sibra in added:
             self._handle_pending_requests(dst_ia, sibra)
+
+    def _verify_path(self, paths):
+        return True
+        # for _, pcb in paths.iter_pcbs():
+        #     logging.error("PCB")
+        #     logging.error(pcb)
+        #     asm = pcb.asm(-1)
+        #     logging.error("ASM")
+        #     logging.error(asm)
+        #     cert_ia = asm.isd_as()
+        #     trc = self.trust_store.get_trc(cert_ia[0], asm.p.trcVer)
+        #     logging.error(asm.isd_as())
+        #     logging.error(asm.cert_ver())
+        #     chain = self.trust_store.get_cert(asm.isd_as(), asm.cert_ver())
+        #     logging.error(chain)
+        #     if not verify_sig_chain_trc(
+        #             pcb.sig_pack(), asm.p.sig, str(cert_ia), chain, trc,
+        #             asm.p.trcVer):
+        #         return False
+        # return True
 
     def _dispatch_segment_record(self, type_, seg, **kwargs):
         # Check that segment does not contain a revoked interface.

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -40,7 +40,6 @@ from lib.packet.scmp.types import SCMPClass, SCMPPathClass
 from lib.packet.svc import SVCType
 from lib.path_db import DBResult, PathSegmentDB
 from lib.rev_cache import RevCache
-from lib.requests import RequestHandler
 from lib.thread import thread_safety_net
 from lib.types import (
     CertMgmtType,

--- a/infrastructure/sibra_server/main.py
+++ b/infrastructure/sibra_server/main.py
@@ -88,6 +88,13 @@ class SibraServerBase(SCIONElement):
             PayloadClass.PATH: {PMT.REG: self.handle_path_reg},
             PayloadClass.SIBRA: {None: self.handle_sibra_pkt},
         }
+        #     PayloadClass.CERT: {
+        #         CertMgmtType.CERT_CHAIN_REQ: self.process_cert_chain_request,
+        #         CertMgmtType.CERT_CHAIN_REPLY: self.process_cert_chain_reply,
+        #         CertMgmtType.TRC_REPLY: self.process_trc_reply,
+        #         CertMgmtType.TRC_REQ: self.process_trc_request,
+        #     },
+        # }
         self._find_links()
         zkid = ZkID.from_values(self.addr.isd_as, self.id,
                                 [(self.addr.host, self._port)]).pack()

--- a/lib/crypto/trc.py
+++ b/lib/crypto/trc.py
@@ -106,9 +106,12 @@ class TRC(object):
             key_ = trc_dict[CORE_ASES_STRING][subject][ONLINE_KEY_STRING]
             self.core_ases[subject][ONLINE_KEY_STRING] = \
                 base64.b64decode(key_.encode('utf-8'))
-        for subject in trc_dict[SIGNATURES_STRING]:
-            self.signatures[subject] = \
-                base64.b64decode(trc_dict[SIGNATURES_STRING][subject])
+            key_ = trc_dict[CORE_ASES_STRING][subject][OFFLINE_KEY_STRING]
+            self.core_ases[subject][OFFLINE_KEY_STRING] = \
+                base64.b64decode(key_.encode('utf-8'))
+        for subject in trc_dict[ROOT_CAS_STRING]:
+            self.root_cas[subject] = base64.b64decode(
+                trc_dict[ROOT_CAS_STRING][subject].encode('utf-8'))
 
     def get_isd_ver(self):
         return self.isd, self.version
@@ -246,20 +249,13 @@ class TRC(object):
             d = trc_dict[CORE_ASES_STRING][subject]
             for key_ in (ONLINE_KEY_STRING, OFFLINE_KEY_STRING, ):
                 key_str = trc_dict[CORE_ASES_STRING][subject][key_]
-                base64.b64encode(key_str.encode('utf-8')).decode('utf-8')
+                d[key_] = base64.b64encode(key_str).decode('utf-8')
             core_ases[subject] = d
         trc_dict[CORE_ASES_STRING] = core_ases
         root_cas = {}
         for subject, cert_str in trc_dict[ROOT_CAS_STRING].items():
-            root_cas[subject] = base64.b64encode(cert_str).decode()
+            root_cas[subject] = base64.b64encode(cert_str).decode('utf-8')
         trc_dict[ROOT_CAS_STRING] = root_cas
-        if with_signatures:
-            signatures = {}
-            for subject in trc_dict[SIGNATURES_STRING]:
-                signature = trc_dict[SIGNATURES_STRING][subject]
-                signatures[subject] = base64.b64encode(
-                    signature.encode('utf-8')).decode('utf-8')
-            trc_dict[SIGNATURES_STRING] = signatures
         trc_str = json.dumps(trc_dict, sort_keys=True, indent=4)
         return trc_str
 

--- a/lib/packet/cert_mgmt.py
+++ b/lib/packet/cert_mgmt.py
@@ -92,7 +92,7 @@ class TRCReply(CertMgmtBase):  # pragma: no cover
 
     def __init__(self, p):
         super().__init__(p)
-        self.trc = TRC(p.trc, lz4_=True)
+        self.trc = TRC.from_raw(p.trc, lz4_=True)
 
     @classmethod
     def from_values(cls, trc):

--- a/lib/packet/path_mgmt/seg_recs.py
+++ b/lib/packet/path_mgmt/seg_recs.py
@@ -122,56 +122,6 @@ class PathRecordsReply(PathSegmentRecords):
     NAME = "PathRecordsReply"
     PAYLOAD_TYPE = PMT.REPLY
 
-    def get_trcs_certs(self):
-        """
-        Returns a dict of all trcs' versions and a dict of all certificates'
-        versions used in this reply, with their highest version number.
-        """
-        trcs = {}
-        certs = {}
-        for pcb in self.iter_pcbs():
-            trcs_, certs_ = pcb[1].get_trcs_certs()
-            for isd in trcs_:
-                if isd in trcs:
-                    trcs[isd].update(trcs_[isd])
-                else:
-                    trcs[isd] = trcs_[isd]
-            for isd_as in certs_:
-                if isd_as in certs:
-                    certs[isd_as].update(certs_[isd_as])
-                else:
-                    certs[isd_as] = certs_[isd_as]
-        return trcs, certs
-
-    def __str__(self):
-        s = []
-        s.append("%s:" % self.NAME)
-        recs = list(self.iter_pcbs())
-        recs.sort(key=lambda x: x[0])
-        last_type = None
-        for type_, pcb in recs:
-            if type_ != last_type:
-                s.append("  %s:" % PST.to_str(type_))
-            s.append("    %s" % pcb.short_desc())
-        return "\n".join(s)
-
-    def _get_pcbs_hash(self):
-        h = SHA256.new()
-        for pcb in self.iter_pcbs():
-            h.update(struct.pack("!q", hash(pcb[1])))
-        return h.digest()
-
-    def __hash__(self):
-        return hash(self._get_pcbs_hash())
-
-    def __eq__(self, other):
-        return self.__str__ == str(other)
-
-
-class PathRecordsReply(PathSegmentRecords):
-    NAME = "PathRecordsReply"
-    PAYLOAD_TYPE = PMT.REPLY
-
 
 class PathRecordsReg(PathSegmentRecords):
     NAME = "PathRecordsReg"

--- a/lib/packet/path_mgmt/seg_recs.py
+++ b/lib/packet/path_mgmt/seg_recs.py
@@ -15,8 +15,11 @@
 :mod:`seg_recs` --- Path Segment records
 ============================================
 """
+import struct
+
 # External
 import capnp  # noqa
+from Crypto.Hash import SHA256
 
 # SCION
 import proto.path_mgmt_capnp as P
@@ -80,6 +83,56 @@ class PathSegmentRecords(PathMgmtPayloadBase):  # pragma: no cover
             s.append("  %s" % rev_info.short_desc())
 
         return "\n".join(s)
+
+
+class PathRecordsReply(PathSegmentRecords):
+    NAME = "PathRecordsReply"
+    PAYLOAD_TYPE = PMT.REPLY
+
+    def get_trcs_certs(self):
+        """
+        Returns a dict of all trcs' versions and a dict of all certificates'
+        versions used in this reply, with their highest version number.
+        """
+        trcs = {}
+        certs = {}
+        for pcb in self.iter_pcbs():
+            trcs_, certs_ = pcb[1].get_trcs_certs()
+            for isd in trcs_:
+                if isd in trcs:
+                    trcs[isd].update(trcs_[isd])
+                else:
+                    trcs[isd] = trcs_[isd]
+            for isd_as in certs_:
+                if isd_as in certs:
+                    certs[isd_as].update(certs_[isd_as])
+                else:
+                    certs[isd_as] = certs_[isd_as]
+        return trcs, certs
+
+    def __str__(self):
+        s = []
+        s.append("%s:" % self.NAME)
+        recs = list(self.iter_pcbs())
+        recs.sort(key=lambda x: x[0])
+        last_type = None
+        for type_, pcb in recs:
+            if type_ != last_type:
+                s.append("  %s:" % PST.to_str(type_))
+            s.append("    %s" % pcb.short_desc())
+        return "\n".join(s)
+
+    def _get_pcbs_hash(self):
+        h = SHA256.new()
+        for pcb in self.iter_pcbs():
+            h.update(struct.pack("!q", hash(pcb[1])))
+        return h.digest()
+
+    def __hash__(self):
+        return hash(self._get_pcbs_hash())
+
+    def __eq__(self, other):
+        return self.__str__ == str(other)
 
 
 class PathRecordsReply(PathSegmentRecords):

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -241,14 +241,6 @@ class PathSegment(SCIONPayloadBaseProto):
         self.p.exts.sibra = ext_p.copy()
         self.sibra_ext = SibraPCBExt(self.p.exts.sibra)
 
-    def remove_crypto(self):  # pragma: no cover
-        """
-        Removes the signatures and certificates from each AS block.
-        """
-        for asm in self.iter_asms():
-            # asm.remove_sig()
-            asm.remove_chain()
-
     def add_rev_infos(self, rev_infos):  # pragma: no cover
         """
         Appends a list of revocations to the PCB. Replaces existing

--- a/lib/packet/scion_addr.py
+++ b/lib/packet/scion_addr.py
@@ -106,6 +106,7 @@ class ISD_AS(Serializable):
             return {"%s_ia" % name: self}
 
     def __eq__(self, other):  # pragma: no cover
+        assert isinstance(other, ISD_AS)
         return self._isd == other._isd and self._as == other._as
 
     def __getitem__(self, idx):  # pragma: no cover

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -336,7 +336,7 @@ class CertGenerator(object):
         else:
             signing_key = self.sig_priv_keys[issuer]
         self.certs[topo_id] = Certificate.from_values(
-            str(topo_id),  str(issuer), INITIAL_CERT_VERSION, "", False,
+            str(topo_id), str(issuer), INITIAL_CERT_VERSION, "", False,
             self.enc_pub_keys[topo_id], self.sig_pub_keys[topo_id],
             signing_key
         )
@@ -369,20 +369,19 @@ class CertGenerator(object):
         # Add public root online/offline key to TRC
         core = {}
         core[ONLINE_KEY_ALG_STRING] = DEFAULT_KEYGEN_ALG
-        core[ONLINE_KEY_STRING] = \
-            base64.b64encode(self.pub_online_root_keys[topo_id]).decode('utf-8')
+        core[ONLINE_KEY_STRING] = self.pub_online_root_keys[topo_id]
         core[OFFLINE_KEY_ALG_STRING] = DEFAULT_KEYGEN_ALG
-        core[OFFLINE_KEY_STRING] = base64.b64encode(
-            self.priv_online_root_keys[topo_id]).decode('utf-8')
+        core[OFFLINE_KEY_STRING] = self.priv_online_root_keys[topo_id]
         trc.core_ases[str(topo_id)] = core
-
-    def _create_trc(self, isd):
         ca_certs = {}
-        for ca_name, ca_cert in self.ca_certs[isd].items():
+        for ca_name, ca_cert in self.ca_certs[topo_id[0]].items():
             ca_certs[ca_name] = \
                  crypto.dump_certificate(crypto.FILETYPE_ASN1, ca_cert)
+        trc.root_cas = ca_certs
+
+    def _create_trc(self, isd):
         self.trcs[isd] = TRC.from_values(
-            isd, "ISD %s" % isd, 0, {}, ca_certs,
+            isd, "ISD %s" % isd, 0, {}, {},
             {}, 2, 'dns_srv_addr', 2,
             3, 18000, True, {})
 


### PR DESCRIPTION
On receicing a beacon: 

- A list of all TRCs and certificates contained in the beacon is created.

- Checks which TRCs and certificates are missing on this beacon server.

- For missing TRCs and certificates creates requests to receive them

- On receving a reply adds the TRC/certificate to trust store

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/959)
<!-- Reviewable:end -->
