### PR TITLE
New peer revocation handling.

### DIFF
--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -39,6 +39,7 @@ from lib.packet.path_mgmt.seg_recs import PathRecordsReply, PathSegmentRecords
 from lib.packet.scmp.types import SCMPClass, SCMPPathClass
 from lib.packet.svc import SVCType
 from lib.path_db import DBResult, PathSegmentDB
+from lib.rev_cache import RevCache
 from lib.thread import thread_safety_net
 from lib.types import PathMgmtType as PMT, PathSegmentType as PST, PayloadClass
 from lib.util import SCIONTime, sleep_interval
@@ -76,10 +77,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         self.pending_req = defaultdict(list)  # Dict of pending requests.
         # Used when l/cPS doesn't have up/dw-path.
         self.waiting_targets = defaultdict(list)
-        self.revocations = ExpiringDict(1000, HASHTREE_EPOCH_TIME)
-        # Contains PCBs that include revocations.
-        self.pcb_cache = ExpiringDict(100, HASHTREE_EPOCH_TIME)
-        self.pcb_cache_lock = Lock()
+        self.revocations = RevCache()
         # A mapping from (hash tree root of AS, IFID) to segments
         self.htroot_if2seg = ExpiringDict(1000, HASHTREE_TTL)
         self.htroot_if2seglock = Lock()
@@ -218,16 +216,12 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         if rev_info in self.revocations:
             logging.debug("Already received revocation. Dropping...")
             return False
-        self.revocations[rev_info] = True
+        self.revocations.add(rev_info)
         logging.debug("Received revocation from %s:\n%s",
                       meta.get_addr(), rev_info)
         self._revs_to_zk.append(rev_info.copy().pack())  # have to pack copy
         # Remove segments that contain the revoked interface.
         self._remove_revoked_segments(rev_info)
-        # Update revocations for PCBs in the the PCB cache.
-        with self.pcb_cache_lock:
-            for segment in self.pcb_cache.values():
-                segment.add_rev_infos([rev_info.copy()])
         # Forward revocation to other path servers.
         self._forward_revocation(rev_info, meta)
 
@@ -280,18 +274,38 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         up = up or set()
         core = core or set()
         down = down or set()
-        if not (up | core | down):
+        all_segs = up | core | down
+        if not all_segs:
             logging.warning("No segments to send")
             return
+        revs_to_add = self._peer_revs_for_segs(all_segs)
         pld = PathRecordsReply.from_values(
             {PST.UP: up, PST.CORE: core, PST.DOWN: down},
+            revs_to_add
         )
         self.send_meta(pld, meta)
         logging.info(
             "Sending PATH_REPLY with %d segment(s) to:%s "
-            "port:%s in response to: %s", len(up | core | down),
-            meta.get_addr(), meta.port, req.short_desc(),
+            "port:%s in response to: %s", len(all_segs),
+            meta.get_addr(), meta.port, req,
         )
+
+    def _peer_revs_for_segs(self, segs):
+        """Returns a list of peer revocations for segments in 'segs'."""
+        def _handle_one_seg(seg):
+            for asm in seg.iter_asms():
+                for pcbm in asm.iter_pcbms(1):
+                    hof = pcbm.hof()
+                    for if_id in [hof.ingress_if, hof.egress_if]:
+                        rev_info = self.revocations.get((asm.isd_as(), if_id))
+                        if rev_info:
+                            revs_to_add.add(rev_info.copy())
+                            return
+        revs_to_add = set()
+        for seg in segs:
+            _handle_one_seg(seg)
+
+        return list(revs_to_add)
 
     def _handle_pending_requests(self, dst_ia, sibra):
         to_remove = []
@@ -313,6 +327,9 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         added = set()
         for type_, pcb in seg_recs.iter_pcbs():
             added.update(self._dispatch_segment_record(type_, pcb, **params))
+        # Add revocations for peer interfaces included in the path segments.
+        for rev_info in seg_recs.iter_rev_infos():
+            self.revocations.add(rev_info)
         # Handling pending requests, basing on added segments.
         for dst_ia, sibra in added:
             self._handle_pending_requests(dst_ia, sibra)
@@ -338,17 +355,13 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         :return: False, if the path segment contains a revoked upstream/
             downstream interface (not peer). True otherwise.
         """
-        for rev_info in list(self.revocations):
-            if not ConnectedHashTree.verify_epoch(rev_info.p.epoch):
-                self.revocations.pop(rev_info)
-                continue
-            for asm in seg.iter_asms():
-                pcbm = asm.pcbm(0)
-                if (rev_info.isd_as() == asm.isd_as() and
-                        rev_info.p.ifID in [pcbm.p.inIF, pcbm.p.outIF]):
+        for asm in seg.iter_asms():
+            pcbm = asm.pcbm(0)
+            for if_id in [pcbm.p.inIF, pcbm.p.outIF]:
+                rev_info = self.revocations.get((asm.isd_as(), if_id))
+                if rev_info:
                     logging.debug("Found revoked interface (%d) in segment "
-                                  "%s." % (rev_info.p.ifID,
-                                           seg.short_desc()))
+                                  "%s." % (rev_info.p.ifID, seg.short_desc()))
                     return False
         return True
 
@@ -379,51 +392,6 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         Handles all types of path request.
         """
         raise NotImplementedError
