### PR TITLE
Reorder the fields in the common header.

### DIFF
--- a/flake8.ini
+++ b/flake8.ini
@@ -1,3 +1,3 @@
 [flake8]
 exclude = .git,docker,external,sphinx-doc,sub/web,topology/mininet
-max-line-length = 80
+max-line-length = 100

--- a/go/border/rpkt/addr.go
+++ b/go/border/rpkt/addr.go
@@ -90,7 +90,7 @@ func (rp *RtrPkt) DstHost() (addr.HostAddr, *common.Error) {
 // retrieval hooks, falling back to parsing the address header directly
 // otherwise.
 func (rp *RtrPkt) hookHost(
-	hooks []hookHost, idx int, htype uint8) (addr.HostAddr, *common.Error) {
+	hooks []hookHost, idx int, htype addr.HostAddrType) (addr.HostAddr, *common.Error) {
 	for _, f := range hooks {
 		ret, host, err := f()
 		switch {

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -30,21 +30,21 @@ import (
 // RtrPktFromScnPkt creates an RtrPkt from an spkt.ScnPkt.
 func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo Dir) (*RtrPkt, *common.Error) {
 	rp := NewRtrPkt()
-	hdrLen := sp.HdrLen()
 	totalLen := sp.TotalLen()
+	hdrLen := sp.HdrLen()
 	rp.TimeIn = monotime.Now()
 	rp.Id = logext.RandId(4)
 	rp.Logger = log.New("rpkt", rp.Id)
 	rp.DirFrom = DirSelf
 	rp.DirTo = dirTo
 	// Fill in common header.
-	rp.CmnHdr.SrcType = sp.SrcHost.Type()
 	rp.CmnHdr.DstType = sp.DstHost.Type()
-	rp.CmnHdr.HdrLen = uint8(hdrLen)
+	rp.CmnHdr.SrcType = sp.SrcHost.Type()
 	rp.CmnHdr.TotalLen = uint16(totalLen) // Updated later as necessary.
-	rp.CmnHdr.NextHdr = common.L4None     // Updated later as necessary.
-	rp.CmnHdr.CurrInfoF = uint8(hdrLen)   // Updated later as necessary.
-	rp.CmnHdr.CurrHopF = uint8(hdrLen)    // Updated later as necessary.
+	rp.CmnHdr.HdrLen = uint8(hdrLen)
+	rp.CmnHdr.CurrInfoF = uint8(hdrLen) // Updated later as necessary.
+	rp.CmnHdr.CurrHopF = uint8(hdrLen)  // Updated later as necessary.
+	rp.CmnHdr.NextHdr = common.L4None   // Updated later as necessary.
 	// Fill in address header and indexes.
 	rp.idxs.srcIA = spkt.CmnHdrLen
 	rp.srcIA = sp.SrcIA

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -169,8 +169,8 @@ func (d Dir) String() string {
 // addrIFPair contains the overlay source/destination addresses, as well as the
 // list of associated interface IDs.
 type addrIFPair struct {
-	Src   *net.UDPAddr
 	Dst   *net.UDPAddr
+	Src   *net.UDPAddr
 	IfIDs []spath.IntfID
 }
 

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -22,12 +22,28 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
+type HostAddrType uint8
+
 const (
-	HostTypeNone = iota
+	HostTypeNone HostAddrType = iota
 	HostTypeIPv4
 	HostTypeIPv6
 	HostTypeSVC
 )
+
+func (t HostAddrType) String() string {
+	switch t {
+	case HostTypeNone:
+		return "None"
+	case HostTypeIPv4:
+		return "IPv4"
+	case HostTypeIPv6:
+		return "IPv6"
+	case HostTypeSVC:
+		return "SVC"
+	}
+	return fmt.Sprintf("UNKNOWN (%d)", t)
+}
 
 const (
 	HostLenNone = 0
@@ -52,7 +68,7 @@ var (
 
 type HostAddr interface {
 	Size() int
-	Type() uint8
+	Type() HostAddrType
 	Pack() common.RawBytes
 	IP() net.IP
 	Copy() HostAddr
@@ -69,7 +85,7 @@ func (h HostNone) Size() int {
 	return HostLenNone
 }
 
-func (h HostNone) Type() uint8 {
+func (h HostNone) Type() HostAddrType {
 	return HostTypeNone
 }
 
@@ -99,7 +115,7 @@ func (h HostIPv4) Size() int {
 	return HostLenIPv4
 }
 
-func (h HostIPv4) Type() uint8 {
+func (h HostIPv4) Type() HostAddrType {
 	return HostTypeIPv4
 }
 
@@ -129,7 +145,7 @@ func (h HostIPv6) Size() int {
 	return HostLenIPv6
 }
 
-func (h HostIPv6) Type() uint8 {
+func (h HostIPv6) Type() HostAddrType {
 	return HostTypeIPv6
 }
 
@@ -159,7 +175,7 @@ func (h HostSVC) Size() int {
 	return HostLenSVC
 }
 
-func (h HostSVC) Type() uint8 {
+func (h HostSVC) Type() HostAddrType {
 	return HostTypeSVC
 }
 
@@ -210,7 +226,7 @@ func (h HostSVC) String() string {
 	return fmt.Sprintf("%v %c (0x%04x)", name, cast, uint16(h))
 }
 
-func HostFromRaw(b common.RawBytes, htype uint8) (HostAddr, *common.Error) {
+func HostFromRaw(b common.RawBytes, htype HostAddrType) (HostAddr, *common.Error) {
 	switch htype {
 	case HostTypeNone:
 		return HostNone{}, nil
@@ -234,7 +250,7 @@ func HostFromIP(ip net.IP) HostAddr {
 	return &h
 }
 
-func HostLen(htype uint8) (uint8, *common.Error) {
+func HostLen(htype HostAddrType) (uint8, *common.Error) {
 	var length uint8
 	switch htype {
 	case HostTypeNone:
@@ -255,7 +271,7 @@ func HostEq(a, b HostAddr) bool {
 	return a.Type() == b.Type() && a.String() == b.String()
 }
 
-func HostTypeCheck(t uint8) bool {
+func HostTypeCheck(t HostAddrType) bool {
 	switch t {
 	case HostTypeIPv6, HostTypeIPv4, HostTypeSVC:
 		return true

--- a/go/lib/spkt/cmnhdr_test.go
+++ b/go/lib/spkt/cmnhdr_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spkt
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/netsec-ethz/scion/go/lib/scmp"
+)
+
+var cmnhInput = [CmnHdrLen]byte{0x01, 0xf8, 0x0c, 0xb6, 0x1f, 0xab, 0xcd, 0xef}
+
+func Test_CmnHdr_Parse(t *testing.T) {
+	Convey("CmnHdr.Parse should parse bytes correctly", t, func() {
+		cmn := &CmnHdr{}
+		So(cmn.Parse(cmnhInput[:]), ShouldEqual, nil)
+		So(cmn.Ver, ShouldEqual, 0x0)
+		So(cmn.DstType, ShouldEqual, 0x07)
+		So(cmn.SrcType, ShouldEqual, 0x38)
+		So(cmn.TotalLen, ShouldEqual, 0x0cb6)
+		So(cmn.HdrLen, ShouldEqual, 0x1f)
+		So(cmn.CurrInfoF, ShouldEqual, 0xab)
+		So(cmn.CurrHopF, ShouldEqual, 0xcd)
+		So(cmn.NextHdr, ShouldEqual, 0xef)
+	})
+	Convey("CmnHdr.Parse should report unsupported version", t, func() {
+		cmn := &CmnHdr{}
+		input := append([]byte(nil), cmnhInput[:]...)
+		input[0] |= 0x30
+		err := cmn.Parse(input)
+		So(err, ShouldNotBeNil)
+		data, ok := err.Data.(*scmp.ErrData)
+		So(ok, ShouldBeTrue)
+		So(data.CT, ShouldResemble, scmp.ClassType{Class: scmp.C_CmnHdr, Type: scmp.T_C_BadVersion})
+		So(cmn.Ver, ShouldEqual, 0x3)
+	})
+}
+
+func Test_CmnHdr_Write(t *testing.T) {
+	Convey("CmnHdr.Write should write bytes correctly", t, func() {
+		cmn := &CmnHdr{
+			Ver: 0x0, DstType: 0x07, SrcType: 0x38, TotalLen: 0x0cb6,
+			HdrLen: 0x1f, CurrInfoF: 0xab, CurrHopF: 0xcd, NextHdr: 0xef,
+		}
+		out := make([]byte, CmnHdrLen)
+		cmn.Write(out)
+		So(out, ShouldResemble, cmnhInput[:])
+	})
+}
+
+func Test_CmnHdr_UpdatePathOffsets(t *testing.T) {
+	Convey("CmnHdr.UpdatePathOffsets should update values correctly", t, func() {
+		cmn := &CmnHdr{}
+		cmn.Parse(cmnhInput[:])
+		out := make([]byte, CmnHdrLen)
+		cmn.UpdatePathOffsets(out, 0x12, 0x23)
+		So(out, ShouldResemble, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x23, 0x00})
+		So(cmn.CurrInfoF, ShouldEqual, 0x12)
+		So(cmn.CurrHopF, ShouldEqual, 0x23)
+	})
+}

--- a/lib/libscion/packet.c
+++ b/lib/libscion/packet.c
@@ -240,10 +240,10 @@ void pack_cmn_hdr(uint8_t *buf, int src_type, int dst_type, int next_hdr,
                   int path_len, int exts_len, int l4_len)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    uint16_t vsd = 0;
-    vsd |= src_type << 6;
-    vsd |= dst_type;
-    sch->ver_src_dst = htons(vsd);
+    uint16_t vds = 0;
+    vds |= dst_type << 6;
+    vds |= src_type;
+    sch->ver_dst_src = htons(vds);
     sch->next_header = next_hdr;
 
     int addr_len = padded_addr_len(buf);

--- a/lib/libscion/packet.h
+++ b/lib/libscion/packet.h
@@ -7,26 +7,26 @@
 #pragma pack(1)
 
 typedef struct {
-    /** Packet Type of the packet (version, srcType, dstType) */
-    uint16_t ver_src_dst;
+    /** Packet Type of the packet (version, dstType, srcType) */
+    uint16_t ver_dst_src;
     /** Total Length of the packet */
     uint16_t total_len;
+    /** Header length that includes the path */
+    uint8_t header_len;
     /** Offset of current Info opaque field*/
     uint8_t current_iof;
     /** Offset of current Hop opaque field*/
     uint8_t current_hof;
     /** next header type, shared with IP protocol number*/
     uint8_t next_header;
-    /** Header length that includes the path */
-    uint8_t header_len;
 } SCIONCommonHeader;
 typedef SCIONCommonHeader sch_t;
 
 #pragma pack(pop)
 
-#define PROTO_VER(sch) ((ntohs((sch)->ver_src_dst) >> 12))
-#define SRC_TYPE(sch) ((ntohs((sch)->ver_src_dst) & 0xfc0) >> 6)
-#define DST_TYPE(sch) (ntohs((sch)->ver_src_dst) & 0x3f)
+#define PROTO_VER(sch) ((ntohs((sch)->ver_dst_src) >> 12))
+#define DST_TYPE(sch) ((ntohs((sch)->ver_dst_src) >> 6) & 0x3f)
+#define SRC_TYPE(sch) (ntohs((sch)->ver_dst_src) & 0x3f)
 
 typedef struct {
     uint8_t len;

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -114,7 +114,7 @@ class SCIONCommonHdr(Serializable):
         self._hof_idx = (hof_off - first_of_offset) // OpaqueField.LEN
 
     @classmethod
-    def from_values(cls, src_type, dst_type, next_hdr):
+    def from_values(cls, dst_type, src_type, next_hdr):
         """
         Returns a SCIONCommonHdr object with the values specified.
 
@@ -674,7 +674,7 @@ class SCIONL4Packet(SCIONExtPacket):
 
 
 def build_base_hdrs(src, dst, l4=L4Proto.UDP):
-    cmn_hdr = SCIONCommonHdr.from_values(src.host.TYPE, dst.host.TYPE, l4)
+    cmn_hdr = SCIONCommonHdr.from_values(dst.host.TYPE, src.host.TYPE, l4)
     addr_hdr = SCIONAddrHdr.from_values(src, dst)
     return cmn_hdr, addr_hdr
 

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -78,14 +78,14 @@ class SCIONCommonHdr(Serializable):
 
     def __init__(self, raw=None):  # pragma: no cover
         self.version = 0  # Version of SCION packet.
-        self.src_addr_type = None  # Type of the src address.
-        self.dst_addr_type = None  # Length of the dst address.
+        self.dst_addr_type = None
+        self.src_addr_type = None
         self.addrs_len = None  # Length of the address block
         self.total_len = None  # Total length of the packet.
+        self.hdr_len = None  # Header length including the path.
         self._iof_idx = None  # Index of the current Info Opaque Field
         self._hof_idx = None  # Index of the current Hop Opaque Field
         self.next_hdr = None  # Type of the next hdr field (IP protocol numbers)
-        self.hdr_len = None  # Header length including the path.
         super().__init__(raw)
 
     def _parse(self, raw):
@@ -93,15 +93,15 @@ class SCIONCommonHdr(Serializable):
         Parses the raw data and populates the fields accordingly.
         """
         data = Raw(raw, self.NAME, self.LEN)
-        (types, self.total_len, curr_iof_p, curr_hof_p,
-         self.next_hdr, self.hdr_len) = struct.unpack("!HHBBBB", data.pop())
+        (types, self.total_len, self.hdr_len, iof_off, hof_off,
+         self.next_hdr) = struct.unpack("!HHBBBB", data.pop())
         self.version = types >> 12
         if self.version != SCION_PROTO_VERSION:
             raise SCMPBadVersion("Unsupported SCION version: %s" % self.version)
-        self.src_addr_type = (types & 0x0fc0) >> 6
-        self.dst_addr_type = types & 0x003f
+        self.dst_addr_type = (types >> 6) & 0x3f
+        self.src_addr_type = types & 0x3f
         self.addrs_len, _ = SCIONAddrHdr.calc_lens(
-            self.src_addr_type, self.dst_addr_type)
+            self.dst_addr_type, self.src_addr_type)
         if self.hdr_len < self.LEN + self.addrs_len:
             # Can't send an SCMP error, as there isn't enough information to
             # parse the path and the l4 header.
@@ -110,8 +110,8 @@ class SCIONCommonHdr(Serializable):
                 (self.hdr_len, self.LEN, self.addrs_len))
         first_of_offset = self.LEN + self.addrs_len
         # FIXME(kormat): NB this assumes that all OFs have the same length.
-        self._iof_idx = (curr_iof_p - first_of_offset) // OpaqueField.LEN
-        self._hof_idx = (curr_hof_p - first_of_offset) // OpaqueField.LEN
+        self._iof_idx = (iof_off - first_of_offset) // OpaqueField.LEN
+        self._hof_idx = (hof_off - first_of_offset) // OpaqueField.LEN
 
     @classmethod
     def from_values(cls, src_type, dst_type, next_hdr):
@@ -123,9 +123,9 @@ class SCIONCommonHdr(Serializable):
         :param int next_hdr: Next header type.
         """
         inst = cls()
-        inst.src_addr_type = src_type
         inst.dst_addr_type = dst_type
-        inst.addrs_len, _ = SCIONAddrHdr.calc_lens(src_type, dst_type)
+        inst.src_addr_type = src_type
+        inst.addrs_len, _ = SCIONAddrHdr.calc_lens(dst_type, src_type)
         inst.next_hdr = next_hdr
         inst.total_len = inst.hdr_len = cls.LEN + inst.addrs_len
         inst._iof_idx = inst._hof_idx = 0
@@ -133,16 +133,15 @@ class SCIONCommonHdr(Serializable):
 
     def pack(self):
         packed = []
-        types = ((self.version << 12) | (self.src_addr_type << 6) |
-                 self.dst_addr_type)
-        packed.append(struct.pack("!HH", types, self.total_len))
+        types = ((self.version << 12) | (self.dst_addr_type << 6) |
+                 self.src_addr_type)
+        packed.append(struct.pack("!HHB", types, self.total_len, self.hdr_len))
         curr_iof_p = curr_hof_p = self.LEN + self.addrs_len
         if self._iof_idx:
             curr_iof_p += self._iof_idx * OpaqueField.LEN
         if self._hof_idx:
             curr_hof_p += self._hof_idx * OpaqueField.LEN
-        packed.append(struct.pack("!BB", curr_iof_p, curr_hof_p))
-        packed.append(struct.pack("!BB", self.next_hdr, self.hdr_len))
+        packed.append(struct.pack("!BBB", curr_iof_p, curr_hof_p, self.next_hdr))
         raw = b"".join(packed)
         assert len(raw) == self.LEN
         return raw
@@ -249,17 +248,17 @@ class SCIONAddrHdr(Serializable):
             self.src.host.TYPE, self.dst.host.TYPE)
 
     @classmethod
-    def calc_lens(cls, src_type, dst_type):
+    def calc_lens(cls, dst_type, src_type):
         try:
-            data_len = SCIONAddr.calc_len(src_type)
-        except HostAddrInvalidType:
-            raise SCMPBadSrcType(
-                "Unsupported src address type: %s" % src_type) from None
-        try:
-            data_len += SCIONAddr.calc_len(dst_type)
+            data_len = SCIONAddr.calc_len(dst_type)
         except HostAddrInvalidType:
             raise SCMPBadDstType(
                 "Unsupported dst address type: %s" % dst_type) from None
+        try:
+            data_len += SCIONAddr.calc_len(src_type)
+        except HostAddrInvalidType:
+            raise SCMPBadSrcType(
+                "Unsupported src address type: %s" % src_type) from None
         pad_len = calc_padding(data_len, cls.BLK_SIZE)
         total_len = data_len + pad_len
         assert total_len % cls.BLK_SIZE == 0

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -137,6 +137,7 @@ class SCIONCommonHdr(Serializable):
                  self.src_addr_type)
         packed.append(struct.pack("!HHB", types, self.total_len, self.hdr_len))
         curr_iof_p = curr_hof_p = self.LEN + self.addrs_len
+        # FIXME(kormat): NB this assumes that all OFs have the same length.
         if self._iof_idx:
             curr_iof_p += self._iof_idx * OpaqueField.LEN
         if self._hof_idx:

--- a/test/integration/scmp_error_test.py
+++ b/test/integration/scmp_error_test.py
@@ -117,8 +117,8 @@ class ErrorGenBadVersion(ErrorGenBase):
         self._send_raw_pkt(raw, next_hop, port)
 
 
-class ErrorGenBadSrcType(ErrorGenBase):
-    DESC = "bad src type"
+class ErrorGenBadDstType(ErrorGenBase):
+    DESC = "bad dst type"
 
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
@@ -127,8 +127,8 @@ class ErrorGenBadSrcType(ErrorGenBase):
         self._send_raw_pkt(raw, next_hop, port)
 
 
-class ErrorGenBadDstType(ErrorGenBase):
-    DESC = "bad dst type"
+class ErrorGenBadSrcType(ErrorGenBase):
+    DESC = "bad src type"
 
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
@@ -163,7 +163,7 @@ class ErrorGenBadHdrLenShort(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[7] = 5
+        barr[4] = 5
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -173,7 +173,7 @@ class ErrorGenBadHdrLenLong(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[7] = 255
+        barr[4] = 255
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -185,7 +185,7 @@ class ErrorGenBadIOFOffsetShort(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[4] -= 8
+        barr[5] -= 8
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -197,7 +197,7 @@ class ErrorGenBadIOFOffsetLong(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[4] = 255
+        barr[5] = 255
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -209,7 +209,7 @@ class ErrorGenBadHOFOffsetShort(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[5] = 1
+        barr[6] = 1
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -221,7 +221,7 @@ class ErrorGenBadHOFOffsetLong(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[5] = 255
+        barr[6] = 255
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -338,8 +338,8 @@ GEN_LIST = (
     # ErrorGenOversizePkt,
     ErrorGenBadHost,
     ErrorGenBadVersion,
-    ErrorGenBadSrcType,
     ErrorGenBadDstType,
+    ErrorGenBadSrcType,
     ErrorGenBadPktLenShort,
     ErrorGenBadPktLenLong,
     ErrorGenBadHdrLenShort,


### PR DESCRIPTION
For:
https://github.com/netsec-ethz/scion/issues/980:
- "Move HdrLen just after TotalLen"
https://github.com/netsec-ethz/scion/issues/982:
- "Change address header order and padding"

N.B.: this change only affects the common header. The address header
will be changed in an upcoming PR instead.

Also:
- Add dedicated Go HostAddrType type.
- Unit tests for go/lib/spkt/cmnhdr.go
- Increase max python line length to 100 to match Go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1019)
<!-- Reviewable:end -->
