### PR TITLE
Adjust socket timeout in lib.app.sciond

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -77,7 +77,7 @@ class SCIONDaemon(SCIONElement):
     The SCION Daemon used for retrieving and combining paths.
     """
     # Max time for a path lookup to succeed/fail.
-    TIMEOUT = 2
+    PATH_REQ_TOUT = 2
     # Time a path segment is cached at a host (in seconds).
     SEGMENT_TTL = 300
 
@@ -95,7 +95,8 @@ class SCIONDaemon(SCIONElement):
         req_name = "SCIONDaemon Requests %s" % self.addr.isd_as
         self.requests = RequestHandler.start(
             req_name, self._check_segments, self._fetch_segments,
-            self._reply_segments, ttl=self.TIMEOUT, key_map=self._req_key_map,
+            self._reply_segments, ttl=self.PATH_REQ_TOUT,
+            key_map=self._req_key_map,
         )
         self._api_sock = None
         self.daemon_thread = None
@@ -371,7 +372,7 @@ class SCIONDaemon(SCIONElement):
             empty = SCIONPath()
             empty_meta = FwdPathMeta.from_values(empty, [], self.topology.mtu)
             return [empty_meta], SCIONDPathReplyError.OK
-        deadline = SCIONTime.get_time() + self.TIMEOUT
+        deadline = SCIONTime.get_time() + self.PATH_REQ_TOUT
         e = threading.Event()
         self.requests.put(((dst_ia, flags), e))
         if not self._wait_for_events([e], deadline):

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -77,10 +77,9 @@ class SCIONDaemon(SCIONElement):
     The SCION Daemon used for retrieving and combining paths.
     """
     # Max time for a path lookup to succeed/fail.
-    TIMEOUT = 5
+    TIMEOUT = 2
     # Time a path segment is cached at a host (in seconds).
     SEGMENT_TTL = 300
-    MAX_SEG_NO = 5  # TODO: replace by config variable.
 
     def __init__(self, conf_dir, addr, api_addr, run_local_api=False,
                  port=None):