-
-    def _add_peer_revs(self, segments):
-        """
-        Adds revocations to revoked peering interfaces in segments.
-
-        :returns: Set with modified segments. Elements of the original set
-            stay untouched.
-        """
-        # TODO(shitz): This could be optimized, by keeping a map of (ISD_AS, IF)
-        # -> RevocationInfo for peer revocations.
-        modified_segs = set()
-        current_epoch = ConnectedHashTree.get_current_epoch()
-        for segment in segments:
-            seg_id = segment.get_hops_hash()
-            with self.pcb_cache_lock:
-                if seg_id in self.pcb_cache:
-                    cached_seg = self.pcb_cache[seg_id]
-                    logging.debug("Adding segment from PCB cache to response:"
-                                  " %s" % cached_seg.short_desc())
-                    modified_segs.add(cached_seg)
-                    continue
-                revs_to_add = set()
-                for rev_info in list(self.revocations):
-                    if rev_info.p.epoch < current_epoch:
-                        self.revocations.pop(rev_info)
-                        continue
-                    for asm in segment.iter_asms():
-                        if asm.isd_as() != rev_info.isd_as():
-                            continue
-                        for pcbm in asm.iter_pcbms(1):
-                            hof = pcbm.hof()
-                            if rev_info.p.ifID in [hof.ingress_if,
-                                                   hof.egress_if]:
-                                revs_to_add.add(rev_info.copy())
-                if revs_to_add:
-                    new_seg = segment.copy()
-                    new_seg.add_rev_infos(list(revs_to_add))
-                    logging.debug("Adding revocations to PCB: %s" %
-                                  new_seg.short_desc())
-                    self.pcb_cache[seg_id] = new_seg
-                    modified_segs.add(new_seg)
-                else:
-                    modified_segs.add(segment)
-
-        return modified_segs
 
     def _handle_waiting_targets(self, pcb):
         """

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -287,7 +287,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         logging.info(
             "Sending PATH_REPLY with %d segment(s) to:%s "
             "port:%s in response to: %s", len(all_segs),
-            meta.get_addr(), meta.port, req,
+            meta.get_addr(), meta.port, req.short_desc(),
         )
 
     def _peer_revs_for_segs(self, segs):

--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -255,7 +255,6 @@ class CorePathServer(PathServer):
                                 "is missing. Shouldn't be here (too often).")
             return False
 
-        down_segs = self._add_peer_revs(down_segs)
         self._send_path_segments(req, meta, core=core_segs, down=down_segs)
         return True
 

--- a/infrastructure/path_server/local.py
+++ b/infrastructure/path_server/local.py
@@ -80,8 +80,6 @@ class LocalPathServer(PathServer):
         else:
             self._resolve_not_core(req, up_segs, core_segs, down_segs)
         if up_segs | core_segs | down_segs:
-            up_segs = self._add_peer_revs(up_segs)
-            down_segs = self._add_peer_revs(down_segs)
             self._send_path_segments(req, meta, up_segs, core_segs, down_segs)
             return True
         if new_request:

--- a/lib/crypto/hash_tree.py
+++ b/lib/crypto/hash_tree.py
@@ -250,8 +250,9 @@ class ConnectedHashTree(object):
         return h01 == root or h12 == root
 
     @classmethod
-    def verify_epoch(cls, epoch):
-        cur_epoch = cls.get_current_epoch()
+    def verify_epoch(cls, epoch, cur_epoch=None):
+        if not cur_epoch:
+            cur_epoch = cls.get_current_epoch()
         gap_time = cls.get_time_since_epoch()
         return (epoch == cur_epoch or
                 cur_epoch == epoch + 1 and gap_time < HASHTREE_EPOCH_TOLERANCE)

--- a/lib/packet/path_mgmt/seg_recs.py
+++ b/lib/packet/path_mgmt/seg_recs.py
@@ -71,13 +71,12 @@ class PathSegmentRecords(PathMgmtPayloadBase):  # pragma: no cover
         s.append("%s:" % self.NAME)
         recs = list(self.iter_pcbs())
         recs.sort(key=lambda x: x[0])
-        rev_infos = list(self.iter_rev_infos())
         last_type = None
         for type_, pcb in recs:
             if type_ != last_type:
                 s.append("  %s:" % PST.to_str(type_))
             s.append("    %s" % pcb.short_desc())
-        for rev_info in rev_infos:
+        for rev_info in self.iter_rev_infos():
             s.append("  %s" % rev_info.short_desc())
 
         return "\n".join(s)

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -26,12 +26,10 @@ import capnp  # noqa
 import proto.pcb_capnp as P
 from lib.crypto.asymcrypto import sign
 from lib.crypto.certificate_chain import CertificateChain
-from lib.crypto.hash_tree import ConnectedHashTree
 from lib.defines import EXP_TIME_UNIT
 from lib.flagtypes import PathSegFlags as PSF
 from lib.packet.opaque_field import HopOpaqueField, InfoOpaqueField
 from lib.packet.packet_base import Cerealizable, SCIONPayloadBaseProto
-from lib.packet.path_mgmt.rev_info import RevocationInfo
 from lib.packet.path import SCIONPath
 from lib.packet.scion_addr import ISD_AS
 from lib.sibra.pcb_ext import SibraPCBExt
@@ -182,15 +180,10 @@ class PathSegment(SCIONPayloadBaseProto):
             self.sibra_ext = SibraPCBExt(self.p.exts.sibra)
 
     @classmethod
-    def from_values(cls, info, rev_infos=None,
-                    sibra_ext=None):  # pragma: no cover
+    def from_values(cls, info, sibra_ext=None):  # pragma: no cover
         p = cls.P_CLS.new_message(info=info.pack())
         if sibra_ext:
             p.exts.sibra = sibra_ext.p
-        if rev_infos:
-            p.exts.init("revInfos", len(rev_infos))
-            for i, info in enumerate(rev_infos):
-                p.exts.revInfos[i] = info.copy()
         return cls(p)
 
     def _calc_min_exp(self):
@@ -243,33 +236,6 @@ class PathSegment(SCIONPayloadBaseProto):
     def add_sibra_ext(self, ext_p):  # pragma: no cover
         self.p.exts.sibra = ext_p.copy()
         self.sibra_ext = SibraPCBExt(self.p.exts.sibra)
-
-    def add_rev_infos(self, rev_infos):  # pragma: no cover
-        """
-        Appends a list of revocations to the PCB. Replaces existing
-        revocations with newer ones.
-        """
-        if not rev_infos:
-            return
-        existing = {}
-        current_epoch = ConnectedHashTree.get_current_epoch()
-        for i in range(len(self.p.exts.revInfos)):
-            orphan = self.p.exts.revInfos.disown(i)
-            info_p = orphan.get()
-            if info_p.epoch >= current_epoch:
-                existing[(info_p.isdas, info_p.ifID)] = orphan
-        # Remove revocations for which we already have a newer one.
-        filtered = []
-        for info in rev_infos:
-            if (info.p.epoch >= current_epoch and
-                    (info.p.isdas, info.p.ifID) not in existing):
-                filtered.append(info)
-        self.p.exts.init("revInfos", len(existing) + len(filtered))
-        for i, orphan in enumerate(existing.values()):
-            self.p.exts.revInfos.adopt(i, orphan)
-        n_existing = len(existing)
-        for i, info in enumerate(filtered):
-            self.p.exts.revInfos[n_existing + i] = info.p
 
     def remove_crypto(self):  # pragma: no cover
         """
