### PR TITLE
Fix the `context` dependency error after allowing go 1.7.

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -38,7 +38,7 @@ deps: vendor/.deps.stamp
 vendor/.deps.stamp: vendor/vendor.json
 	@echo "$$(date -Iseconds) Syncing deps"; govendor sync -v
 	@echo "$$(date -Iseconds) Installing deps"; go install ./vendor/...
-	@if [ -n "$$(govendor list -no-status +outside)" ]; then \
+	@if [ -n "$$(govendor list -no-status +outside | grep -v '^context$$')" ]; then \
 	    echo "ERROR: external/missing packages:"; \
 	    govendor list +outside; \
 	    exit 1; \


### PR DESCRIPTION
With govendor no longer blacklisting the go17 build tag, it pulls in
vendor/golang.org/x/net/context/go17.go, which depends on that "context"
package that is supplied by go 1.7. This file is not built under go 1.6
due to the build tag, but govendor is not aware of this, and hence under
1.6 it lists "context" as a missing dependency. This change specifically
excludes just this case.

("golang.org/x/net/context" was moved into the standard library as
"context" in go 1.7, hence this problem).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/996)
<!-- Reviewable:end -->
