### PR TITLE
Add libcapnp-dev to packages list

### DIFF
--- a/pkgs_debian.txt
+++ b/pkgs_debian.txt
@@ -9,6 +9,7 @@ file
 flake8
 g++
 gcc
+libcapnp-dev
 libcurl4-openssl-dev
 libffi-dev
 libjs-jquery-hotkeys


### PR DESCRIPTION
This greatly reduces the amount of work that the pycapnp installation
has to do:

With 500M of ram, it takes 3.5mins for pycapnp to install without the
headers, and 35s with the headers. With less than 500M of ram, pycapnp
install will fail without the headers, but with the headers it can
succeed with 275M of ram (although it takes 5.5mins).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/972)
<!-- Reviewable:end -->