@@ -355,25 +321,6 @@ class PathSegment(SCIONPayloadBaseProto):
             f |= PSF.SIBRA
         return f
 
-    def rev_info(self, idx):
-        return RevocationInfo(self.p.exts.revInfos[idx])
-
-    def iter_rev_infos(self, start=0):
-        for i in range(start, len(self.p.exts.revInfos)):
-            yield self.rev_info(i)
-
-    def get_rev_map(self):
-        """
-        Returns a dict (ISD_AS, IF) -> RevocationInfo, if there are any
-        revocations in the PCB extensions, otherwise an empty dict.
-        """
-        result = {}
-        for rev_info in self.iter_rev_infos():
-            key = (rev_info.isd_as(), rev_info.p.ifID)
-            result[key] = rev_info
-
-        return result
-
     def short_desc(self):  # pragma: no cover
         """
         Return a short description string of the PathSegment, consisting of a
@@ -390,8 +337,6 @@ class PathSegment(SCIONPayloadBaseProto):
         exts = []
         if self.is_sibra():
             exts.append("  %s" % self.sibra_ext.short_desc())
-        for rev_info in self.iter_rev_infos():
-            exts.append("  %s" % rev_info.short_desc())
         desc.append(" > ".join(hops))
         if exts:
             return "%s\n%s" % ("".join(desc), "\n".join(exts))
@@ -406,9 +351,6 @@ class PathSegment(SCIONPayloadBaseProto):
                 s.append("  %s" % line)
         if self.sibra_ext:
             for line in str(self.sibra_ext).splitlines():
-                s.append("  %s" % line)
-        for rev_info in self.iter_rev_infos():
-            for line in rev_info.short_desc().splitlines():
                 s.append("  %s" % line)
         return "\n".join(s)
 

--- a/lib/rev_cache.py
+++ b/lib/rev_cache.py
@@ -1,0 +1,90 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`rev_cache` --- Cache for revocations
+==========================================
+"""
+# Stdlib
+import logging
+import threading
+
+# SCION
+from lib.crypto.hash_tree import ConnectedHashTree
+
+
+def _mk_key(rev_info):
+    """Returns the key for a RevocationInfo object."""
+    return (rev_info.isd_as(), rev_info.p.ifID)
+
+
+class RevCache:
+    """Thread-safe cache for revocations with auto expiration of entries."""
+
+    def __init__(self, capacity=1000):
+        self._cache = {}
+        self._lock = threading.RLock()
+        self._capacity = capacity
+
+    def __contains__(self, rev_info):
+        return self.contains_key(_mk_key(rev_info))
+
+    def contains_key(self, key):
+        with self._lock:
+            stored_info = self._cache.get(key)
+            return stored_info and self._validate_entry(stored_info)
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def get(self, key, default=None):
+        with self._lock:
+            try:
+                rev_info = self._cache[key]
+            except KeyError:
+                return default
+            if self._validate_entry(rev_info):
+                return rev_info
+            return default
+
+    def add(self, rev_info):
+        """
+        Adds rev_info to the cache and returns True if the operation succeeds.
+        """
+        if not ConnectedHashTree.verify_epoch(rev_info.p.epoch):
+            return False
+        with self._lock:
+            key = _mk_key(rev_info)
+            stored_info = self[key]
+            if not stored_info:
+                # Try to free up space in case the cache reaches the cap limit.
+                if len(self._cache) >= self._capacity:
+                    for rev_info in list(self._cache.values()):
+                        self._validate_entry(rev_info)
+                # Couldn't free up enough space...
+                if len(self._cache) >= self._capacity:
+                    logging.error("Revocation cache full!.")
+                    return False
+                self._cache[key] = rev_info
+                return True
+            if rev_info.p.epoch > stored_info.p.epoch:
+                self._cache[key] = rev_info
+                return True
+            return False
+
+    def _validate_entry(self, rev_info, cur_epoch=None):
+        """Removes an expired revocation from the cache."""
+        if not ConnectedHashTree.verify_epoch(rev_info.p.epoch, cur_epoch):
+            del self._cache[_mk_key(rev_info)]
+            return False
+        return True

