### PR TITLE
Flush paths when retrying after no response has been received.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -307,7 +307,7 @@ class SCIONDaemon(SCIONElement):
                     to_remove.append(segment.get_hops_hash())
         return db.delete_all(to_remove)
 
-    def _flush_dbs(self):
+    def _flush_path_dbs(self):
         self.core_segments.flush()
         self.down_segments.flush()
         self.up_segments.flush()

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -130,14 +130,14 @@ class TestClientBase(TestBase):
         super().__init__(sd, api_addr, data, finished, addr, timeout)
         self._get_path(api)
 
-    def _get_path(self, api):
+    def _get_path(self, api, flush=False):
         if api:
-            self._get_path_via_api()
+            self._get_path_via_api(flush)
         else:
             self._get_path_direct()
         assert self.path_meta.p.mtu
 
-    def _get_path_via_api(self):
+    def _get_path_via_api(self, flush=False):
         """Request path via SCIOND API."""
         response = self._try_sciond_api()
         path_entry = response.path_entry(0)
@@ -148,8 +148,9 @@ class TestClientBase(TestBase):
         port = path_entry.p.port or SCION_UDP_EH_DATA_PORT
         self.first_hop = (fh_addr, port)
 
-    def _try_sciond_api(self):
-        request = SCIONDPathRequest.from_values(self._req_id, self.dst.isd_as)
+    def _try_sciond_api(self, flush=False):
+        request = SCIONDPathRequest.from_values(
+            self._req_id, self.dst.isd_as, flush=flush)
         packed = request.pack_full()
         self._req_id += 1
         start = time.time()
@@ -195,8 +196,8 @@ class TestClientBase(TestBase):
             spkt = self._recv()
             recv_dur = time.time() - start
             if not spkt:
-                logging.info("Timeout waiting for response")
-                self._retry_or_stop()
+                logging.info("Timeout waiting for response.")
+                self._retry_or_stop(flush=True)
                 continue
             r_code = self._handle_response(spkt)
             if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
@@ -206,15 +207,16 @@ class TestClientBase(TestBase):
                 self._retry_or_stop(1.0 - recv_dur)
         self._shutdown()
 
-    def _retry_or_stop(self, delay=0.0):
+    def _retry_or_stop(self, delay=0.0, flush=False):
         if delay < 0:
             delay = 0
         if self.retries:
             self.retries -= 1
-            logging.info("Retrying in %.1f s... (%d retries remaining)." %
-                         (delay, self.retries))
+            logging.info(
+                "Retrying in %.1f s... (%d retries remaining, flush=%s)." %
+                (delay, self.retries, flush))
             time.sleep(delay)
-            self._get_path(self.api)
+            self._get_path(self.api, flush=flush)
         else:
             self._stop()
 

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -139,7 +139,7 @@ class TestClientBase(TestBase):
 
     def _get_path_via_api(self, flush=False):
         """Request path via SCIOND API."""
-        response = self._try_sciond_api()
+        response = self._try_sciond_api(flush)
         path_entry = response.path_entry(0)
         self.path_meta = path_entry.path()
         fh_addr = path_entry.ipv4()


### PR DESCRIPTION
This should fix the flaky revocation test. The reason for the flaky test is a client that uses a path containing a revoked interface and the first hop BR is not alive anymore. The client never receives a revocation, thus it retries the same path over and over again until it reaches the maximum number of retries and fails. With this change a client instructs SCIOND to flush all paths first to make it request new path after the client hasn't received a reponse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1006)
<!-- Reviewable:end -->