@@ -89,12 +88,9 @@ class SCIONDaemon(SCIONElement):
         """
         super().__init__("sciond", conf_dir, host_addr=addr, port=port)
         # TODO replace by pathstore instance
-        self.up_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL,
-                                         max_res_no=self.MAX_SEG_NO)
-        self.down_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL,
-                                           max_res_no=self.MAX_SEG_NO)
-        self.core_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL,
-                                           max_res_no=self.MAX_SEG_NO)
+        self.up_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL)
+        self.down_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL)
+        self.core_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL)
         self.peer_revs = RevCache()
         req_name = "SCIONDaemon Requests %s" % self.addr.isd_as
         self.requests = RequestHandler.start(

--- a/lib/app/sciond.py
+++ b/lib/app/sciond.py
@@ -57,7 +57,7 @@ _IF_INFO_TTL = 60 * 60
 # amount of time.
 _SVC_INFO_TTL = 10
 # Time after which a request gets retired.
-_SCIOND_TOUT = 10
+_SCIOND_TOUT = 3
 
 
 class SCIONDLibError(SCIONBaseError):

--- a/lib/app/sciond.py
+++ b/lib/app/sciond.py
@@ -57,7 +57,7 @@ _IF_INFO_TTL = 60 * 60
 # amount of time.
 _SVC_INFO_TTL = 10
 # Time after which a request gets retired.
-_SCIOND_TOUT = 5
+_SCIOND_TOUT = 10
 
 
 class SCIONDLibError(SCIONBaseError):

--- a/lib/app/sciond.py
+++ b/lib/app/sciond.py
@@ -72,6 +72,10 @@ class SCIONDConnectionError(SCIONDLibError):
     """Connection to SCIOND failed."""
 
 
+class SCIONDRequestError(SCIONDLibError):
+    """Request could not be sent to SCIOND."""
+
+
 class SCIONDResponseError(SCIONDLibError):
     """Erroneous reponse from SCIOND."""
 
@@ -117,7 +121,8 @@ class SCIONDConnector:
         request = SCIONDPathRequest.from_values(
             req_id, dst_ia, src_ia, max_paths, flags.flush, flags.sibra)
         with closing(self._create_socket()) as socket:
-            socket.send(request.pack_full())
+            if not socket.send(request.pack_full()):
+                raise SCIONDRequestError
             response = self._get_response(socket, req_id, SMT.PATH_REPLY)
             if response.p.errorCode != SCIONDPathReplyError.OK:
                 raise SCIONDResponseError(
@@ -136,7 +141,8 @@ class SCIONDConnector:
             as_req = SCIONDASInfoRequest.from_values(
                 req_id, isd_as)
             with closing(self._create_socket()) as socket:
-                socket.send(as_req.pack_full())
+                if not socket.send(as_req.pack_full()):
+                    raise SCIONDRequestError
                 response = self._get_response(socket, req_id, SMT.AS_REPLY)
             self._as_infos[q_ia] = list(response.iter_entries())
             return self._as_infos[q_ia]
@@ -156,7 +162,8 @@ class SCIONDConnector:
             req_id = self._req_id.inc()
             br_req = SCIONDIFInfoRequest.from_values(req_id, if_list)
             with closing(self._create_socket()) as socket:
-                socket.send(br_req.pack_full())
+                if not socket.send(br_req.pack_full()):
+                    raise SCIONDRequestError
                 response = self._get_response(socket, req_id, SMT.IF_REPLY)
             for entry in response.iter_entries():
                 self._if_infos[entry.p.ifID] = entry
@@ -179,7 +186,8 @@ class SCIONDConnector:
             svc_req = SCIONDServiceInfoRequest.from_values(
                 req_id, service_types)
             with closing(self._create_socket()) as socket:
-                socket.send(svc_req.pack_full())
+                if not socket.send(svc_req.pack_full()):
+                    raise SCIONDRequestError
                 response = self._get_response(socket, req_id, SMT.SERVICE_REPLY)
             for entry in response.iter_entries():
                 self._svc_infos[entry.service_type()] = entry
@@ -215,7 +223,8 @@ class SCIONDConnector:
         rev_not = SCIONDRevNotification.from_values(
             self._req_id.inc(), rev_info)
         with closing(self._create_socket()) as socket:
-            socket.send(rev_not.pack_full())
+            if not socket.send(rev_not.pack_full()):
+                raise SCIONDRequestError
 
     def _create_socket(self):
         socket = ReliableSocket()
@@ -223,6 +232,7 @@ class SCIONDConnector:
         try:
             socket.connect(self._api_addr)
         except OSError:
+            socket.close()
             raise SCIONDConnectionError()
         return socket
 

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -183,9 +183,6 @@ class UDPSocket(Socket):
                 return self.sock.recvfrom(SCION_BUFLEN, flags)
             except InterruptedError:
                 pass
-            except OSError as e:
-                logging.error("error in recv: %s" % e)
-                return None, None
 
 
 class ReliableSocket(Socket):
@@ -284,11 +281,7 @@ class ReliableSocket(Socket):
         flags = 0
         if not block:
             flags = MSG_DONTWAIT
-        try:
-            buf = recv_all(self.sock, self.COOKIE_LEN + 5, flags)
-        except OSError as e:
-            logging.error("error in receive: %s", e)
-            return None, None
+        buf = recv_all(self.sock, self.COOKIE_LEN + 5, flags)
         if not buf:
             return None, None
         cookie, addr_type, packet_len = struct.unpack("=8sBI", buf)

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -183,6 +183,9 @@ class UDPSocket(Socket):
                 return self.sock.recvfrom(SCION_BUFLEN, flags)
             except InterruptedError:
                 pass
+            except OSError as e:
+                logging.error("error in recv: %s" % e)
+                return None, None
 
 
 class ReliableSocket(Socket):
@@ -281,7 +284,11 @@ class ReliableSocket(Socket):
         flags = 0
         if not block:
             flags = MSG_DONTWAIT
-        buf = recv_all(self.sock, self.COOKIE_LEN + 5, flags)
+        try:
+            buf = recv_all(self.sock, self.COOKIE_LEN + 5, flags)
+        except OSError as e:
+            logging.error("error in receive: %s", e)
+            return None, None
         if not buf:
             return None, None
         cookie, addr_type, packet_len = struct.unpack("=8sBI", buf)

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -227,7 +227,7 @@ class TestServerBase(TestBase):
     def run(self):
         while not self.finished.is_set():
             spkt = self._recv()
-            if spkt and not self._handle_request(spkt):
+            if spkt is not None and not self._handle_request(spkt):
                 self.success = False
                 self.finished.set()
         self._shutdown()


### PR DESCRIPTION
Adjust socket timeout in `lib.app.sciond` to 3 seconds and the path request timeout it `endhost.sciond` to 2s. Before, it was the case that the socket timeout in `lib.app.sciond` matched the path request timeout in `endhost.sciond`. It could happen that the app closed the socket, but the `SCIOND` try to send a response over the already closed socket.

Also raise an exception in case send fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1021)
<!-- Reviewable:end -->