--- a/lib/rev_cache.py
+++ b/lib/rev_cache.py
@@ -31,20 +31,20 @@ def _mk_key(rev_info):
 class RevCache:
     """Thread-safe cache for revocations with auto expiration of entries."""
 
-    def __init__(self, capacity=1000):
+    def __init__(self, capacity=1000):  # pragma: no cover
         self._cache = {}
         self._lock = threading.RLock()
         self._capacity = capacity
 
-    def __contains__(self, rev_info):
+    def __contains__(self, rev_info):  # pragma: no cover
         return self.contains_key(_mk_key(rev_info))
 
-    def contains_key(self, key):
+    def contains_key(self, key):  # pragma: no cover
         with self._lock:
             stored_info = self._cache.get(key)
             return stored_info and self._validate_entry(stored_info)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # pragma: no cover
         return self.get(key)
 
     def get(self, key, default=None):
@@ -69,8 +69,8 @@ class RevCache:
             if not stored_info:
                 # Try to free up space in case the cache reaches the cap limit.
                 if len(self._cache) >= self._capacity:
-                    for rev_info in list(self._cache.values()):
-                        self._validate_entry(rev_info)
+                    for info in list(self._cache.values()):
+                        self._validate_entry(info)
                 # Couldn't free up enough space...
                 if len(self._cache) >= self._capacity:
                     logging.error("Revocation cache full!.")
@@ -82,7 +82,7 @@ class RevCache:
                 return True
             return False
 
-    def _validate_entry(self, rev_info, cur_epoch=None):
+    def _validate_entry(self, rev_info, cur_epoch=None):  # pragma: no cover
         """Removes an expired revocation from the cache."""
         if not ConnectedHashTree.verify_epoch(rev_info.p.epoch, cur_epoch):
             del self._cache[_mk_key(rev_info)]

--- a/lib/rev_cache.py
+++ b/lib/rev_cache.py
@@ -65,7 +65,7 @@ class RevCache:
             return False
         with self._lock:
             key = _mk_key(rev_info)
-            stored_info = self[key]
+            stored_info = self.get(key)
             if not stored_info:
                 # Try to free up space in case the cache reaches the cap limit.
                 if len(self._cache) >= self._capacity:

