### PR TITLE
tcmpw_accept() fix

### DIFF
--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -349,6 +349,7 @@ void tcpmw_accept(struct conn_args *args, char *buf, int len){
     app_pollfd.fd = args->fd;
     app_pollfd.events = 0;
     while(1){
+        /* zlog_debug(zc_tcp, "tcpmw_accept loop()"); */
         if ((lwip_err = netconn_accept(args->conn, &newconn)) == ERR_OK)
             break;
 
@@ -362,8 +363,10 @@ void tcpmw_accept(struct conn_args *args, char *buf, int len){
                 if (app_timeout > 0)
                     continue;
             }
-            else
+            else {
                 zlog_error(zc_tcp, "tcpmw_accept(): app died");
+                tcpmw_terminate(args);
+            }
         }
         else /* Other error code than timeout */
             zlog_error(zc_tcp, "tcpmw_accept(): netconn_accept(): %s", lwip_strerr(lwip_err));

--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -349,7 +349,6 @@ void tcpmw_accept(struct conn_args *args, char *buf, int len){
     app_pollfd.fd = args->fd;
     app_pollfd.events = 0;
     while(1){
-        /* zlog_debug(zc_tcp, "tcpmw_accept loop()"); */
         if ((lwip_err = netconn_accept(args->conn, &newconn)) == ERR_OK)
             break;
 

--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -345,7 +345,6 @@ void tcpmw_accept(struct conn_args *args, char *buf, int len){
         netconn_set_recvtimeout(args->conn, tmp_timeout);
     }
     /* Run netconn_accept() checking every timeout if app is stile alive */
-    zlog_debug(zc_tcp, "tcpmw_accept() entering the loop");
     struct pollfd app_pollfd;
     app_pollfd.fd = args->fd;
     app_pollfd.events = 0;

--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -337,13 +337,41 @@ void tcpmw_accept(struct conn_args *args, char *buf, int len){
         goto exit;
     }
 
-    if ((lwip_err = netconn_accept(args->conn, &newconn)) != ERR_OK){
-        if (lwip_err == ERR_TIMEOUT)
-            zlog_debug(zc_tcp, "tcpmw_accept(): netconn_accept(): %s", lwip_strerr(lwip_err));
-        else
+    /* Set temporary timeout for netconn_accept() */
+    int tmp_timeout, app_timeout, org_timeout;
+    tmp_timeout = app_timeout = org_timeout = netconn_get_recvtimeout(args->conn);
+    if (!tmp_timeout || tmp_timeout > ACCEPT_TOUT){
+        tmp_timeout = ACCEPT_TOUT;
+        netconn_set_recvtimeout(args->conn, tmp_timeout);
+    }
+    /* Run netconn_accept() checking every timeout if app is stile alive */
+    zlog_debug(zc_tcp, "tcpmw_accept() entering the loop");
+    struct pollfd app_pollfd;
+    app_pollfd.fd = args->fd;
+    app_pollfd.events = 0;
+    while(1){
+        if ((lwip_err = netconn_accept(args->conn, &newconn)) == ERR_OK)
+            break;
+
+        if (lwip_err == ERR_TIMEOUT){
+            /* Check whether app is alive */
+            if (!poll(&app_pollfd, 1, 0)){
+                /* App is alive, check timeout */
+                if (!app_timeout)
+                    continue;
+                app_timeout -= tmp_timeout;
+                if (app_timeout > 0)
+                    continue;
+            }
+            else
+                zlog_error(zc_tcp, "tcpmw_accept(): app died");
+        }
+        else /* Other error code than timeout */
             zlog_error(zc_tcp, "tcpmw_accept(): netconn_accept(): %s", lwip_strerr(lwip_err));
         goto exit;
     }
+    /* Set original timeout back */
+    netconn_set_recvtimeout(args->conn, org_timeout);
 
     zlog_info(zc_tcp, "tcpmw_accept(): waiting...");
 

--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -337,45 +337,11 @@ void tcpmw_accept(struct conn_args *args, char *buf, int len){
         goto exit;
     }
 
-    /* Set temporary timeout for netconn_accept() */
-    int tmp_timeout, app_timeout, org_timeout;
-    tmp_timeout = app_timeout = org_timeout = netconn_get_recvtimeout(args->conn);
-    if (!tmp_timeout || tmp_timeout > ACCEPT_TOUT){
-        tmp_timeout = ACCEPT_TOUT;
-        netconn_set_recvtimeout(args->conn, tmp_timeout);
-    }
     /* Run netconn_accept() checking every timeout if app is stile alive */
-    struct pollfd app_pollfd;
-    app_pollfd.fd = args->fd;
-    app_pollfd.events = 0;
-    while(1){
-        if ((lwip_err = netconn_accept(args->conn, &newconn)) == ERR_OK)
-            break;
-
-        if (lwip_err == ERR_TIMEOUT){
-            /* Check whether app is alive */
-            if (!poll(&app_pollfd, 1, 0)){
-                /* App is alive, check timeout */
-                if (!app_timeout)
-                    continue;
-                app_timeout -= tmp_timeout;
-                if (app_timeout > 0)
-                    continue;
-            }
-            else {
-                zlog_error(zc_tcp, "tcpmw_accept(): app died");
-                tcpmw_terminate(args);
-            }
-        }
-        else /* Other error code than timeout */
-            zlog_error(zc_tcp, "tcpmw_accept(): netconn_accept(): %s", lwip_strerr(lwip_err));
+    if ((lwip_err = tcpmw_accept_loop(args, &newconn)) != ERR_OK)
         goto exit;
-    }
-    /* Set original timeout back */
-    netconn_set_recvtimeout(args->conn, org_timeout);
 
-    zlog_info(zc_tcp, "tcpmw_accept(): waiting...");
-
+    /* Connection accepted */
     assert(strlen(LWIP_SOCK_DIR) + SOCK_PATH_LEN < sizeof(addr.sun_path));
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
@@ -455,6 +421,45 @@ clean:
         lwip_err = ERR_SYS;
 exit:
     tcpmw_reply(args, CMD_ACCEPT, lwip_err);
+}
+
+s8_t tcpmw_accept_loop(struct conn_args *args, struct netconn **newconn){
+    s8_t lwip_err = 0;
+    /* Set temporary timeout for netconn_accept() */
+    int tmp_timeout, app_timeout, org_timeout;
+    tmp_timeout = app_timeout = org_timeout = netconn_get_recvtimeout(args->conn);
+    if (!tmp_timeout || tmp_timeout > ACCEPT_TOUT){
+        tmp_timeout = ACCEPT_TOUT;
+        netconn_set_recvtimeout(args->conn, tmp_timeout);
+    }
+    struct pollfd app_pollfd;
+    app_pollfd.fd = args->fd;
+    app_pollfd.events = 0;
+    while(1){
+        if ((lwip_err = netconn_accept(args->conn, newconn)) == ERR_OK)
+            break;
+
+        if (lwip_err == ERR_TIMEOUT){
+            /* Check whether app is alive */
+            if (!poll(&app_pollfd, 1, 0)){
+                /* App is alive, check timeout */
+                if (!app_timeout)
+                    continue;
+                app_timeout -= tmp_timeout;
+                if (app_timeout > 0)
+                    continue;
+            }
+            else {
+                zlog_error(zc_tcp, "tcpmw_accept(): app died: poll(): %s", strerror(errno));
+                tcpmw_terminate(args);
+            }
+        }
+        else /* Other error code than timeout */
+            zlog_error(zc_tcp, "tcpmw_accept(): netconn_accept(): %s", lwip_strerr(lwip_err));
+    }
+    /* Set original timeout back */
+    netconn_set_recvtimeout(args->conn, org_timeout);
+    return lwip_err;
 }
 
 void *tcpmw_pipe_loop(void *data){

--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -456,6 +456,7 @@ s8_t tcpmw_accept_loop(struct conn_args *args, struct netconn **newconn){
         }
         else /* Other error code than timeout */
             zlog_error(zc_tcp, "tcpmw_accept(): netconn_accept(): %s", lwip_strerr(lwip_err));
+        break;
     }
     /* Set original timeout back */
     netconn_set_recvtimeout(args->conn, org_timeout);

--- a/lib/tcp/middleware.h
+++ b/lib/tcp/middleware.h
@@ -77,6 +77,7 @@ void tcpmw_bind(struct conn_args *, char *, int);
 void tcpmw_connect(struct conn_args *, char *, int);
 void tcpmw_listen(struct conn_args *, int);
 void tcpmw_accept(struct conn_args *, char *, int);
+s8_t tcpmw_accept_loop(struct conn_args *, struct netconn **);
 void tcpmw_set_recv_tout(struct conn_args *, char *, int);
 void tcpmw_get_recv_tout(struct conn_args *, int);
 void tcpmw_set_sock_opt(struct conn_args *, char *, int);

--- a/lib/tcp/middleware.h
+++ b/lib/tcp/middleware.h
@@ -26,6 +26,7 @@
 #include <sys/un.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <poll.h>
 #include <pthread.h>
 #include "lwip/api.h"
 #include "lwip/err.h"
@@ -45,6 +46,7 @@
 #define ERR_MW -127  /* API/TCP middleware error. */
 #define ERR_SYS -128  /* All system errors are mapped to this LWIP's code. */
 #define TCP_POLLING_TOUT 15 /* Polling timeout (in ms) used within tcpmw_pipe_loop */
+#define ACCEPT_TOUT 150 /* Polling timeout (in ms) used within tcpmw_accept */
 
 /* Middleware API commands */
 #define CMD_ACCEPT "ACCE"


### PR DESCRIPTION
Currently, when an app calls `accept()` the middleware calls `netconn_accept()` that blocks. If the app dies the `netconn_accept()` still is blocking, thus no new app cannot bind to the blocked addr, port pair (even when using `SO_REUSE`).
This PR solves the problem, by running `netconn_accep()` in a loop and periodically checking whether the app is alive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/976)
<!-- Reviewable:end -->
