### PR TITLE
Fix minor issues with mininet.

### DIFF
--- a/flake8.ini
+++ b/flake8.ini
@@ -1,3 +1,3 @@
 [flake8]
-exclude = .git,docker,external,sphinx-doc,sub/web
+exclude = .git,docker,external,sphinx-doc,sub/web,topology/mininet
 max-line-length = 80

--- a/pkgs_debian.txt
+++ b/pkgs_debian.txt
@@ -20,6 +20,7 @@ net-tools
 netcat-openbsd
 ntp
 parallel
+python-flake8
 python-minimal
 python-pip
 python-setuptools

--- a/scion.sh
+++ b/scion.sh
@@ -92,11 +92,13 @@ go_cover() {
 cmd_lint() {
     set -o pipefail
     local ret=0
-    for i in . sub/web; do
+    for i in . topology/mininet sub/web; do
       [ -d "$i" ] || continue
       echo "Linting $i"
+      local cmd="flake8"
+      [ "$i" = "topology/mininet" ] && cmd="python2 -m flake8"
       echo "============================================="
-      ( cd "$i" && flake8 --config flake8.ini . ) | sort -t: -k1,1 -k2n,2 -k3n,3 || ((ret++))
+      ( cd "$i" && $cmd --config flake8.ini . ) | sort -t: -k1,1 -k2n,2 -k3n,3 || ((ret++))
     done
     return $ret
 }

--- a/topology/mininet/flake8.ini
+++ b/topology/mininet/flake8.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 80

--- a/topology/mininet/run.sh
+++ b/topology/mininet/run.sh
@@ -43,6 +43,7 @@ log "Starting mininet"
 make -C endhost; make install -C endhost
 bin/dispatcher 2>logs/dispatcher.OUT &
 DISPATCHER_PID=$!
+echo "Dispatcher: $DISPATCHER_PID"
 sudo SUPERVISORD=$(which supervisord) python topology/mininet/topology.py
 kill $DISPATCHER_PID
 

--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -40,19 +40,21 @@ class ScionTopo(Topo):
 
         host_map = {}
         for name, section in mnconfig.items():
-            for elem, intf_str in section.items():
-                if ipaddress.ip_interface(intf_str).is_loopback:
+            for elem, addr in section.items():
+                if ipaddress.ip_address(addr).is_loopback:
                     print("""ERROR: The IP address for %s (%s) is a loopback
-                          address""" % (elem, intf_str))
+                          address""" % (elem, addr))
                     print("Try running scion.sh topology -m")
                     sys.exit(1)
+                network = ipaddress.ip_network(unicode(section.name))
                 # The config is utf8, need to convert to a plain string to avoid
                 # tickling bugs in mininet.
                 elem = str(elem)
                 elem_name = elem.replace("-", "_")
                 if elem not in host_map:
                     host_map[elem] = self.addHost(elem_name, ip=None)
-                intf = ipaddress.ip_interface(intf_str)
+                intf = ipaddress.ip_interface(
+                    "%s/%d" % (addr, network.prefixlen))
                 is_link = False
                 if intf.network.prefixlen == intf.max_prefixlen - 1:
                     is_link = True

--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -25,8 +25,6 @@ class ScionTopo(Topo):
     Topology built from a SCION network config."
     """
     def __init__(self, mnconfig, **params):
-
-        # Initialize topology
         Topo.__init__(self, **params)
         self.switch_map = {}
         self._genTopo(mnconfig)


### PR DESCRIPTION
- gen/networks.conf no longer has the subnet mask for each entry, so use
  the one from the section title instead.
- Fix an encoding issue with the backported ipaddress module we use.

Also include the dispatcher PID in the script output, so it's clear if
it died.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/997)
<!-- Reviewable:end -->
