### PR TITLE
Allow Go 1.7

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -63,14 +63,14 @@ cmd_zlog() {
 }
 
 cmd_golang() {
-    if ! check_path go git || ! go version | grep -q ' go1\.6\>'; then
+    if ! check_path go git || ! go version | grep -q ' go1\.[67]\>'; then
         echo "Installing go 1.6 from apt"
         # Include git, as it's needed for fetching go deps. Relevant for
         # testing building Go code inside docker.
         sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends golang golang-1.6 git
     fi
-    if ! go version | grep -q ' go1\.6\>'; then
-        echo "ERROR: Go version 1.6 required. Unsupported go version found ($(type -p go)): $(go version)"
+    if ! go version | grep -q ' go1\.[67]\>'; then
+        echo "ERROR: Go version 1.6 or 1.7 required. Unsupported go version found ($(type -p go)): $(go version)"
         exit 1
     fi
     echo "Installing/updating govendor dep manager"

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test go1.7",
+	"ignore": "test",
 	"package": [
 		{
 			"checksumSHA1": "YNhwvoScUezhDwq58QMY8vUwuqg=",
@@ -250,7 +250,7 @@
 			"revisionTime": "2016-10-21T22:59:10Z"
 		},
 		{
-			"checksumSHA1": "ywm8niu75NXihtusbtxMK44qOU4=",
+			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
 			"license": "3-BSD",
 			"path": "golang.org/x/net/context",
 			"revision": "65dfc08770ce66f74becfdff5f8ab01caef4e946",


### PR DESCRIPTION
Note that this will still install Go 1.6 on apt-based distributions.
If/when we want to change that, we need further testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/992)
<!-- Reviewable:end -->
