### PR TITLE
Update address header order

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -32,7 +32,7 @@ shutdown() {
 run() {
     log "${1:?}: starting"
     time ${2:?}
-    result=$?
+    local result=$?
     if [ $result -eq 0 ]; then
         log "$1: success"
     else

--- a/go/border/error.go
+++ b/go/border/error.go
@@ -47,7 +47,7 @@ func (r *Router) handlePktError(rp *rpkt.RtrPkt, perr *common.Error, desc string
 	switch sdata.CT.Class {
 	case scmp.C_CmnHdr:
 		switch sdata.CT.Type {
-		case scmp.T_C_BadVersion, scmp.T_C_BadSrcType, scmp.T_C_BadDstType:
+		case scmp.T_C_BadVersion, scmp.T_C_BadDstType, scmp.T_C_BadSrcType:
 			// For any of these cases, do nothing. A reply would only be
 			// possible in the case of a version/addr type being understood but
 			// deprecated, which hasn't happened yet.

--- a/go/border/hsr/hsr.go
+++ b/go/border/hsr/hsr.go
@@ -126,8 +126,8 @@ func NewHSR() *HSR {
 	h := HSR{}
 	// Allocate storage for each RouterPacket's src/dest fields.
 	for i := range h.InPkts {
-		h.InPkts[i].src = &C.saddr_storage{}
 		h.InPkts[i].dst = &C.saddr_storage{}
+		h.InPkts[i].src = &C.saddr_storage{}
 	}
 	return &h
 }
@@ -184,7 +184,7 @@ func SendPacket(dst *net.UDPAddr, portID int, buf common.RawBytes) *common.Error
 	cp.buflen = C.size_t(len(buf))
 	// Use pre-converted C source address from AddrMs.
 	cp.src = &AddrMs[portID].CAddr
-	// Convery destination address from Go to C.
+	// Convert destination address from Go to C.
 	cp.dst = &C.saddr_storage{}
 	udpAddrToSaddr(dst, cp.dst)
 	cp.port_id = C.uint8_t(portID)

--- a/go/border/ifid.go
+++ b/go/border/ifid.go
@@ -56,8 +56,8 @@ func (r *Router) GenIFIDPkt(ifid spath.IntfID) {
 	srcAddr := intf.IFAddr.PublicAddr()
 	// Create base packet
 	rp, err := rpkt.RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
-		DstIA: intf.RemoteIA, DstHost: addr.HostFromIP(intf.RemoteAddr.IP),
+		DstIA: intf.RemoteIA, SrcIA: conf.C.IA,
+		DstHost: addr.HostFromIP(intf.RemoteAddr.IP), SrcHost: addr.HostFromIP(srcAddr.IP),
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: uint16(intf.RemoteAddr.Port)},
 	}, rpkt.DirExternal)
 	if err != nil {

--- a/go/border/ifstate.go
+++ b/go/border/ifstate.go
@@ -54,13 +54,13 @@ func (r *Router) IFStateUpdate() {
 // GenIFStateReq generates an Interface State request packet to the local
 // beacon service.
 func (r *Router) GenIFStateReq() {
+	dstHost := addr.SvcBS.Multicast()
 	// Pick first local address from topology as source.
 	srcAddr := conf.C.Net.LocAddr[0].PublicAddr()
-	dstHost := addr.SvcBS.Multicast()
 	// Create base packet
 	rp, err := rpkt.RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
-		DstIA: conf.C.IA, DstHost: dstHost,
+		DstIA: conf.C.IA, SrcIA: conf.C.IA,
+		DstHost: dstHost, SrcHost: addr.HostFromIP(srcAddr.IP),
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: 0},
 	}, rpkt.DirLocal)
 	if err != nil {

--- a/go/border/io.go
+++ b/go/border/io.go
@@ -54,8 +54,8 @@ func (r *Router) readPosixInput(in *net.UDPConn, dirFrom rpkt.Dir, ifids []spath
 		metrics.InputProcessTime.With(labels).Add(t)
 		rp.TimeIn = monotime.Now()
 		rp.Raw = rp.Raw[:length] // Set the length of the slice
-		rp.Ingress.Src = src
 		rp.Ingress.Dst = dst
+		rp.Ingress.Src = src
 		rp.Ingress.IfIDs = ifids
 		metrics.PktsRecv.With(labels).Inc()
 		metrics.BytesRecv.With(labels).Add(float64(length))

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -88,8 +88,8 @@ func (r *Router) fwdRevInfo(revInfo *proto.RevInfo, dstHost addr.HostAddr) {
 	srcAddr := conf.C.Net.LocAddr[0].PublicAddr()
 	// Create base packet
 	rp, err := rpkt.RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
-		DstIA: conf.C.IA, DstHost: dstHost,
+		DstIA: conf.C.IA, SrcIA: conf.C.IA,
+		DstHost: dstHost, SrcHost: addr.HostFromIP(srcAddr.IP),
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: 0},
 	}, rpkt.DirLocal)
 	if err != nil {

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -95,8 +95,8 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 		assert.Must(len(rp.Raw) > 0, "Raw must not be empty")
 		assert.Must(rp.DirFrom != rpkt.DirUnset, "DirFrom must be set")
 		assert.Must(rp.TimeIn != 0, "TimeIn must be set")
-		assert.Must(rp.Ingress.Src != nil, "Ingress.Src must be set")
 		assert.Must(rp.Ingress.Dst != nil, "Ingress.Dst must be set")
+		assert.Must(rp.Ingress.Src != nil, "Ingress.Src must be set")
 		assert.Must(len(rp.Ingress.IfIDs) > 0, "Ingress.IfIDs must not be empty")
 	}
 	// Assign a pseudorandom ID to the packet, for correlating log entries.

--- a/go/border/rpkt/addr.go
+++ b/go/border/rpkt/addr.go
@@ -21,18 +21,6 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
-// SrcIA retrieves the source ISD-AS if it isn't already known.
-func (rp *RtrPkt) SrcIA() (*addr.ISD_AS, *common.Error) {
-	if rp.srcIA == nil {
-		var err *common.Error
-		rp.srcIA, err = rp.hookIA(rp.hooks.SrcIA, rp.idxs.srcIA)
-		if err != nil {
-			return nil, common.NewError("Unable to retrieve source ISD-AS", "err", err)
-		}
-	}
-	return rp.srcIA, nil
-}
-
 // DstIA retrieves the destination ISD-AS if it isn't already known.
 func (rp *RtrPkt) DstIA() (*addr.ISD_AS, *common.Error) {
 	if rp.dstIA == nil {
@@ -45,7 +33,19 @@ func (rp *RtrPkt) DstIA() (*addr.ISD_AS, *common.Error) {
 	return rp.dstIA, nil
 }
 
-// hookIA is a helper method used by SrcIA/DstIA to run ISD-AS retrieval hooks,
+// SrcIA retrieves the source ISD-AS if it isn't already known.
+func (rp *RtrPkt) SrcIA() (*addr.ISD_AS, *common.Error) {
+	if rp.srcIA == nil {
+		var err *common.Error
+		rp.srcIA, err = rp.hookIA(rp.hooks.SrcIA, rp.idxs.srcIA)
+		if err != nil {
+			return nil, common.NewError("Unable to retrieve source ISD-AS", "err", err)
+		}
+	}
+	return rp.srcIA, nil
+}
+
+// hookIA is a helper method used by DstIA/SrcIA to run ISD-AS retrieval hooks,
 // falling back to parsing the address header directly otherwise.
 func (rp *RtrPkt) hookIA(hooks []hookIA, idx int) (*addr.ISD_AS, *common.Error) {
 	for _, f := range hooks {
@@ -62,18 +62,6 @@ func (rp *RtrPkt) hookIA(hooks []hookIA, idx int) (*addr.ISD_AS, *common.Error) 
 	return addr.IAFromRaw(rp.Raw[idx:]), nil
 }
 
-// SrcHost retrieves the source host address if it isn't already known.
-func (rp *RtrPkt) SrcHost() (addr.HostAddr, *common.Error) {
-	if rp.srcHost == nil {
-		var err *common.Error
-		rp.srcHost, err = rp.hookHost(rp.hooks.SrcHost, rp.idxs.srcHost, rp.CmnHdr.SrcType)
-		if err != nil {
-			return nil, common.NewError("Unable to retrieve source host", "err", err)
-		}
-	}
-	return rp.srcHost, nil
-}
-
 // DstHost retrieves the destination host address if it isn't already known.
 func (rp *RtrPkt) DstHost() (addr.HostAddr, *common.Error) {
 	if rp.dstHost == nil {
@@ -86,7 +74,19 @@ func (rp *RtrPkt) DstHost() (addr.HostAddr, *common.Error) {
 	return rp.dstHost, nil
 }
 
-// hookHost is a helper method used by SrcHost/DstHost to run host address
+// SrcHost retrieves the source host address if it isn't already known.
+func (rp *RtrPkt) SrcHost() (addr.HostAddr, *common.Error) {
+	if rp.srcHost == nil {
+		var err *common.Error
+		rp.srcHost, err = rp.hookHost(rp.hooks.SrcHost, rp.idxs.srcHost, rp.CmnHdr.SrcType)
+		if err != nil {
+			return nil, common.NewError("Unable to retrieve source host", "err", err)
+		}
+	}
+	return rp.srcHost, nil
+}
+
+// hookHost is a helper method used by DstHost/SrcHost to run host address
 // retrieval hooks, falling back to parsing the address header directly
 // otherwise.
 func (rp *RtrPkt) hookHost(

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -46,18 +46,18 @@ func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo Dir) (*RtrPkt, *common.Error) {
 	rp.CmnHdr.CurrHopF = uint8(hdrLen)  // Updated later as necessary.
 	rp.CmnHdr.NextHdr = common.L4None   // Updated later as necessary.
 	// Fill in address header and indexes.
-	rp.idxs.srcIA = spkt.CmnHdrLen
-	rp.srcIA = sp.SrcIA
-	rp.idxs.srcHost = rp.idxs.srcIA + addr.IABytes
-	rp.srcHost = sp.SrcHost
-	rp.idxs.dstIA = rp.idxs.srcHost + rp.srcHost.Size()
+	rp.idxs.dstIA = spkt.CmnHdrLen
 	rp.dstIA = sp.DstIA
-	rp.idxs.dstHost = rp.idxs.dstIA + addr.IABytes
+	rp.idxs.srcIA = rp.idxs.dstIA + addr.IABytes
+	rp.srcIA = sp.SrcIA
+	rp.idxs.dstHost = rp.idxs.srcIA + addr.IABytes
 	rp.dstHost = sp.DstHost
-	rp.srcIA.Write(rp.Raw[rp.idxs.srcIA:])
-	copy(rp.Raw[rp.idxs.srcHost:], rp.srcHost.Pack())
+	rp.idxs.srcHost = rp.idxs.dstHost + rp.dstHost.Size()
+	rp.srcHost = sp.SrcHost
 	rp.dstIA.Write(rp.Raw[rp.idxs.dstIA:])
+	rp.srcIA.Write(rp.Raw[rp.idxs.srcIA:])
 	copy(rp.Raw[rp.idxs.dstHost:], rp.dstHost.Pack())
+	copy(rp.Raw[rp.idxs.srcHost:], rp.srcHost.Pack())
 	// Fill in path
 	rp.idxs.path = spkt.CmnHdrLen + sp.AddrLen()
 	if sp.Path != nil {

--- a/go/border/rpkt/hooks.go
+++ b/go/border/rpkt/hooks.go
@@ -41,10 +41,10 @@ type hookRoute func() (HookResult, *common.Error)
 // of the router register to handle certain functions by adding a callback to
 // the relevant slice.
 type hooks struct {
-	SrcIA    []hookIA
-	SrcHost  []hookHost
 	DstIA    []hookIA
+	SrcIA    []hookIA
 	DstHost  []hookHost
+	SrcHost  []hookHost
 	Infof    []hookInfoF
 	HopF     []hookHopF
 	UpFlag   []hookBool

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -117,8 +117,8 @@ func (rp *RtrPkt) verifyL4() *common.Error {
 func (rp *RtrPkt) verifyL4Chksum() *common.Error {
 	switch h := rp.l4.(type) {
 	case *l4.UDP, *scmp.Hdr:
-		src, dst, pld := rp.getChksumInput()
-		if err := l4.CheckCSum(h, src, dst, pld); err != nil {
+		addr, pld := rp.getChksumInput()
+		if err := l4.CheckCSum(h, addr, pld); err != nil {
 			return err
 		}
 	default:
@@ -129,11 +129,11 @@ func (rp *RtrPkt) verifyL4Chksum() *common.Error {
 
 // getChksumInput is a helper method to return the raw bytes of the src/dest
 // addresses, and the payload, for calculating a layer 4 checksum.
-func (rp *RtrPkt) getChksumInput() (src, dst, pld common.RawBytes) {
-	srcLen, _ := addr.HostLen(rp.CmnHdr.SrcType)
+func (rp *RtrPkt) getChksumInput() (ahdr, pld common.RawBytes) {
 	dstLen, _ := addr.HostLen(rp.CmnHdr.DstType)
-	src = rp.Raw[rp.idxs.srcIA : rp.idxs.srcIA+addr.IABytes+int(srcLen)]
-	dst = rp.Raw[rp.idxs.dstIA : rp.idxs.dstIA+addr.IABytes+int(dstLen)]
+	srcLen, _ := addr.HostLen(rp.CmnHdr.SrcType)
+	addrsLen := int(addr.IABytes*2 + dstLen + srcLen)
+	ahdr = rp.Raw[rp.idxs.srcIA : rp.idxs.srcIA+addrsLen]
 	pld = rp.Raw[rp.idxs.pld:]
 	return
 }
@@ -143,9 +143,9 @@ func (rp *RtrPkt) getChksumInput() (src, dst, pld common.RawBytes) {
 func (rp *RtrPkt) updateL4() *common.Error {
 	switch h := rp.l4.(type) {
 	case *l4.UDP, *scmp.Hdr:
-		src, dst, pld := rp.getChksumInput()
+		addr, pld := rp.getChksumInput()
 		h.SetPldLen(len(pld))
-		if err := l4.SetCSum(h, src, dst, pld); err != nil {
+		if err := l4.SetCSum(h, addr, pld); err != nil {
 			return err
 		}
 		if err := h.Write(rp.Raw[rp.idxs.l4:]); err != nil {

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -133,7 +133,7 @@ func (rp *RtrPkt) getChksumInput() (ahdr, pld common.RawBytes) {
 	dstLen, _ := addr.HostLen(rp.CmnHdr.DstType)
 	srcLen, _ := addr.HostLen(rp.CmnHdr.SrcType)
 	addrsLen := int(addr.IABytes*2 + dstLen + srcLen)
-	ahdr = rp.Raw[rp.idxs.srcIA : rp.idxs.srcIA+addrsLen]
+	ahdr = rp.Raw[rp.idxs.dstIA : rp.idxs.dstIA+addrsLen]
 	pld = rp.Raw[rp.idxs.pld:]
 	return
 }

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -127,8 +127,9 @@ func (rp *RtrPkt) verifyL4Chksum() *common.Error {
 	return nil
 }
 
-// getChksumInput is a helper method to return the raw bytes of the src/dest
-// addresses, and the payload, for calculating a layer 4 checksum.
+// getChksumInput is a helper method to return the raw bytes of the address
+// header (excluding padding) and the payload, for calculating a
+// layer 4 checksum.
 func (rp *RtrPkt) getChksumInput() (ahdr, pld common.RawBytes) {
 	dstLen, _ := addr.HostLen(rp.CmnHdr.DstType)
 	srcLen, _ := addr.HostLen(rp.CmnHdr.SrcType)

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -100,7 +100,7 @@ func (rp *RtrPkt) parseBasic() *common.Error {
 		return err
 	}
 	// Set index for path header.
-	addrLen := addr.IABytes*2 + int(srcLen) + int(dstLen)
+	addrLen := int(addr.IABytes*2 + dstLen + srcLen)
 	addrPad := util.CalcPadding(addrLen, common.LineLen)
 	rp.idxs.path = spkt.CmnHdrLen + addrLen + addrPad
 	if rp.idxs.path > int(rp.CmnHdr.HdrLen) {

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -75,32 +75,32 @@ func (rp *RtrPkt) Parse() *common.Error {
 // parseBasic handles the parsing of the common and address headers.
 func (rp *RtrPkt) parseBasic() *common.Error {
 	var err *common.Error
+	var dstLen, srcLen uint8
 	// Parse common header.
-	if err := rp.CmnHdr.Parse(rp.Raw); err != nil {
+	if err = rp.CmnHdr.Parse(rp.Raw); err != nil {
 		return err
 	}
-	// Set indexes for source ISD-AS and host address.
-	rp.idxs.srcIA = spkt.CmnHdrLen
-	rp.idxs.srcHost = rp.idxs.srcIA + addr.IABytes
-	srcLen, err := addr.HostLen(rp.CmnHdr.SrcType)
-	if err != nil {
-		if err.Desc == addr.ErrorBadHostAddrType {
-			err.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil)
-		}
-		return err
-	}
-	// Set indexes for destination ISD-AS and host address.
-	rp.idxs.dstIA = rp.idxs.srcHost + int(srcLen)
-	rp.idxs.dstHost = rp.idxs.dstIA + addr.IABytes
-	dstLen, err := addr.HostLen(rp.CmnHdr.DstType)
-	if err != nil {
+	// Set indexes for destination and source ISD-ASes.
+	rp.idxs.dstIA = spkt.CmnHdrLen
+	rp.idxs.srcIA = rp.idxs.dstIA + addr.IABytes
+	// Set index for destination host address and calculate its length.
+	rp.idxs.dstHost = rp.idxs.srcIA + addr.IABytes
+	if dstLen, err = addr.HostLen(rp.CmnHdr.DstType); err != nil {
 		if err.Desc == addr.ErrorBadHostAddrType {
 			err.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil)
 		}
 		return err
 	}
+	// Set index for source host address and calculate its length.
+	rp.idxs.srcHost = rp.idxs.dstHost + int(dstLen)
+	if srcLen, err = addr.HostLen(rp.CmnHdr.SrcType); err != nil {
+		if err.Desc == addr.ErrorBadHostAddrType {
+			err.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil)
+		}
+		return err
+	}
 	// Set index for path header.
-	addrLen := addr.IABytes + int(srcLen) + addr.IABytes + int(dstLen)
+	addrLen := addr.IABytes*2 + int(srcLen) + int(dstLen)
 	addrPad := util.CalcPadding(addrLen, common.LineLen)
 	rp.idxs.path = spkt.CmnHdrLen + addrLen + addrPad
 	if rp.idxs.path > int(rp.CmnHdr.HdrLen) {

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -155,8 +155,8 @@ func (rp *RtrPkt) processIFID(pld proto.IFID) (HookResult, *common.Error) {
 	srcAddr := conf.C.Net.LocAddr[intf.LocAddrIdx].PublicAddr()
 	// Create base packet to local beacon service (multicast).
 	fwdrp, err := RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
-		DstIA: conf.C.IA, DstHost: addr.SvcBS.Multicast(),
+		DstIA: conf.C.IA, SrcIA: conf.C.IA,
+		DstHost: addr.SvcBS.Multicast(), SrcHost: addr.HostFromIP(srcAddr.IP),
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: 0},
 	}, DirLocal)
 	if err != nil {

--- a/go/border/rpkt/validate.go
+++ b/go/border/rpkt/validate.go
@@ -37,17 +37,17 @@ func (rp *RtrPkt) Validate() *common.Error {
 		return common.NewError(errCurrIntfInvalid, "ifid", *rp.ifCurr)
 	}
 	// XXX(kormat): the rest of the common header is checked by the parsing phase.
+	if !addr.HostTypeCheck(rp.CmnHdr.DstType) {
+		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil)
+		return common.NewErrorData("Unsupported destination address type", sdata,
+			"type", rp.CmnHdr.DstType)
+	}
 	if !addr.HostTypeCheck(rp.CmnHdr.SrcType) || rp.CmnHdr.SrcType == addr.HostTypeSVC {
 		// Either the source address type isn't supported, or it is an SVC
 		// address (which is forbidden).
 		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil)
 		return common.NewErrorData("Unsupported source address type", sdata,
 			"type", rp.CmnHdr.SrcType)
-	}
-	if !addr.HostTypeCheck(rp.CmnHdr.DstType) {
-		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil)
-		return common.NewErrorData("Unsupported destination address type", sdata,
-			"type", rp.CmnHdr.DstType)
 	}
 	if int(rp.CmnHdr.TotalLen) != len(rp.Raw) {
 		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadPktLen,

--- a/go/lib/l4/common.go
+++ b/go/lib/l4/common.go
@@ -40,19 +40,19 @@ type L4Header interface {
 	Reverse()
 }
 
-func CalcCSum(h L4Header, src, dst, pld common.RawBytes) (common.RawBytes, *common.Error) {
+func CalcCSum(h L4Header, addr, pld common.RawBytes) (common.RawBytes, *common.Error) {
 	rawh, err := h.Pack(true)
 	if err != nil {
 		return nil, err
 	}
-	sum := libscion.Checksum(src, dst, []uint8{uint8(h.L4Type())}, rawh, pld)
+	sum := libscion.Checksum(addr, []uint8{uint8(h.L4Type())}, rawh, pld)
 	out := make(common.RawBytes, 2)
 	common.Order.PutUint16(out, sum)
 	return out, nil
 }
 
-func SetCSum(h L4Header, src, dst, pld common.RawBytes) *common.Error {
-	out, err := CalcCSum(h, src, dst, pld)
+func SetCSum(h L4Header, addr, pld common.RawBytes) *common.Error {
+	out, err := CalcCSum(h, addr, pld)
 	if err != nil {
 		return err
 	}
@@ -60,8 +60,8 @@ func SetCSum(h L4Header, src, dst, pld common.RawBytes) *common.Error {
 	return nil
 }
 
-func CheckCSum(h L4Header, src, dst, pld common.RawBytes) *common.Error {
-	calc, err := CalcCSum(h, src, dst, pld)
+func CheckCSum(h L4Header, addr, pld common.RawBytes) *common.Error {
+	calc, err := CalcCSum(h, addr, pld)
 	if err != nil {
 		return err
 	}

--- a/go/lib/scmp/scmp.go
+++ b/go/lib/scmp/scmp.go
@@ -66,8 +66,8 @@ const (
 // C_CmnHdr types
 const (
 	T_C_BadVersion Type = iota
-	T_C_BadSrcType
 	T_C_BadDstType
+	T_C_BadSrcType
 	T_C_BadPktLen
 	T_C_BadInfoFOffset
 	T_C_BadHopFOffset
@@ -106,7 +106,7 @@ var typeNameMap = map[Class][]string{
 	C_General: {"UNSPECIFIED", "ECHO_REQEST", "ECHO_REPLY"},
 	C_Routing: {"UNREACH_NET", "UNREACH_HOST", "L2_ERROR", "UNREACH_PROTO",
 		"UNREACH_PORT", "UNKNOWN_HOST", "BAD_HOST", "OVERSIZE_PKT", "ADMIN_DENIED"},
-	C_CmnHdr: {"BAD_VERSION", "BAD_SRC_TYPE", "BAD_DST_TYPE",
+	C_CmnHdr: {"BAD_VERSION", "BAD_DST_TYPE", "BAD_SRC_TYPE",
 		"BAD_PKT_LEN", "BAD_IOF_OFFSET", "BAD_HOF_OFFSET"},
 	C_Path: {"PATH_REQUIRED", "BAD_MAC", "EXPIRED_HOPF", "BAD_IF", "REVOKED_IF",
 		"NON_ROUTING_HOPF", "DELIVERY_FWD_ONLY", "DELIVERY_NON_LOCAL", "BAD_SEGMENT",

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -24,10 +24,10 @@ import (
 
 // SCION Packet structure.
 type ScnPkt struct {
-	SrcIA   *addr.ISD_AS
-	SrcHost addr.HostAddr
 	DstIA   *addr.ISD_AS
+	SrcIA   *addr.ISD_AS
 	DstHost addr.HostAddr
+	SrcHost addr.HostAddr
 	Path    *spath.Path
 	HBHExt  []common.Extension
 	E2EExt  []common.Extension
@@ -37,17 +37,17 @@ type ScnPkt struct {
 
 func (s *ScnPkt) Copy() *ScnPkt {
 	c := &ScnPkt{}
-	if s.SrcIA != nil {
-		c.SrcIA = s.SrcIA.Copy()
-	}
-	if s.SrcHost != nil {
-		c.SrcHost = s.SrcHost.Copy()
-	}
 	if s.DstIA != nil {
 		c.DstIA = s.DstIA.Copy()
 	}
+	if s.SrcIA != nil {
+		c.SrcIA = s.SrcIA.Copy()
+	}
 	if s.DstHost != nil {
 		c.DstHost = s.DstHost.Copy()
+	}
+	if s.SrcHost != nil {
+		c.SrcHost = s.SrcHost.Copy()
 	}
 	if s.Path != nil {
 		c.Path = s.Path.Copy()
@@ -66,8 +66,8 @@ func (s *ScnPkt) Copy() *ScnPkt {
 }
 
 func (s *ScnPkt) Reverse() *common.Error {
-	s.SrcIA, s.DstIA = s.DstIA, s.SrcIA
-	s.SrcHost, s.DstHost = s.DstHost, s.SrcHost
+	s.DstIA, s.SrcIA = s.SrcIA, s.DstIA
+	s.DstHost, s.SrcHost = s.SrcHost, s.DstHost
 	if s.Path != nil {
 		if err := s.Path.Reverse(); err != nil {
 			return err
@@ -81,7 +81,7 @@ func (s *ScnPkt) Reverse() *common.Error {
 }
 
 func (s *ScnPkt) AddrLen() int {
-	addrLen := addr.IABytes*2 + s.SrcHost.Size() + s.DstHost.Size()
+	addrLen := addr.IABytes*2 + s.DstHost.Size() + s.SrcHost.Size()
 	return addrLen + util.CalcPadding(addrLen, common.LineLen)
 }
 

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -407,7 +407,7 @@ class SCIONElement(object):
         if payload is None:
             payload = PayloadRaw()
         dst_addr = SCIONAddr.from_values(dst_ia, dst_host)
-        cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dst_addr)
+        cmn_hdr, addr_hdr = build_base_hdrs(dst_addr, self.addr)
         udp_hdr = SCIONUDPHeader.from_values(
             self.addr, self._port, dst_addr, dst_port)
         return SCIONL4Packet.from_values(

--- a/infrastructure/sibra_server/steady.py
+++ b/infrastructure/sibra_server/steady.py
@@ -223,7 +223,7 @@ class SteadyPath(object):
         Create headers for a SCION packet
         """
         dest = SCIONAddr.from_values(self.remote, SVCType.SB_A)
-        cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
+        cmn_hdr, addr_hdr = build_base_hdrs(dest, self.addr)
         payload = SIBRAPayload.from_values()
         udp_hdr = SCIONUDPHeader.from_values(self.addr, self._port, dest, 0)
         return cmn_hdr, addr_hdr, udp_hdr, payload
@@ -270,7 +270,7 @@ class SteadyPath(object):
         pcb = self._create_reg_pcb(remote)
         pld = PathRecordsReg.from_values({type_: [pcb]})
         dest = SCIONAddr.from_values(dst_ia, SVCType.PS_A)
-        cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
+        cmn_hdr, addr_hdr = build_base_hdrs(dest, self.addr)
         udp_hdr = SCIONUDPHeader.from_values(self.addr, self._port, dest, 0)
         return SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, path, [], udp_hdr, pld)

--- a/lib/libscion/address.c
+++ b/lib/libscion/address.c
@@ -62,6 +62,16 @@ uint8_t get_src_len(uint8_t *buf)
     return ADDR_LENS[SRC_TYPE(sch)];
 }
 
+/*
+ * Get combined length of dst and src addresses
+ * buf: Pointer to start of SCION packet
+ * return value: Length of dst + src addresses
+ * */
+uint8_t get_addrs_len(uint8_t *buf)
+{
+    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
+    return ISD_AS_LEN * 2 + ADDR_LENS[DST_TYPE(sch)] + ADDR_LENS[SRC_TYPE(sch)];
+}
 
 /*
  * Get dst host addr

--- a/lib/libscion/address.c
+++ b/lib/libscion/address.c
@@ -137,8 +137,8 @@ void format_host(int addr_type, uint8_t *addr, char *buf, int size) {
  */
 void print_addresses(uint8_t *buf) {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    uint32_t dst_isd_as = ntohl(get_dst_isd_as(buf));
-    uint32_t src_isd_as = ntohl(get_src_isd_as(buf));
+    uint32_t dst_isd_as = get_dst_isd_as(buf);
+    uint32_t src_isd_as = get_src_isd_as(buf);
     char host_str[MAX_HOST_ADDR_STR];
     format_host(DST_TYPE(sch), get_dst_addr(buf), host_str, sizeof(host_str));
     fprintf(stderr, "Dst: ISD-AS: %d-%d Host(%s): %s\n", ISD(dst_isd_as),

--- a/lib/libscion/address.c
+++ b/lib/libscion/address.c
@@ -21,27 +21,37 @@ int get_addr_len(int type)
 }
 
 /*
+ * Get dst ISD_AS
+ * buf: Pointer to start of SCION packet
+ * return value: dst ISD_AS value
+ */
+uint32_t get_dst_isd_as(uint8_t *buf)
+{
+    return ntohl(*(uint32_t *)(buf + DST_IA_OFFSET));
+}
+
+/*
  * Get src ISD_AS
  * buf: Pointer to start of SCION packet
- * return value: src ISD_AS value, 0 on error
+ * return value: src ISD_AS value
  */
 uint32_t get_src_isd_as(uint8_t *buf)
 {
-    return ntohl(*(uint32_t *)(buf + sizeof(SCIONCommonHeader)));
+    return ntohl(*(uint32_t *)(buf + SRC_IA_OFFSET));
 }
 
-/* 
- * Get src host addr
+/*
+ * Get length of dst host addr
  * buf: Pointer to start of SCION packet
- * return value: pointer to start of src host addr
+ * return value: Length of dst host addr
  * */
-uint8_t * get_src_addr(uint8_t *buf)
+uint8_t get_dst_len(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return (uint8_t *)(sch + 1) + ISD_AS_LEN;
+    return ADDR_LENS[DST_TYPE(sch)];
 }
 
-/* 
+/*
  * Get length of src host addr
  * buf: Pointer to start of SCION packet
  * return value: Length of src host addr
@@ -52,58 +62,27 @@ uint8_t get_src_len(uint8_t *buf)
     return ADDR_LENS[SRC_TYPE(sch)];
 }
 
+
 /*
- * Get dst ISD_AS
- * buf: Pointer to start of SCION packet
- * return value: dst ISD_AS value, 0 on error
- */
-uint32_t get_dst_isd_as(uint8_t *buf)
-{
-    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-
-    uint8_t src_len;
-    uint8_t src_type = SRC_TYPE(sch);
-
-    if (src_type < ADDR_NONE_TYPE || src_type > ADDR_SVC_TYPE) {
-        printf("invalid src addr type: %d\n", src_type);
-        return 0;
-    }
-
-    src_len = ADDR_LENS[src_type];
-    return ntohl(*(uint32_t *)(buf + sizeof(SCIONCommonHeader) + ISD_AS_LEN + src_len));
-}
-
-/* 
  * Get dst host addr
  * buf: Pointer to start of SCION packet
- * return value: Pointer to start of dst host addr, NULL on error
+ * return value: pointer to start of dst host addr
  * */
 uint8_t * get_dst_addr(uint8_t *buf)
 {
-    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    uint8_t src_len;
-    uint8_t src_type = SRC_TYPE(sch);
-
-    if (src_type < ADDR_NONE_TYPE || src_type > ADDR_SVC_TYPE) {
-        printf("invalid src addr type: %d\n", src_type);
-        return NULL;
-    }
-
-    src_len = ADDR_LENS[src_type];
-    void *ret = (uint8_t *)(sch + 1) + ISD_AS_LEN +
-        src_len + ISD_AS_LEN;
-    return ret;
+    int offset = sizeof(SCIONCommonHeader) + ISD_AS_LEN * 2;
+    return (uint8_t *)(buf + offset);
 }
 
-/* 
- * Get length of dst host addr
+/*
+ * Get src host addr
  * buf: Pointer to start of SCION packet
- * return value: Length of dst host addr
+ * return value: pointer to start of src host addr
  * */
-uint8_t get_dst_len(uint8_t *buf)
+uint8_t * get_src_addr(uint8_t *buf)
 {
-    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return ADDR_LENS[DST_TYPE(sch)];
+    int offset = sizeof(SCIONCommonHeader) + ISD_AS_LEN * 2 + get_dst_len(buf);
+    return (uint8_t *)(buf + offset);
 }
 
 /*
@@ -158,13 +137,13 @@ void format_host(int addr_type, uint8_t *addr, char *buf, int size) {
  */
 void print_addresses(uint8_t *buf) {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    uint32_t src_isd_as = get_src_isd_as(buf);
-    uint32_t dst_isd_as = get_dst_isd_as(buf);
+    uint32_t dst_isd_as = ntohl(get_dst_isd_as(buf));
+    uint32_t src_isd_as = ntohl(get_src_isd_as(buf));
     char host_str[MAX_HOST_ADDR_STR];
-    format_host(SRC_TYPE(sch), get_src_addr(buf), host_str, sizeof(host_str));
-    fprintf(stderr, "Src: ISD-AS: %d-%d Host(%s): %s\n", ISD(src_isd_as),
-            AS(src_isd_as), addr_type_str(SRC_TYPE(sch)), host_str);
     format_host(DST_TYPE(sch), get_dst_addr(buf), host_str, sizeof(host_str));
     fprintf(stderr, "Dst: ISD-AS: %d-%d Host(%s): %s\n", ISD(dst_isd_as),
             AS(dst_isd_as), addr_type_str(DST_TYPE(sch)), host_str);
+    format_host(SRC_TYPE(sch), get_src_addr(buf), host_str, sizeof(host_str));
+    fprintf(stderr, "Src: ISD-AS: %d-%d Host(%s): %s\n", ISD(src_isd_as),
+            AS(src_isd_as), addr_type_str(SRC_TYPE(sch)), host_str);
 }

--- a/lib/libscion/address.h
+++ b/lib/libscion/address.h
@@ -63,15 +63,17 @@ typedef struct {
 #define SADDR_AS(saddr) AS(ntohs(*(uint32_t *)(saddr.addr)))
 #define SADDR_HOST(saddr) (saddr.addr + ISD_AS_LEN)
 
+#define DST_IA_OFFSET sizeof(SCIONCommonHeader)
+#define SRC_IA_OFFSET sizeof(SCIONCommonHeader) + ISD_AS_LEN
+
 int get_addr_len(int type);
-uint32_t get_src_isd_as(uint8_t *buf);
-uint8_t * get_src_addr(uint8_t *buf);
-uint8_t get_src_len(uint8_t *buf);
 uint32_t get_dst_isd_as(uint8_t *buf);
-uint8_t * get_dst_addr(uint8_t *buf);
+uint32_t get_src_isd_as(uint8_t *buf);
 uint8_t get_dst_len(uint8_t *buf);
-void format_host(int addr_type, uint8_t *addr, char *buf, int size);
-void print_addresses(uint8_t *buf);
+uint8_t get_src_len(uint8_t *buf);
+uint8_t * get_dst_addr(uint8_t *buf);
+uint8_t * get_src_addr(uint8_t *buf);
 void format_host(int, uint8_t *, char *, int);
+void print_addresses(uint8_t *buf);
 
 #endif

--- a/lib/libscion/address.h
+++ b/lib/libscion/address.h
@@ -71,6 +71,7 @@ uint32_t get_dst_isd_as(uint8_t *buf);
 uint32_t get_src_isd_as(uint8_t *buf);
 uint8_t get_dst_len(uint8_t *buf);
 uint8_t get_src_len(uint8_t *buf);
+uint8_t get_addrs_len(uint8_t *buf);
 uint8_t * get_dst_addr(uint8_t *buf);
 uint8_t * get_src_addr(uint8_t *buf);
 void format_host(int, uint8_t *, char *, int);

--- a/lib/libscion/packet.h
+++ b/lib/libscion/packet.h
@@ -54,14 +54,14 @@ typedef struct {
 
 typedef struct {
     sch_t *sch;
-    saddr_t *src;
     saddr_t *dst;
+    saddr_t *src;
     spath_t *path;
     exts_t *exts;
     l4_pld *l4;
 } spkt_t;
 
-spkt_t * build_spkt(saddr_t *src, saddr_t *dst, spath_t *path, exts_t *exts, l4_pld *l4);
+spkt_t * build_spkt(saddr_t *dst, saddr_t *src, spath_t *path, exts_t *exts, l4_pld *l4);
 
 spkt_t * parse_spkt(uint8_t *buf);
 void parse_spkt_cmn_hdr(uint8_t *buf, spkt_t *spkt);
@@ -79,9 +79,8 @@ uint8_t * pack_spkt_l4(spkt_t *spkt, uint8_t *ptr);
 
 void destroy_spkt(spkt_t *spkt, int from_raw);
 
-void pack_cmn_hdr(uint8_t *buf, int src_type, int dst_type, int next_hdr,
+void pack_cmn_hdr(uint8_t *buf, int dst_type, int src_type, int next_hdr,
                   int path_len, int exts_len, int l4_len);
-void pack_addr_hdr(uint8_t *buf, SCIONAddr *src, SCIONAddr *dst);
 int padded_addr_len(uint8_t *buf);
 void set_path(uint8_t *buf, uint8_t *path, int len);
 uint8_t * get_path(uint8_t *buf);

--- a/lib/libscion/scmp.c
+++ b/lib/libscion/scmp.c
@@ -15,7 +15,7 @@ uint16_t scmp_checksum(uint8_t *buf)
     uint16_t payload_len, ret, blank_sum = 0;
 
     // Address header (without padding)
-    chk_add_chunk(input, buf + DST_IA_OFFSET, 2 * ISD_AS_LEN + get_dst_len(buf) + get_src_len(buf));
+    chk_add_chunk(input, buf + DST_IA_OFFSET, get_addrs_len(buf));
 
     uint8_t *ptr = buf;
     l4_type = get_l4_proto(&ptr);

--- a/lib/libscion/scmp.c
+++ b/lib/libscion/scmp.c
@@ -9,17 +9,15 @@
 
 uint16_t scmp_checksum(uint8_t *buf)
 {
-    uint8_t *ptr = buf + sizeof(SCIONCommonHeader);
-    chk_input *input = mk_chk_input(7);
+    chk_input *input = mk_chk_input(6);
     SCMPL4Header *scmp_l4;
     uint8_t l4_type;
     uint16_t payload_len, ret, blank_sum = 0;
 
-    // Src ISD-AS & host address
-    ptr = chk_add_chunk(input, ptr, ISD_AS_LEN + get_src_len(buf));
-    // Dest ISD-AS & host address
-    chk_add_chunk(input, ptr, ISD_AS_LEN + get_dst_len(buf));
-    ptr = buf;
+    // Address header (without padding)
+    chk_add_chunk(input, buf + DST_IA_OFFSET, 2 * ISD_AS_LEN + get_dst_len(buf) + get_src_len(buf));
+
+    uint8_t *ptr = buf;
     l4_type = get_l4_proto(&ptr);
     scmp_l4 = (SCMPL4Header *)ptr;
     // L4 protocol type

--- a/lib/libscion/scmp.h
+++ b/lib/libscion/scmp.h
@@ -63,8 +63,8 @@ typedef enum {
 
 typedef enum {
     SCMP_BAD_VERSION,
-    SCMP_BAD_SRC_TYPE,
     SCMP_BAD_DST_TYPE,
+    SCMP_BAD_SRC_TYPE,
     SCMP_BAD_PKT_LEN,
     SCMP_BAD_IOF_OFFSET,
     SCMP_BAD_HOF_OFFSET,

--- a/lib/libscion/udp.c
+++ b/lib/libscion/udp.c
@@ -60,7 +60,7 @@ uint16_t scion_udp_checksum(uint8_t *buf)
     uint16_t payload_len, ret, blank_sum = 0;
 
     // Address header (without padding)
-    chk_add_chunk(input, buf + DST_IA_OFFSET, 2 * ISD_AS_LEN + get_dst_len(buf) + get_src_len(buf));
+    chk_add_chunk(input, buf + DST_IA_OFFSET, get_addrs_len(buf));
 
     uint8_t *ptr = buf;
     l4_type = get_l4_proto(&ptr);

--- a/lib/libscion/udp.c
+++ b/lib/libscion/udp.c
@@ -54,17 +54,15 @@ uint8_t get_payload_type(uint8_t *buf)
  */
 uint16_t scion_udp_checksum(uint8_t *buf)
 {
-    uint8_t *ptr = buf + sizeof(SCIONCommonHeader);
-    chk_input *input = mk_chk_input(6);
+    chk_input *input = mk_chk_input(5);
     SCIONUDPHeader *udp_hdr;
     uint8_t l4_type;
     uint16_t payload_len, ret, blank_sum = 0;
 
-    // Src ISD-AS & host address
-    ptr = chk_add_chunk(input, ptr, ISD_AS_LEN + get_src_len(buf));
-    // Dest ISD-AS & host address
-    chk_add_chunk(input, ptr, ISD_AS_LEN + get_dst_len(buf));
-    ptr = buf;
+    // Address header (without padding)
+    chk_add_chunk(input, buf + DST_IA_OFFSET, 2 * ISD_AS_LEN + get_dst_len(buf) + get_src_len(buf));
+
+    uint8_t *ptr = buf;
     l4_type = get_l4_proto(&ptr);
     udp_hdr = (SCIONUDPHeader *)ptr;
     // L4 protocol type

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -178,8 +178,8 @@ class SCIONCommonHdr(Serializable):
             "dst_addr_type": haddr_get_type(self.dst_addr_type).name(),
             "src_addr_type": haddr_get_type(self.src_addr_type).name(),
         }
-        for i in ("version", "total_len",
-                  "_iof_idx", "_hof_idx", "next_hdr", "hdr_len"):
+        for i in ("version", "total_len", "hdr_len",
+                  "_iof_idx", "_hof_idx", "next_hdr"):
             values[i] = getattr(self, i)
         return (
             "CH ver: %(version)s, dst type: %(dst_addr_type)s, src type: %(src_addr_type)s, "

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -41,7 +41,7 @@ from lib.packet.packet_base import (
 from lib.packet.path import SCIONPath, parse_path
 from lib.packet.path_mgmt.parse import parse_pathmgmt_payload
 from lib.packet.pcb import parse_pcb_payload
-from lib.packet.scion_addr import SCIONAddr
+from lib.packet.scion_addr import ISD_AS, SCIONAddr
 from lib.packet.scion_l4 import parse_l4_hdr
 from lib.packet.scmp.errors import (
     SCMPBadDstType,
@@ -118,8 +118,8 @@ class SCIONCommonHdr(Serializable):
         """
         Returns a SCIONCommonHdr object with the values specified.
 
-        :param int src: Source address type.
-        :param int dst: Destination address type.
+        :param int dst_type: Destination address type.
+        :param int src_type: Source address type.
         :param int next_hdr: Next header type.
         """
         inst = cls()
@@ -175,17 +175,17 @@ class SCIONCommonHdr(Serializable):
 
     def __str__(self):
         values = {
-            "src_addr_type": haddr_get_type(self.src_addr_type).name(),
             "dst_addr_type": haddr_get_type(self.dst_addr_type).name(),
+            "src_addr_type": haddr_get_type(self.src_addr_type).name(),
         }
         for i in ("version", "total_len",
                   "_iof_idx", "_hof_idx", "next_hdr", "hdr_len"):
             values[i] = getattr(self, i)
         return (
-            "CH ver: %(version)s, src type: %(src_addr_type)s, "
-            "dst type: %(dst_addr_type)s, total len: %(total_len)sB, "
+            "CH ver: %(version)s, dst type: %(dst_addr_type)s, src type: %(src_addr_type)s, "
+            "total len: %(total_len)sB, hdr len: %(hdr_len)sB, "
             "IOF idx: %(_iof_idx)s, HOF idx: %(_hof_idx)s, "
-            "next hdr: %(next_hdr)s, hdr len: %(hdr_len)sB" % values)
+            "next hdr: %(next_hdr)s" % values)
 
 
 class SCIONAddrHdr(Serializable):
@@ -196,42 +196,48 @@ class SCIONAddrHdr(Serializable):
     def __init__(self, raw_values=()):  # pragma: no cover
         """
         :param tuple raw:
-            Tuple of src addr type, dst addr type, and raw addr bytes.
+            Tuple of dst addr type, src addr type, and raw addr bytes.
         """
         super().__init__()
-        self.src = None
         self.dst = None
+        self.src = None
         self._pad_len = None
         self._total_len = None
         if raw_values:
             self._parse(*raw_values)
 
-    def _parse(self, src_type, dst_type, raw):
-        data = Raw(raw, self.NAME, self.calc_lens(src_type, dst_type)[0])
-        self.src = SCIONAddr((src_type, data.get()))
-        data.pop(len(self.src))
-        self.dst = SCIONAddr((dst_type, data.get()))
-        data.pop(len(self.dst))
+    def _parse(self, dst_type, src_type, raw):
+        data = Raw(raw, self.NAME, self.calc_lens(dst_type, src_type)[0])
+        dst_ia = ISD_AS(data.pop(ISD_AS.Len))
+        src_ia = ISD_AS(data.pop(ISD_AS.Len))
+        dst_addr_t = haddr_get_type(dst_type)
+        dst_addr = dst_addr_t(data.pop(dst_addr_t.LEN))
+        self.dst = SCIONAddr.from_values(dst_ia, dst_addr)
+        src_addr_t = haddr_get_type(src_type)
+        src_addr = src_addr_t(data.pop(src_addr_t.LEN))
+        self.src = SCIONAddr.from_values(src_ia, src_addr)
         self.update()
         if self.src.host.TYPE == AddrType.SVC:
             raise SCMPBadSrcType("Invalid source type: SVC")
 
     @classmethod
-    def from_values(cls, src, dst):  # pragma: no cover
+    def from_values(cls, dst, src):  # pragma: no cover
         """
-        src/dst must be a :any:`SCIONAddr`
+        dst/src must be a :any:`SCIONAddr`
         """
         inst = cls()
-        inst.src = src
         inst.dst = dst
+        inst.src = src
         inst.update()
         return inst
 
     def pack(self):
         self.update()
         packed = []
-        packed.append(self.src.pack())
-        packed.append(self.dst.pack())
+        packed.append(self.dst.isd_as.pack())
+        packed.append(self.src.isd_as.pack())
+        packed.append(self.dst.host.pack())
+        packed.append(self.src.host.pack())
         packed.append(bytes(self._pad_len))
         raw = b"".join(packed)
         assert len(raw) % self.BLK_SIZE == 0
@@ -243,10 +249,12 @@ class SCIONAddrHdr(Serializable):
             if self.dst.host.anycast() not in [SVCType.BS_A, SVCType.PS_A,
                                                SVCType.CS_A, SVCType.SB_A]:
                 raise SCMPBadHost("Invalid dest SVC: %s" % self.dst.host.addr)
+        if self.src.host.TYPE == AddrType.SVC:
+            raise SCMPBadSrcType("Invalid source type: SVC")
 
     def update(self):
         self._total_len, self._pad_len = self.calc_lens(
-            self.src.host.TYPE, self.dst.host.TYPE)
+            self.dst.host.TYPE, self.src.host.TYPE)
 
     @classmethod
     def calc_lens(cls, dst_type, src_type):
@@ -266,22 +274,21 @@ class SCIONAddrHdr(Serializable):
         return total_len, pad_len
 
     def reverse(self):
-        self.src, self.dst = self.dst, self.src
+        self.dst, self.src = self.src, self.dst
         self.update()
-
-    def src_type(self):  # pragma: no cover
-        return self.src.host.TYPE
 
     def dst_type(self):  # pragma: no cover
         return self.dst.host.TYPE
+
+    def src_type(self):  # pragma: no cover
+        return self.src.host.TYPE
 
     def __len__(self):  # pragma: no cover
         assert self._total_len is not None
         return self._total_len
 
     def __str__(self):
-        return "%s(%sB): Src:<%s> Dst:<%s>" % (
-            self.NAME, len(self), self.src, self.dst)
+        return "%s(%sB): Dst:<%s> Src:<%s>" % (self.NAME, len(self), self.dst, self.src)
 
 
 class SCIONBasePacket(PacketBase):
@@ -312,8 +319,8 @@ class SCIONBasePacket(PacketBase):
 
     def _parse_addrs(self, data):
         self.addrs = SCIONAddrHdr((
-            self.cmn_hdr.src_addr_type,
             self.cmn_hdr.dst_addr_type,
+            self.cmn_hdr.src_addr_type,
             data.get(self.cmn_hdr.addrs_len),
         ))
         data.pop(len(self.addrs))
@@ -407,8 +414,8 @@ class SCIONBasePacket(PacketBase):
 
     def _update_cmn_hdr(self):
         hdr = self.cmn_hdr
-        hdr.src_addr_type = self.addrs.src_type()
         hdr.dst_addr_type = self.addrs.dst_type()
+        hdr.src_addr_type = self.addrs.src_type()
         hdr.addrs_len = len(self.addrs)
         hdr.hdr_len = len(hdr) + len(self.addrs) + len(self.path)
         hdr.total_len = hdr.hdr_len + self._get_offset_len()
@@ -588,7 +595,7 @@ class SCIONL4Packet(SCIONExtPacket):
         super()._inner_parse(data)
         # Parse L4 header
         self.l4_hdr = parse_l4_hdr(
-            self._l4_proto, data, src=self.addrs.src, dst=self.addrs.dst)
+            self._l4_proto, data, dst=self.addrs.dst, src=self.addrs.src)
 
     @classmethod
     def from_values(cls, cmn_hdr, addr_hdr, path_hdr, ext_hdrs, l4_hdr,
@@ -674,9 +681,9 @@ class SCIONL4Packet(SCIONExtPacket):
         return self._l4_proto
 
 
-def build_base_hdrs(src, dst, l4=L4Proto.UDP):
+def build_base_hdrs(dst, src, l4=L4Proto.UDP):
     cmn_hdr = SCIONCommonHdr.from_values(dst.host.TYPE, src.host.TYPE, l4)
-    addr_hdr = SCIONAddrHdr.from_values(src, dst)
+    addr_hdr = SCIONAddrHdr.from_values(dst, src)
     return cmn_hdr, addr_hdr
 
 

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -208,8 +208,8 @@ class SCIONAddrHdr(Serializable):
 
     def _parse(self, dst_type, src_type, raw):
         data = Raw(raw, self.NAME, self.calc_lens(dst_type, src_type)[0])
-        dst_ia = ISD_AS(data.pop(ISD_AS.Len))
-        src_ia = ISD_AS(data.pop(ISD_AS.Len))
+        dst_ia = ISD_AS(data.pop(ISD_AS.LEN))
+        src_ia = ISD_AS(data.pop(ISD_AS.LEN))
         dst_addr_t = haddr_get_type(dst_type)
         dst_addr = dst_addr_t(data.pop(dst_addr_t.LEN))
         self.dst = SCIONAddr.from_values(dst_ia, dst_addr)

--- a/lib/packet/scion_l4.py
+++ b/lib/packet/scion_l4.py
@@ -48,7 +48,7 @@ class SCIONL4Unknown(L4HeaderBase):  # pragma: no cover
         return "[Unknown L4 protocol header]"
 
 
-def parse_l4_hdr(proto, data, src=None, dst=None):
+def parse_l4_hdr(proto, data, dst=None, src=None):
     if proto == L4Proto.UDP:
         raw_hdr = data.pop(SCIONUDPHeader.LEN)
         assert src

--- a/lib/packet/scion_udp.py
+++ b/lib/packet/scion_udp.py
@@ -112,7 +112,9 @@ class SCIONUDPHeader(L4HeaderBase):
         assert isinstance(self._src, SCIONAddr)
         assert isinstance(self._dst, SCIONAddr)
         pseudo_header = b"".join([
-            self._src.pack(), self._dst.pack(), struct.pack("!B", L4Proto.UDP),
+            self._dst.isd_as.pack(), self._src.isd_as.pack(),
+            self._dst.host.pack(), self._src.host.pack(),
+            struct.pack("!B", L4Proto.UDP),
             self.pack(payload, checksum=bytes(2)), payload,
         ])
         chk_int = scapy.utils.checksum(pseudo_header)

--- a/lib/packet/scmp/hdr.py
+++ b/lib/packet/scmp/hdr.py
@@ -124,7 +124,9 @@ class SCMPHeader(L4HeaderBase):
         assert isinstance(self._src, SCIONAddr)
         assert isinstance(self._dst, SCIONAddr)
         pseudo_header = b"".join([
-            self._src.pack(), self._dst.pack(), struct.pack("!B", L4Proto.SCMP),
+            self._dst.isd_as.pack(), self._src.isd_as.pack(),
+            self._dst.host.pack(), self._src.host.pack(),
+            struct.pack("!B", L4Proto.SCMP),
             self.pack(payload, checksum=bytes(2)), payload,
         ])
         chk_int = scapy.utils.checksum(pseudo_header)

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -193,7 +193,7 @@ class TestClientBase(TestBase):
         logging.debug(self.path_meta)
 
     def _build_pkt(self, path=None):
-        cmn_hdr, addr_hdr = build_base_hdrs(self.addr, self.dst)
+        cmn_hdr, addr_hdr = build_base_hdrs(self.dst, self.addr)
         l4_hdr = self._create_l4_hdr()
         extensions = self._create_extensions()
         if path is None:

--- a/test/integration/cert_req_test.py
+++ b/test/integration/cert_req_test.py
@@ -53,7 +53,7 @@ class TestCertClient(TestClientBase):
         pass  # No path required. All queries go to local CS
 
     def _build_pkt(self):
-        cmn_hdr, addr_hdr = build_base_hdrs(self.addr, self.dst)
+        cmn_hdr, addr_hdr = build_base_hdrs(self.dst, self.addr)
         l4_hdr = self._create_l4_hdr()
         spkt = SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, SCIONPath(), [], l4_hdr)

--- a/test/lib/packet/scion_l4_test.py
+++ b/test/lib/packet/scion_l4_test.py
@@ -37,7 +37,7 @@ class TestParseL4Hdr(object):
     def test_udp(self, udp_hdr):
         data = create_mock(["get", "pop"])
         # Call
-        ntools.eq_(parse_l4_hdr(L4Proto.UDP, data, "src addr", "dst addr"),
+        ntools.eq_(parse_l4_hdr(L4Proto.UDP, data, "dst addr", "src addr"),
                    udp_hdr.return_value)
         # Tests
         udp_hdr.assert_called_once_with((
@@ -47,7 +47,7 @@ class TestParseL4Hdr(object):
     def test_scmp(self, scmp_hdr):
         data = create_mock(["get", "pop"])
         # Call
-        ntools.eq_(parse_l4_hdr(L4Proto.SCMP, data, "src addr", "dst addr"),
+        ntools.eq_(parse_l4_hdr(L4Proto.SCMP, data, "dst addr", "src addr"),
                    scmp_hdr.return_value)
         # Tests
         scmp_hdr.assert_called_once_with((

--- a/test/lib/packet/scion_test.py
+++ b/test/lib/packet/scion_test.py
@@ -1013,12 +1013,12 @@ class TestBuildBaseHdrs(object):
     @patch("lib.packet.scion.SCIONCommonHdr.from_values",
            new_callable=create_mock)
     def test(self, cmn_hdr, addr_hdr):
-        src = create_mock(["host"])
-        src.host = create_mock(["TYPE"])
         dst = create_mock(["host"])
         dst.host = create_mock(["TYPE"])
+        src = create_mock(["host"])
+        src.host = create_mock(["TYPE"])
         # Call
-        ntools.eq_(build_base_hdrs(src, dst),
+        ntools.eq_(build_base_hdrs(dst, dst),
                    (cmn_hdr.return_value, addr_hdr.return_value))
         # Tests
         cmn_hdr.assert_called_once_with(dst.host.TYPE, src.host.TYPE,

--- a/test/lib/packet/scion_test.py
+++ b/test/lib/packet/scion_test.py
@@ -196,15 +196,14 @@ class TestSCIONCommonHdrStr(object):
     @patch("lib.packet.scion.haddr_get_type", autospec=True)
     def test(self, get_type):
         inst = SCIONCommonHdr()
-        inst.version = 0b1111
-        inst.src_addr_type = 0b000000
         inst.dst_addr_type = 0b111111
-        inst.addrs_len = 24
+        inst.src_addr_type = 0b000000
+        inst.version = 0b1111
         inst.total_len = 0x304
+        inst.hdr_len = 0x8
         inst._iof_idx = 3
         inst._hof_idx = 4
         inst.next_hdr = 0x7
-        inst.hdr_len = 0x8
         addr_type = create_mock(['name'])
         addr_type.name.return_value = "name"
         get_type.return_value = addr_type


### PR DESCRIPTION
For https://github.com/netsec-ethz/scion/issues/982

This changes the address header from being: `(src IA, src host, dst IA, dst host)` to `(dst IA, src IA, dst host, src host)`. It also changes the l4 checksum calculations to operate over the entire address header (sans padding) as a block, rather than using the src and dst addresses as separate inputs.

N.B.:
- this does not update `endhost/ssp/`, meaning it is now completely unusable. That code is already broken due to the sciond API changes, and is deprecated in any case. We should remove it soon.
- While the SCION address header order is changing (to be, roughly, `dst,src`), the L4 headers are not. Their ports etc will still be `src,dst`. In the case of UDP/SCION and TCP/SCION, that means we retain greater compatibility with their IP variants. In the case of SCMP etc, it's just for consistency with the other L4 headers.
- The SCMP error codes pertaining to source and destination addresses have been swapped accordingly.

Misc:
- Fixes the counting of failed tests in `docker/integration_test.sh`.
- Improved/fixed some logging in the dispatcher.
- Found 2 memory leaks in `packet.c`'s `reverse_packet()` - i simplified the code and fixed both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1031)
<!-- Reviewable:end -->
