### PR TITLE
Implemented missing calls of SCIOND API

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -290,7 +290,7 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(br_reply.pack_full(), meta)
 
     def _api_handle_service_request(self, request, meta):
-        all_svcs, svc_list = request.all_brs(), []
+        all_svcs, svc_list = request.all_services(), []
         if not all_svcs:
             svc_list = list(request.iter_service_types())
         svc_entries = []

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -243,10 +243,7 @@ class SCIONDaemon(SCIONElement):
         thread = threading.current_thread()
         thread.name = "SCIONDaemon API id:%s %s -> %s" % (
             thread.ident, src_ia, dst_ia)
-        flags = ()
-        if request.p.flags.flush:
-            flags = (_FLUSH_FLAG)
-        paths, error = self.get_paths(dst_ia, flags)
+        paths, error = self.get_paths(dst_ia, flush=request.p.flags.flush)
         if request.p.maxPaths:
             paths = paths[:request.p.maxPaths]
         logging.debug("Replying to api request for %s with %d paths",
@@ -354,10 +351,11 @@ class SCIONDaemon(SCIONElement):
         self.down_segments.flush()
         self.up_segments.flush()
 
-    def get_paths(self, dst_ia, flags=()):
+    def get_paths(self, dst_ia, flags=(), flush=False):
         """Return a list of paths."""
-        logging.debug("Paths requested for %s %s", dst_ia, flags)
-        if _FLUSH_FLAG in flags:
+        logging.debug(
+            "Paths requested for %s %s flush=%s", dst_ia, flags, flush)
+        if flush:
             logging.info("Flushing PathDBs.")
             self._flush_path_dbs()
         if self.addr.isd_as == dst_ia or (

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -41,6 +41,7 @@ from lib.path_db import DBResult, PathSegmentDB
 from lib.requests import RequestHandler
 from lib.rev_cache import RevCache
 from lib.sciond_api.as_req import SCIONDASInfoReply, SCIONDASInfoReplyEntry
+from lib.sciond_api.host_info import HostInfo
 from lib.sciond_api.parse import parse_sciond_msg
 from lib.sciond_api.path_meta import FwdPathMeta
 from lib.sciond_api.path_req import (
@@ -249,8 +250,9 @@ class SCIONDaemon(SCIONElement):
                 br = self.ifid2br[fwd_if]
                 haddr, port = br.addr, br.port
             addrs = [haddr] if haddr else []
+            first_hop = HostInfo.from_values(addrs, port)
             reply_entry = SCIONDPathReplyEntry.from_values(
-                path_meta, addrs, port)
+                path_meta, first_hop)
             reply_entries.append(reply_entry)
         self._send_path_reply(req_id, reply_entries, error, meta)
 

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -274,7 +274,8 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(as_reply.pack_full(), meta)
 
     def _api_handle_br_request(self, request, meta):
-        all_brs, if_list = request.all_brs(), []
+        all_brs = request.all_brs()
+        if_list = []
         if not all_brs:
             if_list = list(request.iter_ids())
         br_entries = []
@@ -287,7 +288,8 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(br_reply.pack_full(), meta)
 
     def _api_handle_service_request(self, request, meta):
-        all_svcs, svc_list = request.all_services(), []
+        all_svcs = request.all_services()
+        svc_list = []
         if not all_svcs:
             svc_list = list(request.iter_service_types())
         svc_entries = []
@@ -353,8 +355,8 @@ class SCIONDaemon(SCIONElement):
 
     def get_paths(self, dst_ia, flags=(), flush=False):
         """Return a list of paths."""
-        logging.debug(
-            "Paths requested for %s %s flush=%s", dst_ia, flags, flush)
+        logging.debug("Paths requested for ISDAS=%s, flags=%s, flush=%s",
+                      dst_ia, flags, flush)
         if flush:
             logging.info("Flushing PathDBs.")
             self._flush_path_dbs()

--- a/lib/sciond_api/br_req.py
+++ b/lib/sciond_api/br_req.py
@@ -36,7 +36,8 @@ class SCIONDBRInfoRequest(SCIONDMsgBase):
         """
         Creates an SCIONDBRInfoRequest.
 
-        :param ids: List of interface ids. An empty list means all BRs.
+        :param ids: List of interface ids. An empty list means all interfaces of
+            all BRs.
         """
         p = cls.P_CLS.new_message()
         if ids:

--- a/lib/sciond_api/br_req.py
+++ b/lib/sciond_api/br_req.py
@@ -1,0 +1,98 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`br_req` --- SCIOND BR requests and replies
+================================================
+"""
+# External
+import capnp  # noqa
+
+# SCION
+import proto.sciond_capnp as P
+from lib.packet.packet_base import Cerealizable
+from lib.sciond_api.base import SCIONDMsgBase
+from lib.sciond_api.host_info import HostInfo
+from lib.types import SCIONDMsgType as SMT
+
+
+class SCIONDBRInfoRequest(SCIONDMsgBase):
+    NAME = "BRInfoRequest"
+    MSG_TYPE = SMT.BR_REQUEST
+    P_CLS = P.BRInfoRequest
+
+    @classmethod
+    def from_values(cls, ids=None):
+        """
+        Creates an SCIONDBRInfoRequest.
+
+        :param ids: List of interface ids. An empty list means all BRs.
+        """
+        p = cls.P_CLS.new_message()
+        if ids:
+            id_entries = p.init("ifIDs", len(ids))
+            for i, if_id in enumerate(ids):
+                id_entries[i] = if_id
+        return cls(p)
+
+    def all_brs(self):
+        return not self.p.ifIDs
+
+    def iter_ids(self):
+        for if_id in self.p.ifIDs:
+            yield if_id
+
+    def short_desc(self):
+        if_str = "ALL" if self.all_brs() else str(self.p.ifIDs)
+        return "IF IDs: %s" % if_str
+
+
+class SCIONDBRInfoReply(SCIONDMsgBase):
+    NAME = "BRInfoReply"
+    MSG_TYPE = SMT.BR_REPLY
+    P_CLS = P.BRInfoReply
+
+    @classmethod
+    def from_values(cls, entries):
+        p = cls.P_CLS.new_message()
+        entry_list = p.init("entries", len(entries))
+        for i, entry in enumerate(entries):
+            entry_list[i] = entry.p
+        return cls(p)
+
+    def entry(self, idx):
+        return SCIONDBRInfoReplyEntry(self.p.entries[idx])
+
+    def iter_entries(self):
+        for entry in self.p.entries:
+            yield SCIONDBRInfoReplyEntry(entry)
+
+    def short_desc(self):
+        return "\n".join([entry.short_desc() for entry in self.iter_entries()])
+
+
+class SCIONDBRInfoReplyEntry(Cerealizable):
+    NAME = "BRInfoReplyEntry"
+    P_CLS = P.BRInfoReplyEntry
+
+    @classmethod
+    def from_values(cls, if_id, host_info):
+        p = cls.P_CLS.new_message(ifID=if_id, hostInfo=host_info.p)
+        return cls(p)
+
+    def host_info(self):
+        return HostInfo(self.p.hostInfo)
+
+    def short_desc(self):
+        return "IF ID: %d Host Info: %s" % (
+            self.p.ifID, self.host_info().short_desc())

--- a/lib/sciond_api/host_info.py
+++ b/lib/sciond_api/host_info.py
@@ -37,7 +37,7 @@ class HostInfo(Cerealizable):  # pragma: no cover
         """
         Returns a HostInfo object with the specified entries.
 
-        :param addr: The list of first hop HostAddr object.
+        :param addrs: The list of HostAddr objects.
         :param port: The first hop port.
         """
         p = cls.P_CLS.new_message()

--- a/lib/sciond_api/host_info.py
+++ b/lib/sciond_api/host_info.py
@@ -1,0 +1,67 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`host_info` --- Host info objects
+======================================
+"""
+# Stdlib
+import logging
+
+# External
+import capnp  # noqa
+
+# SCION
+import proto.sciond_capnp as P
+from lib.packet.host_addr import HostAddrIPv4, HostAddrIPv6
+from lib.packet.packet_base import Cerealizable
+from lib.types import AddrType
+
+
+class HostInfo(Cerealizable):  # pragma: no cover
+    NAME = "HostInfo"
+    P_CLS = P.HostInfo
+
+    @classmethod
+    def from_values(cls, addrs, port):
+        """
+        Returns a HostInfo object with the specified entries.
+
+        :param addr: The list of first hop HostAddr object.
+        :param port: The first hop port.
+        """
+        p = cls.P_CLS.new_message()
+        if port:
+            p.port = port
+        for addr in addrs:
+            if addr.TYPE == AddrType.IPV4:
+                p.addrs.ipv4 = addr.pack()
+            elif addr.TYPE == AddrType.IPV6:
+                p.addrs.ipv6 = addr.pack()
+            else:
+                logging.warning("Unsupported address type: %s" % addr.TYPE)
+        return cls(p)
+
+    def ipv4(self):
+        if self.p.addrs.ipv4:
+            return HostAddrIPv4(self.p.addrs.ipv4)
+        return None
+
+    def ipv6(self):
+        if self.p.addrs.ipv6:
+            return HostAddrIPv6(self.p.addrs.ipv6)
+        return None
+
+    def short_desc(self):
+        return ("IPv4: %s IPv6: %s Port: %d" %
+                (self.ipv4() or "unset", self.ipv6() or "unset", self.p.port))

--- a/lib/sciond_api/parse.py
+++ b/lib/sciond_api/parse.py
@@ -28,15 +28,15 @@ from lib.sciond_api.service_req import (
 )
 
 _MSG_TYPES = (
-    SCIONDPathRequest,
-    SCIONDPathReply,
-    SCIONDASInfoRequest,
     SCIONDASInfoReply,
-    SCIONDBRInfoRequest,
+    SCIONDASInfoRequest,
     SCIONDBRInfoReply,
-    SCIONDServiceInfoRequest,
-    SCIONDServiceInfoReply,
+    SCIONDBRInfoRequest,
+    SCIONDPathReply,
+    SCIONDPathRequest,
     SCIONDRevNotification,
+    SCIONDServiceInfoReply,
+    SCIONDServiceInfoRequest,
 )
 
 

--- a/lib/sciond_api/parse.py
+++ b/lib/sciond_api/parse.py
@@ -19,15 +19,31 @@
 import proto.sciond_capnp as P
 from lib.errors import SCIONParseError
 from lib.sciond_api.as_req import SCIONDASInfoReply, SCIONDASInfoRequest
+from lib.sciond_api.br_req import SCIONDBRInfoReply, SCIONDBRInfoRequest
 from lib.sciond_api.path_req import SCIONDPathReply, SCIONDPathRequest
 from lib.sciond_api.revocation import SCIONDRevNotification
+from lib.sciond_api.service_req import (
+    SCIONDServiceInfoReply,
+    SCIONDServiceInfoRequest,
+)
+
+_MSG_TYPES = (
+    SCIONDPathRequest,
+    SCIONDPathReply,
+    SCIONDASInfoRequest,
+    SCIONDASInfoReply,
+    SCIONDBRInfoRequest,
+    SCIONDBRInfoReply,
+    SCIONDServiceInfoRequest,
+    SCIONDServiceInfoReply,
+    SCIONDRevNotification,
+)
 
 
 def parse_sciond_msg(raw):  # pragma: no cover
     wrapper = P.SCIONDMsg.from_bytes_packed(raw).as_builder()
     type_ = wrapper.which()
-    for cls_ in (SCIONDPathReply, SCIONDPathRequest, SCIONDRevNotification,
-                 SCIONDASInfoRequest, SCIONDASInfoReply):
+    for cls_ in _MSG_TYPES:
         if cls_.MSG_TYPE == type_:
             return cls_(getattr(wrapper, type_))
     raise SCIONParseError("Unsupported SCIOND message type: %s" % type_)

--- a/lib/sciond_api/path_req.py
+++ b/lib/sciond_api/path_req.py
@@ -15,20 +15,17 @@
 :mod:`path_req` --- SCIOND path requests and replies
 ====================================================
 """
-# Stdlib
-import logging
-
 # External
 import capnp  # noqa
 
 # SCION
 import proto.sciond_capnp as P
-from lib.packet.host_addr import HostAddrIPv4, HostAddrIPv6
 from lib.packet.packet_base import Cerealizable
 from lib.packet.scion_addr import ISD_AS
 from lib.sciond_api.base import SCIONDMsgBase
+from lib.sciond_api.host_info import HostInfo
 from lib.sciond_api.path_meta import FwdPathMeta
-from lib.types import AddrType, SCIONDMsgType as SMT
+from lib.types import SCIONDMsgType as SMT
 
 
 class SCIONDPathRequest(SCIONDMsgBase):  # pragma: no cover
@@ -130,25 +127,15 @@ class SCIONDPathReplyEntry(Cerealizable):  # pragma: no cover
         self._path = None
 
     @classmethod
-    def from_values(cls, path, addrs, port):
+    def from_values(cls, path, first_hop):
         """
         Returns a SCIONDPathReplyEntry object with the specified entries.
 
         :param path: The FwdPathMeta object.
-        :param addr: The list of first hop HostAddr object.
-        :param port: The first hop port.
+        :param first_hop: A HostInfo object for the first hop of the path.
         """
         assert isinstance(path, FwdPathMeta)
-        p = cls.P_CLS.new_message(path=path.p)
-        if port:
-            p.port = port
-        for addr in addrs:
-            if addr.TYPE == AddrType.IPV4:
-                p.addrs.ipv4 = addr.pack()
-            elif addr.TYPE == AddrType.IPV6:
-                p.addrs.ipv6 = addr.pack()
-            else:
-                logging.warning("Unsupported address type: %s" % addr.TYPE)
+        p = cls.P_CLS.new_message(path=path.p, hostInfo=first_hop.p)
         return cls(p)
 
     def path(self):
@@ -156,24 +143,14 @@ class SCIONDPathReplyEntry(Cerealizable):  # pragma: no cover
             self._path = FwdPathMeta(self.p.path)
         return self._path
 
-    def ipv4(self):
-        if self.p.addrs.ipv4:
-            return HostAddrIPv4(self.p.addrs.ipv4)
-        return None
-
-    def ipv6(self):
-        if self.p.addrs.ipv6:
-            return HostAddrIPv6(self.p.addrs.ipv6)
-        return None
+    def first_hop(self):
+        return HostInfo(self.p.hostInfo)
 
     def short_desc(self):
         desc = ["%s:" % self.NAME]
         desc.append("  %s" % self.path())
-        fh_str = ["  First Hop:"]
-        if self.ipv4():
-            fh_str.append("IPv4: %s" % self.ipv4())
-        if self.ipv6():
-            fh_str.append("IPv6: %s" % self.ipv6())
-        fh_str.append("Port: %d" % self.p.port)
-        desc.append(" ".join(fh_str))
+        desc.append("  First Hop: %s" % self.first_hop().short_desc())
         return "\n".join(desc)
+
+    def __str__(self):
+        return self.short_desc()

--- a/lib/sciond_api/service_req.py
+++ b/lib/sciond_api/service_req.py
@@ -28,7 +28,7 @@ from lib.types import SCIONDMsgType as SMT
 
 class SCIONDServiceInfoRequest(SCIONDMsgBase):
     NAME = "ServiceInfoRequest"
-    MSG_TYPE = SMT.Service_REQUEST
+    MSG_TYPE = SMT.SERVICE_REQUEST
     P_CLS = P.ServiceInfoRequest
 
     @classmethod
@@ -60,7 +60,7 @@ class SCIONDServiceInfoRequest(SCIONDMsgBase):
 
 class SCIONDServiceInfoReply(SCIONDMsgBase):
     NAME = "ServiceInfoReply"
-    MSG_TYPE = SMT.Service_REPLY
+    MSG_TYPE = SMT.SERVICE_REPLY
     P_CLS = P.ServiceInfoReply
 
     @classmethod
@@ -105,4 +105,4 @@ class SCIONDServiceInfoReplyEntry(Cerealizable):
     def short_desc(self):
         return "Type: %d Host Infos: %s" % (
             self.p.serviceType, ", ".join([info.short_desc() for info in
-                                           self.iter_host_infos()])
+                                           self.iter_host_infos()]))

--- a/lib/sciond_api/service_req.py
+++ b/lib/sciond_api/service_req.py
@@ -37,7 +37,7 @@ class SCIONDServiceInfoRequest(SCIONDMsgBase):
         Creates an SCIONDServiceInfoRequest.
 
         :param service_types: List of service types. An empty list means all
-            services.
+            service types.
         """
         p = cls.P_CLS.new_message()
         if service_types:

--- a/lib/sciond_api/service_req.py
+++ b/lib/sciond_api/service_req.py
@@ -1,0 +1,108 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`service_req` --- SCIOND Service requests and replies
+==========================================================
+"""
+# External
+import capnp  # noqa
+
+# SCION
+import proto.sciond_capnp as P
+from lib.packet.packet_base import Cerealizable
+from lib.sciond_api.base import SCIONDMsgBase
+from lib.sciond_api.host_info import HostInfo
+from lib.types import SCIONDMsgType as SMT
+
+
+class SCIONDServiceInfoRequest(SCIONDMsgBase):
+    NAME = "ServiceInfoRequest"
+    MSG_TYPE = SMT.Service_REQUEST
+    P_CLS = P.ServiceInfoRequest
+
+    @classmethod
+    def from_values(cls, service_types=None):
+        """
+        Creates an SCIONDServiceInfoRequest.
+
+        :param service_types: List of service types. An empty list means all
+            services.
+        """
+        p = cls.P_CLS.new_message()
+        if service_types:
+            service_entries = p.init("serviceTypes", len(service_types))
+            for i, type_ in enumerate(service_types):
+                service_entries[i] = type_
+        return cls(p)
+
+    def all_services(self):
+        return not self.p.serviceTypes
+
+    def iter_service_types(self):
+        for type_ in self.p.serviceType:
+            yield type_
+
+    def short_desc(self):
+        type_str = "ALL" if self.all_services() else str(self.p.serviceTypes)
+        return "Service types: %s" % type_str
+
+
+class SCIONDServiceInfoReply(SCIONDMsgBase):
+    NAME = "ServiceInfoReply"
+    MSG_TYPE = SMT.Service_REPLY
+    P_CLS = P.ServiceInfoReply
+
+    @classmethod
+    def from_values(cls, entries):
+        p = cls.P_CLS.new_message()
+        entry_list = p.init("entries", len(entries))
+        for i, entry in enumerate(entries):
+            entry_list[i] = entry.p
+        return cls(p)
+
+    def entry(self, idx):
+        return SCIONDServiceInfoReplyEntry(self.p.entries[idx])
+
+    def iter_entries(self):
+        for entry in self.p.entries:
+            yield SCIONDServiceInfoReplyEntry(entry)
+
+    def short_desc(self):
+        return "\n".join([entry.short_desc() for entry in self.iter_entries()])
+
+
+class SCIONDServiceInfoReplyEntry(Cerealizable):
+    NAME = "ServiceInfoReplyEntry"
+    P_CLS = P.ServiceInfoReplyEntry
+
+    @classmethod
+    def from_values(cls, service_type, host_infos):
+        p = cls.P_CLS.new_message(serviceType=service_type)
+        if host_infos:
+            entries = p.init("hostInfos", len(host_infos))
+            for i, info in enumerate(host_infos):
+                entries[i] = info.p
+        return cls(p)
+
+    def host_info(self, idx):
+        return HostInfo(self.p.hostInfos[idx])
+
+    def iter_host_infos(self):
+        for info in self.p.hostInfos:
+            return HostInfo(info)
+
+    def short_desc(self):
+        return "Type: %d Host Infos: %s" % (
+            self.p.serviceType, ", ".join([info.short_desc() for info in
+                                           self.iter_host_infos()])

--- a/lib/sciond_api/service_req.py
+++ b/lib/sciond_api/service_req.py
@@ -95,6 +95,9 @@ class SCIONDServiceInfoReplyEntry(Cerealizable):
                 entries[i] = info.p
         return cls(p)
 
+    def service_type(self):
+        return str(self.p.serviceType)
+
     def host_info(self, idx):
         return HostInfo(self.p.hostInfos[idx])
 

--- a/lib/types.py
+++ b/lib/types.py
@@ -29,6 +29,12 @@ class TypeBase(object):  # pragma: no cover
             return "UNKNOWN (%s)" % type_
         raise IndexError
 
+    @classmethod
+    def all(cls):
+        return [getattr(cls, attr) for attr in dir(cls) if
+                not attr.startswith("__") and
+                not callable(getattr(cls, attr))]
+
 
 ############################
 # Basic types

--- a/lib/types.py
+++ b/lib/types.py
@@ -51,7 +51,6 @@ class ServiceType(TypeBase):
     BS = "bs"
     PS = "ps"
     CS = "cs"
-    DNS = "ds"
     BR = "br"
     SIBRA = "sb"
 

--- a/lib/types.py
+++ b/lib/types.py
@@ -41,6 +41,15 @@ class AddrType(TypeBase):
     UNIX = 4  # For dispatcher socket
 
 
+class ServiceType(TypeBase):
+    BS = "bs"
+    PS = "ps"
+    CS = "cs"
+    DNS = "ds"
+    BR = "br"
+    SIBRA = "sb"
+
+
 class ExtensionClass(TypeBase):
     """
     Constants for two types of extensions. These values are shared with L4
@@ -159,3 +168,7 @@ class SCIONDMsgType(TypeBase):
     AS_REQUEST = "asInfoReq"
     AS_REPLY = "asInfoReply"
     REVOCATION = "revNotification"
+    BR_REQUEST = "brInfoRequest"
+    BR_REPLY = "brInfoReply"
+    SERVICE_REQUEST = "serviceInfoRequest"
+    SERVICE_REPLY = "serviceInfoReply"

--- a/proto/sciond.capnp
+++ b/proto/sciond.capnp
@@ -109,6 +109,6 @@ struct ServiceInfoReply {
 }
 
 struct ServiceInfoReplyEntry {
-    serviceID @0 :ServiceInfoRequest.ServiceType;  # The service ID of the service.
-    hostInfo @1 :HostInfo;  # The host info of the service.
+    serviceType @0 :ServiceInfoRequest.ServiceType;  # The service ID of the service.
+    hostInfos @1 :List(HostInfo);  # The host infos of the service.
 }

--- a/proto/sciond.capnp
+++ b/proto/sciond.capnp
@@ -13,6 +13,10 @@ struct SCIONDMsg {
         asInfoReq @3 :ASInfoReq;
         asInfoReply @4 :ASInfoReply;
         revNotification @5 :RevNotification;
+        brInfoRequest @6 :BRInfoRequest;
+        brInfoReply @7 :BRInfoReply;
+        serviceInfoRequest @8 :ServiceInfoRequest;
+        serviceInfoReply @9 :ServiceInfoReply;
     }
 }
 
@@ -35,10 +39,14 @@ struct PathReply {
 
 struct PathReplyEntry {
     path @0 :FwdPathMeta;  # End2end path
-    port @1 :UInt16;  # First hop port
-    addrs :group {  # First hop address
-        ipv4 @2 :Data;
-        ipv6 @3 :Data;
+    hostInfo @1 :HostInfo;  # First hop host info.
+}
+
+struct HostInfo {
+    port @0 :UInt16;  # Reachable port of the host.
+    addrs :group {  # Addresses of the host.
+        ipv4 @1 :Data;
+        ipv6 @2 :Data;
     }
 }
 
@@ -68,4 +76,39 @@ struct ASInfoReplyEntry {
 
 struct RevNotification {
     revInfo @0 :RevInfo.RevInfo;
+}
+
+struct BRInfoRequest {
+    ifIDs @0 :List(UInt64);  # The if IDs for which a client requests the host infos. Empty list means all BRs.
+}
+
+struct BRInfoReply {
+    entries @0 :List(BRInfoReplyEntry);
+}
+
+struct BRInfoReplyEntry {
+    ifID @0 :UInt64;  # The if ID of the BR.
+    hostInfo @1 :HostInfo;  # The host info of the BR.
+}
+
+struct ServiceInfoRequest {
+    serviceTypes @0 :List(ServiceType);  # The service types for which a client requests the host infos. Empty list means all services.
+
+    enum ServiceType {
+        bs @0;  # Beacon service
+        ps @1;  # Path service
+        cs @2;  # Certificate service
+        ds @3;  # DNS service
+        br @4;  # Router service
+        sb @5;  # SIBRA service
+    }
+}
+
+struct ServiceInfoReply {
+    entries @0 :List(ServiceInfoReplyEntry);
+}
+
+struct ServiceInfoReplyEntry {
+    serviceID @0 :ServiceInfoRequest.ServiceType;  # The service ID of the service.
+    hostInfo @1 :HostInfo;  # The host info of the service.
 }

--- a/proto/sciond.capnp
+++ b/proto/sciond.capnp
@@ -79,7 +79,7 @@ struct RevNotification {
 }
 
 struct BRInfoRequest {
-    ifIDs @0 :List(UInt64);  # The if IDs for which a client requests the host infos. Empty list means all BRs.
+    ifIDs @0 :List(UInt64);  # The if IDs for which a client requests the host infos. Empty list means all interfaces of all BRs.
 }
 
 struct BRInfoReply {
@@ -92,15 +92,14 @@ struct BRInfoReplyEntry {
 }
 
 struct ServiceInfoRequest {
-    serviceTypes @0 :List(ServiceType);  # The service types for which a client requests the host infos. Empty list means all services.
+    serviceTypes @0 :List(ServiceType);  # The service types for which a client requests the host infos. Empty list means all service types.
 
     enum ServiceType {
         bs @0;  # Beacon service
         ps @1;  # Path service
         cs @2;  # Certificate service
-        ds @3;  # DNS service
-        br @4;  # Router service
-        sb @5;  # SIBRA service
+        br @3;  # Router service
+        sb @4;  # SIBRA service
     }
 }
 

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -142,10 +142,11 @@ class TestClientBase(TestBase):
         response = self._try_sciond_api(flush)
         path_entry = response.path_entry(0)
         self.path_meta = path_entry.path()
-        fh_addr = path_entry.ipv4()
+        fh_info = path_entry.first_hop()
+        fh_addr = fh_info.ipv4()
         if not fh_addr:
             fh_addr = self.dst.host
-        port = path_entry.p.port or SCION_UDP_EH_DATA_PORT
+        port = fh_info.p.port or SCION_UDP_EH_DATA_PORT
         self.first_hop = (fh_addr, port)
 
     def _try_sciond_api(self, flush=False):


### PR DESCRIPTION
This PR implements all the remaining SCIOND API messages (`BRInfo` and `ServiceInfo`) (issue #986). Note, they are currently not tested/used anywhere. This will be done in a follow up PR where also an application layer wrapper around the low level SCIOND API will be provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1008)
<!-- Reviewable:end -->
