### PR TITLE
Switch go code to use monotonic time for measuring durations.

### DIFF
--- a/go/border/router.go
+++ b/go/border/router.go
@@ -18,8 +18,8 @@ package main
 
 import (
 	"sync"
-	"time"
 
+	"github.com/gavv/monotime"
 	log "github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"
 
@@ -82,7 +82,7 @@ func (r *Router) handleQueue(q chan *rpkt.RtrPkt) {
 	defer liblog.PanicLog()
 	for rp := range q {
 		r.processPacket(rp)
-		metrics.PktProcessTime.Add(time.Now().Sub(rp.TimeIn).Seconds())
+		metrics.PktProcessTime.Add(monotime.Since(rp.TimeIn).Seconds())
 		r.recyclePkt(rp)
 	}
 }
@@ -94,7 +94,7 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 	if assert.On {
 		assert.Must(len(rp.Raw) > 0, "Raw must not be empty")
 		assert.Must(rp.DirFrom != rpkt.DirUnset, "DirFrom must be set")
-		assert.Must(rp.TimeIn != time.Time{}, "TimeIn must be set")
+		assert.Must(rp.TimeIn != 0, "TimeIn must be set")
 		assert.Must(rp.Ingress.Src != nil, "Ingress.Src must be set")
 		assert.Must(rp.Ingress.Dst != nil, "Ingress.Dst must be set")
 		assert.Must(len(rp.Ingress.IfIDs) > 0, "Ingress.IfIDs must not be empty")

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -17,8 +17,7 @@
 package rpkt
 
 import (
-	"time"
-
+	"github.com/gavv/monotime"
 	log "github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"
 
@@ -33,7 +32,7 @@ func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo Dir) (*RtrPkt, *common.Error) {
 	rp := NewRtrPkt()
 	hdrLen := sp.HdrLen()
 	totalLen := sp.TotalLen()
-	rp.TimeIn = time.Now()
+	rp.TimeIn = monotime.Now()
 	rp.Id = logext.RandId(4)
 	rp.Logger = log.New("rpkt", rp.Id)
 	rp.DirFrom = DirSelf

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -69,7 +69,7 @@ type RtrPkt struct {
 	// Raw is the underlying buffer that represents the raw packet bytes. (RECV)
 	Raw common.RawBytes
 	// TimeIn is the time the packet was received. This is used for metrics calculations. (RECV)
-	TimeIn time.Time
+	TimeIn time.Duration
 	// DirFrom is the direction from which the packet was received. (RECV)
 	DirFrom Dir
 	// DirTo is the direction to which the packet is travelling. (PARSE)

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -68,7 +68,9 @@ type RtrPkt struct {
 	Id string
 	// Raw is the underlying buffer that represents the raw packet bytes. (RECV)
 	Raw common.RawBytes
-	// TimeIn is the time the packet was received. This is used for metrics calculations. (RECV)
+	// TimeIn is the time the packet was received. This is used for metrics
+	// calculations. Note that this is a monotonic time value with an arbitrary
+	// epoch, and can't be used to refer to a particular clock time. (RECV)
 	TimeIn time.Duration
 	// DirFrom is the direction from which the packet was received. (RECV)
 	DirFrom Dir

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -38,6 +38,12 @@
 			"revisionTime": "2016-08-04T10:47:26Z"
 		},
 		{
+			"checksumSHA1": "4HpMp8lo5lc64CIb3pULsFlr4ms=",
+			"path": "github.com/gavv/monotime",
+			"revision": "47d58efa69556a936a3c15eb2ed42706d968ab01",
+			"revisionTime": "2016-10-10T19:08:48Z"
+		},
+		{
 			"checksumSHA1": "REOQlcfY2SLvSk2ZZEtkbgD1GUk=",
 			"license": "MIT",
 			"path": "github.com/glycerine/rbtree",
@@ -308,9 +314,9 @@
 		},
 		{
 			"checksumSHA1": "GJNHvjE2X0/nAriHtebd/8f1xHE=",
-                        "comment": "FIXME(kormat): Use repo directly until https://github.com/zombiezen/go-capnproto2/issues/58 is fixed",
+			"comment": "FIXME(kormat): Use repo directly until https://github.com/zombiezen/go-capnproto2/issues/58 is fixed",
 			"license": "MIT",
-                        "origin": "github.com/zombiezen/go-capnproto2",
+			"origin": "github.com/zombiezen/go-capnproto2",
 			"path": "zombiezen.com/go/capnproto2",
 			"revision": "e255c9f719103c5329bc65aac0adcf12137b7424",
 			"revisionTime": "2016-09-19T00:12:20Z",


### PR DESCRIPTION
This fixes a leap-second crash (#961). Go's std library currently
doesn't allow access to a monotonic time source, so this PR uses a tiny
third-party library that works around that.

Go 1.9 will (probably) have a fix for this. The design doc is at
https://golang.org/design/12914-monotonic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/973)
<!-- Reviewable:end -->