--- a/proto/path_mgmt.capnp
+++ b/proto/path_mgmt.capnp
@@ -17,6 +17,7 @@ struct SegReq {
 
 struct SegRecs {
     recs @0 :List(PCB.PathSegMeta);
+    revInfos @1 :List(RevInfo.RevInfo);
 }
 
 struct PathMgmt {

--- a/proto/pcb.capnp
+++ b/proto/pcb.capnp
@@ -3,7 +3,6 @@ using Go = import "go.capnp";
 $Go.package("proto");
 $Go.import("github.com/netsec-ethz/scion/go/proto");
 
-using RevInfo = import "rev_info.capnp";
 using Sibra = import "sibra.capnp";
 
 struct PCBMarking {
@@ -33,7 +32,6 @@ struct PathSegment {
     asms @2 :List(ASMarking);
     exts :group {
         sibra @3 :Sibra.SibraPCBExt;
-        revInfos @4 :List(RevInfo.RevInfo);
     }
 }
 

--- a/test/lib/packet/path_test.py
+++ b/test/lib/packet/path_test.py
@@ -467,10 +467,13 @@ class TestPathCombinatorBuildShortcutPaths(object):
         up_segments = ['up0', 'up1']
         down_segments = ['down0', 'down1']
         build_path.side_effect = [['path0'], ['path1'], [], ['path1']]
+        peer_revs = create_mock()
         ntools.eq_(
-            PathCombinator.build_shortcut_paths(up_segments, down_segments),
+            PathCombinator.build_shortcut_paths(
+                up_segments, down_segments, peer_revs),
             ["path0", "path1"])
-        calls = [call(*x) for x in product(up_segments, down_segments)]
+        calls = [call(*x, peer_revs)
+                 for x in product(up_segments, down_segments)]
         assert_these_calls(build_path, calls)
 
 
@@ -479,7 +482,9 @@ class TestPathCombinatorBuildShortcuts(PathCombinatorBase):
     Unit tests for lib.packet.path.PathCombinator._build_shortcuts
     """
     def _check_none(self, up_seg, down_seg):
-        ntools.eq_(PathCombinator._build_shortcuts(up_seg, down_seg), [])
+        peer_revs = create_mock()
+        ntools.eq_(
+            PathCombinator._build_shortcuts(up_seg, down_seg, peer_revs), [])
 
     def test_none(self):
         for up, down in self._generate_none():
@@ -491,10 +496,11 @@ class TestPathCombinatorBuildShortcuts(PathCombinatorBase):
         up = self._mk_seg(True)
         down = self._mk_seg(True)
         get_xovr_peer.return_value = None, None
+        peer_revs = create_mock()
         # Call
-        ntools.eq_(PathCombinator._build_shortcuts(up, down), [])
+        ntools.eq_(PathCombinator._build_shortcuts(up, down, peer_revs), [])
         # Tests
-        get_xovr_peer.assert_called_once_with(up, down)
+        get_xovr_peer.assert_called_once_with(up, down, peer_revs)
 
     @patch("lib.packet.path.PathCombinator._join_xovr",
            new_callable=create_mock)
@@ -507,16 +513,17 @@ class TestPathCombinatorBuildShortcuts(PathCombinatorBase):
         up = self._mk_seg(True)
         down = self._mk_seg(True)
         get_xovr_peer.return_value = xovr, peer
+        peer_revs = create_mock()
         # Call
         if is_peer:
-            ntools.eq_(PathCombinator._build_shortcuts(up, down),
+            ntools.eq_(PathCombinator._build_shortcuts(up, down, peer_revs),
                        join_peer.return_value)
         else:
-            ntools.eq_(PathCombinator._build_shortcuts(up, down),
+            ntools.eq_(PathCombinator._build_shortcuts(up, down, peer_revs),
                        join_xovr.return_value)
         # Tests
         if is_peer:
-            join_peer.assert_called_once_with(up, down, peer)
+            join_peer.assert_called_once_with(up, down, peer, peer_revs)
         else:
             join_xovr.assert_called_once_with(up, down, xovr)
 
@@ -589,10 +596,11 @@ class TestPathCombinatorGetXovrPeer(object):
     Unit tests for lib.packet.path.PathCombinator._get_xovr_peer
     """
     def test_none(self):
-        seg = create_mock_full({"iter_asms()": [],
-                                "get_rev_map()": {}})
+        seg = create_mock_full({"iter_asms()": []})
+        peer_revs = create_mock()
         # Call
-        ntools.eq_(PathCombinator._get_xovr_peer(seg, seg), (None, None))
+        ntools.eq_(PathCombinator._get_xovr_peer(seg, seg, peer_revs),
+                   (None, None))
 
     @patch("lib.packet.path.PathCombinator._find_peer_hfs",
            new_callable=create_mock)
@@ -602,18 +610,17 @@ class TestPathCombinatorGetXovrPeer(object):
             create_mock_full({"isd_as()": "1-2"}),
             create_mock_full({"isd_as()": "1-3"}),
         ]
-        up_seg = create_mock_full({"iter_asms()": up_asms,
-                                   "get_rev_map()": {}})
+        up_seg = create_mock_full({"iter_asms()": up_asms})
         down_asms = [
             create_mock_full({"isd_as()": "1-1"}),
             create_mock_full({"isd_as()": "1-2"}),
             create_mock_full({"isd_as()": "1-4"}),
         ]
-        down_seg = create_mock_full({"iter_asms()": down_asms,
-                                     "get_rev_map()": {}})
+        down_seg = create_mock_full({"iter_asms()": down_asms})
         find.return_value = False
+        peer_revs = create_mock()
         # Call
-        ntools.eq_(PathCombinator._get_xovr_peer(up_seg, down_seg),
+        ntools.eq_(PathCombinator._get_xovr_peer(up_seg, down_seg, peer_revs),
                    ((2, 2), None))
 
     @patch("lib.packet.path.PathCombinator._find_peer_hfs",
@@ -624,33 +631,30 @@ class TestPathCombinatorGetXovrPeer(object):
             create_mock_full({"isd_as()": "1-2"}),  # peers with 1-12
             create_mock_full({"isd_as()": "1-3"}),
         ]
-        up_seg = create_mock_full({"iter_asms()": up_asms,
-                                   "get_rev_map()": {}})
+        up_seg = create_mock_full({"iter_asms()": up_asms})
         down_asms = [
             create_mock_full({"isd_as()": "1-10"}),  # peers with 1-1
             create_mock_full({"isd_as()": "1-11"}),
             create_mock_full({"isd_as()": "1-12"}),  # peers with 1-2
         ]
-        down_seg = create_mock_full({"iter_asms()": down_asms,
-                                     "get_rev_map()": {}})
+        down_seg = create_mock_full({"iter_asms()": down_asms})
+        peer_revs = create_mock()
 
-        def matching_peers(a, b, c, d):
+        def matching_peers(a, b, c):
             return (a == up_asms[0] and b == down_asms[0]) or (
                 a == up_asms[1] and b == down_asms[2])
         find.side_effect = matching_peers
         # Call
-        ntools.eq_(PathCombinator._get_xovr_peer(up_seg, down_seg),
+        ntools.eq_(PathCombinator._get_xovr_peer(up_seg, down_seg, peer_revs),
                    (None, (2, 3)))
 
 
 class PathCombinatorJoinShortcutsBase(object):
     def _setup(self, path_args, copy_segment):
-        up_segment = create_mock(["asm", "get_rev_map"])
+        up_segment = create_mock(["asm"])
         up_segment.asm = create_mock()
-        up_segment.get_rev_map.return_value = {}
-        down_segment = create_mock(["asm", "get_rev_map"])
+        down_segment = create_mock(["asm"])
         down_segment.asm = create_mock()
-        down_segment.get_rev_map.return_value = {}
         point = (1, 2)
         up_iof = create_mock(["shortcut", "peer"])
         down_iof = create_mock(["shortcut", "peer"])
@@ -697,10 +701,11 @@ class TestPathCombinatorJoinPeer(PathCombinatorJoinShortcutsBase):
         up_segment, down_segment, point = self._setup(path_args, copy_segment)
         find_peers.return_value = [("uph1", "dph1", 1500),
                                    ("uph2", "dph2", 1500)]
+        peer_revs = create_mock()
         path = SCIONPath.from_values()
         path.mtu = 1400
-        ntools.eq_(
-            PathCombinator._join_peer(up_segment, down_segment, point)[0], path)
+        ntools.eq_(PathCombinator._join_peer(
+            up_segment, down_segment, point, peer_revs)[0], path)
         copy_segment.assert_any_call(up_segment, 1)
         copy_segment.assert_any_call(down_segment, 2, up=False)
         ntools.eq_(build_list.call_count, 2)
@@ -933,8 +938,9 @@ class TestPathCombinatorFindPeerHfs(object):
         down_asm = create_mock_full({"isd_as()": "2-1",
                                      "iter_pcbms()": down_pcbms,
                                      "p": p})
+        peer_revs = create_mock_full({"get()": None})
         # Call
-        ntools.eq_(PathCombinator._find_peer_hfs(up_asm, down_asm, {}, {}), [
+        ntools.eq_(PathCombinator._find_peer_hfs(up_asm, down_asm, peer_revs), [
             (up_pcbms[0].hof(), down_pcbms[0].hof(), 500),
             (up_pcbms[2].hof(), down_pcbms[1].hof(), 700),
         ])
@@ -952,8 +958,14 @@ class TestPathCombinatorFindPeerHfs(object):
                                      "p": p})
         up_peer_rev = create_mock()
         down_peer_rev = create_mock()
-        up_rev_map = {("1-1", 3): up_peer_rev}
-        down_rev_map = {("2-1", 3): down_peer_rev}
+        peer_revs = create_mock(["get"])
+
+        def get_side_effect(key):
+            data = {("1-1", 3): up_peer_rev, ("2-1", 3): down_peer_rev}
+            if key in data:
+                return data[key]
+            return None
+        peer_revs.get.side_effect = get_side_effect
 
         def skip_peer_side_effect(rev, ht_root):
             if rev in [up_peer_rev, down_peer_rev] and ht_root == b"1234":
@@ -962,8 +974,7 @@ class TestPathCombinatorFindPeerHfs(object):
         skip_peer.side_effect = skip_peer_side_effect
 
         # Call
-        peers = PathCombinator._find_peer_hfs(up_asm, down_asm, up_rev_map,
-                                              down_rev_map)
+        peers = PathCombinator._find_peer_hfs(up_asm, down_asm, peer_revs)
         # Tests
         ntools.eq_(peers, [(up_pcbms[0].hof(), down_pcbms[0].hof(), 500)])
         skip_peer.assert_has_calls(

--- a/test/lib/packet/path_test.py
+++ b/test/lib/packet/path_test.py
@@ -962,9 +962,8 @@ class TestPathCombinatorFindPeerHfs(object):
 
         def get_side_effect(key):
             data = {("1-1", 3): up_peer_rev, ("2-1", 3): down_peer_rev}
-            if key in data:
-                return data[key]
-            return None
+            return data.get(key)
+
         peer_revs.get.side_effect = get_side_effect
 
         def skip_peer_side_effect(rev, ht_root):

--- a/test/lib/rev_cache_test.py
+++ b/test/lib/rev_cache_test.py
@@ -16,46 +16,50 @@
 =====================================================
 """
 # Stdlib
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 # External packages
 import nose.tools as ntools
 
 # SCION
 from lib.rev_cache import RevCache
-from test.testcommon import create_mock, create_mock_full
+from test.testcommon import assert_these_calls, create_mock, create_mock_full
 
 
 class TestRevCacheGet:
     """Unit tests for lib.rev_cache.RevCache.get"""
-    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
-    def test(self, validate_entry):
+    def test(self):
         key = ("1-1", 1)
         default = "default"
         rev_info = "rev_info"
         rev_cache = RevCache()
         rev_cache._cache[key] = rev_info
-        validate_entry.return_value = True
-        # Test
+        rev_cache._validate_entry = create_mock()
+        rev_cache._validate_entry.return_value = True
+        # Call
         ntools.eq_(rev_cache.get(key, default=default), rev_info)
+        # Tests
+        assert_these_calls(rev_cache._validate_entry, [call(rev_info)])
 
     def test_missing_entry(self):
         key = ("1-1", 1)
         default = "default"
         rev_cache = RevCache()
-        # Test
+        # Call
         ntools.eq_(rev_cache.get(key, default=default), default)
 
-    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
-    def test_expired_entry(self, validate_entry):
+    def test_expired_entry(self):
         key = ("1-1", 1)
         default = "default"
         rev_info = "rev_info"
         rev_cache = RevCache()
         rev_cache._cache[key] = rev_info
-        validate_entry.return_value = False
-        # Test
+        rev_cache._validate_entry = create_mock()
+        rev_cache._validate_entry.return_value = False
+        # Call
         ntools.eq_(rev_cache.get(key, default=default), default)
+        # Tests
+        assert_these_calls(rev_cache._validate_entry, [call(rev_info)])
 
 
 class TestRevCacheAdd:
@@ -67,19 +71,19 @@ class TestRevCacheAdd:
 
     @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
            new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
-    def test(self, get_item, validate_entry, verify_epoch):
-        rev_info = self._create_rev_info("1-1", 1, 2)
-        get_item.return_value = None
+    def test(self, verify_epoch):
+        key = ("1-1", 1)
+        rev_info = self._create_rev_info(key[0], key[1], 2)
         verify_epoch.return_value = True
-        validate_entry.return_value = True
         rev_cache = RevCache()
+        rev_cache.get = create_mock()
+        rev_cache.get.return_value = None
         # Call
-        ret = rev_cache.add(rev_info)
+        ntools.assert_true(rev_cache.add(rev_info))
         # Tests
-        ntools.assert_true(ret)
-        ntools.eq_(rev_cache._cache[("1-1", 1)], rev_info)
+        ntools.eq_(rev_cache._cache[key], rev_info)
+        assert_these_calls(rev_cache.get, [call(key)])
+        assert_these_calls(verify_epoch, [call(rev_info.p.epoch)])
 
     @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
            new_callable=create_mock)
@@ -87,63 +91,90 @@ class TestRevCacheAdd:
         rev_info = self._create_rev_info("1-1", 1, 2)
         verify_epoch.return_value = False
         rev_cache = RevCache()
-        # Tests
+        # Call
         ntools.assert_false(rev_cache.add(rev_info))
+        assert_these_calls(verify_epoch, [call(rev_info.p.epoch)])
 
     @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
            new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
-    def test_same_entry_exists(self, get_item, verify_epoch):
-        rev_info1 = self._create_rev_info("1-1", 1, 1)
-        rev_info2 = self._create_rev_info("1-1", 1, 1)
-        get_item.return_value = rev_info1
+    def test_same_entry_exists(self, verify_epoch):
+        key = ("1-1", 1)
+        rev_info1 = self._create_rev_info(key[0], key[1], 1)
+        rev_info2 = self._create_rev_info(key[0], key[1], 1)
         verify_epoch.return_value = True
         rev_cache = RevCache()
-        rev_cache._cache[("1-1", 1)] = rev_info1
+        rev_cache.get = create_mock()
+        rev_cache.get.return_value = rev_info1
+        rev_cache._cache[key] = rev_info1
         # Call
-        ret = rev_cache.add(rev_info2)
+        ntools.assert_false(rev_cache.add(rev_info2))
         # Tests
-        ntools.assert_false(ret)
-        ntools.eq_(rev_cache._cache[("1-1", 1)], rev_info1)
+        ntools.eq_(rev_cache._cache[key], rev_info1)
+        assert_these_calls(verify_epoch, [call(rev_info2.p.epoch)])
+        assert_these_calls(rev_cache.get, [call(key)])
 
     @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
            new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
-    def test_with_free_up(self, get_item, validate_entry, verify_epoch):
-        rev_info1 = self._create_rev_info("1-1", 1, 1)
-        rev_info2 = self._create_rev_info("1-2", 1, 2)
-        get_item.return_value = None
+    def test_newer_entry_exists(self, verify_epoch):
+        key = ("1-1", 1)
+        rev_info1 = self._create_rev_info(key[0], key[1], 2)
+        rev_info2 = self._create_rev_info(key[0], key[1], 1)
+        verify_epoch.return_value = True
+        rev_cache = RevCache()
+        rev_cache.get = create_mock()
+        rev_cache.get.return_value = rev_info1
+        rev_cache._cache[key] = rev_info1
+        # Call
+        ntools.assert_false(rev_cache.add(rev_info2))
+        # Tests
+        ntools.eq_(rev_cache._cache[key], rev_info1)
+        assert_these_calls(verify_epoch, [call(rev_info2.p.epoch)])
+        assert_these_calls(rev_cache.get, [call(key)])
+
+    @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
+           new_callable=create_mock)
+    def test_with_free_up(self, verify_epoch):
+        key1 = ("1-1", 1)
+        key2 = ("1-2", 1)
+        rev_info1 = self._create_rev_info(key1[0], key1[1], 1)
+        rev_info2 = self._create_rev_info(key2[0], key2[1], 2)
         verify_epoch.return_value = True
 
         def validate_entry_side_effect(rev_info):
             del rev_cache._cache[(rev_info.isd_as(), rev_info.p.ifID)]
             return False
 
-        validate_entry.side_effect = validate_entry_side_effect
         rev_cache = RevCache(capacity=1)
-        rev_cache._cache[("1-1", 1)] = rev_info1
+        rev_cache._cache[key1] = rev_info1
+        rev_cache._validate_entry = create_mock()
+        rev_cache._validate_entry.side_effect = validate_entry_side_effect
+        rev_cache.get = create_mock()
+        rev_cache.get.return_value = None
         # Call
-        ret = rev_cache.add(rev_info2)
+        ntools.assert_true(rev_cache.add(rev_info2))
         # Tests
-        ntools.assert_true(ret)
-        ntools.eq_(rev_cache._cache[("1-2", 1)], rev_info2)
-        ntools.assert_true(("1-1", 1) not in rev_cache._cache)
+        ntools.eq_(rev_cache._cache[key2], rev_info2)
+        ntools.assert_true(key1 not in rev_cache._cache)
+        assert_these_calls(verify_epoch, [call(rev_info2.p.epoch)])
+        assert_these_calls(rev_cache.get, [call(key2)])
 
     @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
            new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
-    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
-    def test_with_no_free_up(self, get_item, validate_entry, verify_epoch):
-        rev_info1 = self._create_rev_info("1-1", 1, 1)
-        rev_info2 = self._create_rev_info("1-2", 1, 2)
-        get_item.return_value = None
+    def test_with_no_free_up(self, verify_epoch):
+        key1 = ("1-1", 1)
+        key2 = ("1-2", 1)
+        rev_info1 = self._create_rev_info(key1[0], key1[1], 1)
+        rev_info2 = self._create_rev_info(key2[0], key2[1], 2)
         verify_epoch.return_value = True
-        validate_entry.return_value = True
         rev_cache = RevCache(capacity=1)
-        rev_cache._cache[("1-1", 1)] = rev_info1
+        rev_cache._cache[key1] = rev_info1
+        rev_cache._validate_entry = create_mock()
+        rev_cache._validate_entry.return_value = True
+        rev_cache.get = create_mock()
+        rev_cache.get.return_value = None
         # Call
-        ret = rev_cache.add(rev_info2)
+        ntools.assert_false(rev_cache.add(rev_info2))
         # Tests
-        ntools.assert_false(ret)
-        ntools.assert_true(("1-1", 1) in rev_cache._cache)
+        ntools.assert_true(key1 in rev_cache._cache)
+        assert_these_calls(verify_epoch, [call(rev_info2.p.epoch)])
+        assert_these_calls(rev_cache.get, [call(key2)])

--- a/test/lib/rev_cache_test.py
+++ b/test/lib/rev_cache_test.py
@@ -1,0 +1,149 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_rev_cache_test` --- lib.rev_cache tests
+=====================================================
+"""
+# Stdlib
+from unittest.mock import patch
+
+# External packages
+import nose.tools as ntools
+
+# SCION
+from lib.rev_cache import RevCache
+from test.testcommon import create_mock, create_mock_full
+
+
+class TestRevCacheGet:
+    """Unit tests for lib.rev_cache.RevCache.get"""
+    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
+    def test(self, validate_entry):
+        key = ("1-1", 1)
+        default = "default"
+        rev_info = "rev_info"
+        rev_cache = RevCache()
+        rev_cache._cache[key] = rev_info
+        validate_entry.return_value = True
+        # Test
+        ntools.eq_(rev_cache.get(key, default=default), rev_info)
+
+    def test_missing_entry(self):
+        key = ("1-1", 1)
+        default = "default"
+        rev_cache = RevCache()
+        # Test
+        ntools.eq_(rev_cache.get(key, default=default), default)
+
+    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
+    def test_expired_entry(self, validate_entry):
+        key = ("1-1", 1)
+        default = "default"
+        rev_info = "rev_info"
+        rev_cache = RevCache()
+        rev_cache._cache[key] = rev_info
+        validate_entry.return_value = False
+        # Test
+        ntools.eq_(rev_cache.get(key, default=default), default)
+
+
+class TestRevCacheAdd:
+    """Unit tests for lib.rev_cache.RevCache.add"""
+    def _create_rev_info(self, isd_as, if_id, epoch):
+        rev_info_p = create_mock_full({"ifID": if_id, "epoch": epoch})
+        rev_info = create_mock_full({"isd_as()": isd_as, "p": rev_info_p})
+        return rev_info
+
+    @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
+           new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
+    def test(self, get_item, validate_entry, verify_epoch):
+        rev_info = self._create_rev_info("1-1", 1, 2)
+        get_item.return_value = None
+        verify_epoch.return_value = True
+        validate_entry.return_value = True
+        rev_cache = RevCache()
+        # Call
+        ret = rev_cache.add(rev_info)
+        # Tests
+        ntools.assert_true(ret)
+        ntools.eq_(rev_cache._cache[("1-1", 1)], rev_info)
+
+    @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
+           new_callable=create_mock)
+    def test_invalid_entry(self, verify_epoch):
+        rev_info = self._create_rev_info("1-1", 1, 2)
+        verify_epoch.return_value = False
+        rev_cache = RevCache()
+        # Tests
+        ntools.assert_false(rev_cache.add(rev_info))
+
+    @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
+           new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
+    def test_same_entry_exists(self, get_item, verify_epoch):
+        rev_info1 = self._create_rev_info("1-1", 1, 1)
+        rev_info2 = self._create_rev_info("1-1", 1, 1)
+        get_item.return_value = rev_info1
+        verify_epoch.return_value = True
+        rev_cache = RevCache()
+        rev_cache._cache[("1-1", 1)] = rev_info1
+        # Call
+        ret = rev_cache.add(rev_info2)
+        # Tests
+        ntools.assert_false(ret)
+        ntools.eq_(rev_cache._cache[("1-1", 1)], rev_info1)
+
+    @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
+           new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
+    def test_with_free_up(self, get_item, validate_entry, verify_epoch):
+        rev_info1 = self._create_rev_info("1-1", 1, 1)
+        rev_info2 = self._create_rev_info("1-2", 1, 2)
+        get_item.return_value = None
+        verify_epoch.return_value = True
+
+        def validate_entry_side_effect(rev_info):
+            del rev_cache._cache[(rev_info.isd_as(), rev_info.p.ifID)]
+            return False
+
+        validate_entry.side_effect = validate_entry_side_effect
+        rev_cache = RevCache(capacity=1)
+        rev_cache._cache[("1-1", 1)] = rev_info1
+        # Call
+        ret = rev_cache.add(rev_info2)
+        # Tests
+        ntools.assert_true(ret)
+        ntools.eq_(rev_cache._cache[("1-2", 1)], rev_info2)
+        ntools.assert_true(("1-1", 1) not in rev_cache._cache)
+
+    @patch("lib.crypto.hash_tree.ConnectedHashTree.verify_epoch",
+           new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache._validate_entry", new_callable=create_mock)
+    @patch("lib.rev_cache.RevCache.__getitem__", new_callable=create_mock)
+    def test_with_no_free_up(self, get_item, validate_entry, verify_epoch):
+        rev_info1 = self._create_rev_info("1-1", 1, 1)
+        rev_info2 = self._create_rev_info("1-2", 1, 2)
+        get_item.return_value = None
+        verify_epoch.return_value = True
+        validate_entry.return_value = True
+        rev_cache = RevCache(capacity=1)
+        rev_cache._cache[("1-1", 1)] = rev_info1
+        # Call
+        ret = rev_cache.add(rev_info2)
+        # Tests
+        ntools.assert_false(ret)
+        ntools.assert_true(("1-1", 1) in rev_cache._cache)


### PR DESCRIPTION
Simplified peer revocation handling a lot. A path server now adds revocations for peer interfaces to every path reply. Also implemented a revocation cache that for more efficient access to revocations by (ISD_AS, if_id).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/979)
<!-- Reviewable:end -->
