### PR TITLE
Allow cache-only cert/trc requests.

### DIFF
--- a/infrastructure/cert_server/main.py
+++ b/infrastructure/cert_server/main.py
@@ -174,6 +174,9 @@ class CertServer(SCIONElement):
                 "Dropping CC request from %s for %sv%s: "
                 "CC not found && requester is not local)",
                 meta.get_addr(), *key)
+        if req.p.cacheOnly:
+            self._reply_cc(key, meta)
+            return
         self.cc_requests.put((key, meta))
 
     def process_cert_chain_reply(self, rep, meta, from_zk=False):
@@ -227,6 +230,9 @@ class CertServer(SCIONElement):
                 "Dropping TRC request from %s for %sv%s: "
                 "TRC not found && requester is not local)",
                 meta.get_addr(), *key)
+        if req.p.cacheOnly:
+            self._reply_trc(key, meta)
+            return
         self.trc_requests.put((key, (meta, req.isd_as()[1]),))
 
     def process_trc_reply(self, trc_rep, meta, from_zk=False):

--- a/lib/packet/cert_mgmt.py
+++ b/lib/packet/cert_mgmt.py
@@ -42,8 +42,9 @@ class CertMgmtRequest(CertMgmtBase):  # pragma: no cover
         return ISD_AS(self.p.isdas)
 
     @classmethod
-    def from_values(cls, isd_as, version):
-        return cls(cls.P_CLS.new_message(isdas=int(isd_as), version=version))
+    def from_values(cls, isd_as, version, cache_only=False):
+        return cls(cls.P_CLS.new_message(isdas=int(isd_as), version=version,
+                                         cacheOnly=cache_only))
 
 
 class CertChainRequest(CertMgmtRequest):
@@ -52,7 +53,8 @@ class CertChainRequest(CertMgmtRequest):
     P_CLS = P.CertChainReq
 
     def short_desc(self):
-        return "%sv%s" % (self.isd_as(), self.p.version)
+        return "%sv%s (Cache only? %s)" % (self.isd_as(), self.p.version,
+                                           self.p.cacheOnly)
 
 
 class CertChainReply(CertMgmtBase):  # pragma: no cover
@@ -82,7 +84,8 @@ class TRCRequest(CertMgmtRequest):
     P_CLS = P.TRCReq
 
     def short_desc(self):
-        return "%sv%s" % (self.isd_as()[0], self.p.version)
+        return "%sv%s (Cache only? %s)" % (self.isd_as()[0], self.p.version,
+                                           self.p.cacheOnly)
 
 
 class TRCReply(CertMgmtBase):  # pragma: no cover

--- a/proto/cert_mgmt.capnp
+++ b/proto/cert_mgmt.capnp
@@ -6,6 +6,7 @@ $Go.import("github.com/netsec-ethz/scion/go/proto");
 struct CertChainReq {
     isdas @0 :UInt32;
     version @1 :UInt32;
+    cacheOnly @2 :Bool;
 }
 
 struct CertChainRep {
@@ -15,6 +16,7 @@ struct CertChainRep {
 struct TRCReq {
     isdas @0 :UInt32;
     version @1 :UInt32;
+    cacheOnly @2 :Bool;
 }
 
 struct TRCRep {


### PR DESCRIPTION
This avoids any circular dependancies between a path server wanting to
verify an up-path and the cert server trying to get a path if it doesn't
have the cert cached already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1016)
<!-- Reviewable:end -->
