### PR TITLE
Integration tests use local SCIOND

### DIFF
--- a/lib/app/sciond.py
+++ b/lib/app/sciond.py
@@ -229,9 +229,9 @@ class SCIONDConnector:
         socket.settimeout(_SCIOND_TOUT)
         try:
             socket.connect(self._api_addr)
-        except OSError:
+        except OSError as e:
             socket.close()
-            raise SCIONDConnectionError()
+            raise SCIONDConnectionError(str(e))
         return socket
 
     def _get_response(self, socket, expected_id, expected_type):  # pragma: no cover

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -31,13 +31,15 @@ from itertools import product
 
 # SCION
 import lib.app.sciond as lib_sciond
-from endhost.sciond import SCIOND_API_SOCKDIR
-from lib.defines import AS_LIST_FILE, GEN_PATH, SCION_UDP_EH_DATA_PORT
+from lib.defines import (
+    AS_LIST_FILE,
+    GEN_PATH,
+    SCIOND_API_SOCKDIR,
+    SCION_UDP_EH_DATA_PORT
+)
 from lib.log import init_logging
 from lib.main import main_wrapper
-from lib.packet.host_addr import (
-    haddr_parse_interface,
-)
+from lib.packet.host_addr import haddr_parse_interface
 from lib.packet.packet_base import PayloadRaw
 from lib.packet.scion import SCIONL4Packet, build_base_hdrs
 from lib.packet.scion_addr import ISD_AS, SCIONAddr
@@ -59,8 +61,8 @@ class ResponseRV:
 
 
 class TestBase(object, metaclass=ABCMeta):
-    def __init__(self, data, finished, addr, timeout=1.0):
-        self.api_addr = SCIOND_API_SOCKDIR + "sd%s.sock" % (addr.isd_as)
+    def __init__(self, data, finished, addr, timeout=1.0, api_addr=None):
+        self.api_addr = api_addr or (SCIOND_API_SOCKDIR + "sd%s.sock" % (addr.isd_as))
         self.data = data
         self.finished = finished
         self.addr = addr
@@ -111,7 +113,7 @@ class TestClientBase(TestBase):
     Base client app
     """
     def __init__(self, data, finished, addr, dst, dport, api=True,
-                 timeout=3.0, retries=0):
+                 timeout=3.0, retries=0, api_addr=None):
         self.dst = dst
         self.dport = dport
         self.api = api
@@ -119,7 +121,7 @@ class TestClientBase(TestBase):
         self.first_hop = None
         self.retries = retries
         self._req_id = 0
-        super().__init__(data, finished, addr, timeout)
+        super().__init__(data, finished, addr, timeout, api_addr)
         self._get_path(api)
 
     def _get_path(self, api, flush=False):

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -31,7 +31,7 @@ from itertools import product
 
 # SCION
 import lib.app.sciond as lib_sciond
-from endhost.sciond import SCIOND_API_SOCKDIR, SCIONDaemon
+from endhost.sciond import SCIOND_API_SOCKDIR
 from lib.defines import AS_LIST_FILE, GEN_PATH, SCION_UDP_EH_DATA_PORT
 from lib.log import init_logging
 from lib.main import main_wrapper
@@ -59,8 +59,8 @@ class ResponseRV:
 
 
 class TestBase(object, metaclass=ABCMeta):
-    def __init__(self, api_addr, data, finished, addr, timeout=1.0):
-        self.api_addr = api_addr
+    def __init__(self, data, finished, addr, timeout=1.0):
+        self.api_addr = SCIOND_API_SOCKDIR + "sd%s.sock" % (addr.isd_as)
         self.data = data
         self.finished = finished
         self.addr = addr
@@ -68,7 +68,7 @@ class TestBase(object, metaclass=ABCMeta):
         self.sock = self._create_socket(addr)
         assert self.sock
         self.success = None
-        self._connector = lib_sciond.init(api_addr)
+        self._connector = lib_sciond.init(self.api_addr)
 
     @abstractmethod
     def run(self):
@@ -110,7 +110,7 @@ class TestClientBase(TestBase):
     """
     Base client app
     """
-    def __init__(self, api_addr, data, finished, addr, dst, dport, api=True,
+    def __init__(self, data, finished, addr, dst, dport, api=True,
                  timeout=3.0, retries=0):
         self.dst = dst
         self.dport = dport
@@ -119,7 +119,7 @@ class TestClientBase(TestBase):
         self.first_hop = None
         self.retries = retries
         self._req_id = 0
-        super().__init__(api_addr, data, finished, addr, timeout)
+        super().__init__(data, finished, addr, timeout)
         self._get_path(api)
 
     def _get_path(self, api, flush=False):
@@ -141,6 +141,9 @@ class TestClientBase(TestBase):
             try:
                 path_entries = lib_sciond.get_paths(
                     self.dst.isd_as, flags=flags, connector=self._connector)
+            except lib_sciond.SCIONDConnectionError as e:
+                logging.error("Connection to SCIOND failed: %s " % e)
+                break
             except lib_sciond.SCIONDLibError as e:
                 logging.error("Error during path lookup: %s" % e)
                 continue
@@ -251,18 +254,10 @@ class TestClientServerBase(object):
         self.src_ias = sources
         self.dst_ias = destinations
         self.local = local
-        self.scionds = {}
         self.max_runs = max_runs
         self.retries = retries
 
     def run(self):
-        try:
-            self._run()
-        finally:
-            self._stop_scionds()
-        logging.info("All tests successful")
-
-    def _run(self):
         """
         Run a test for every pair of src and dst
         """
@@ -283,6 +278,7 @@ class TestClientServerBase(object):
             t.name = "%s %s > %s main" % (self.NAME, src_ia, dst_ia)
             if not self._run_test(src, dst):
                 sys.exit(1)
+        logging.info("All tests successful")
 
     def _run_test(self, src, dst):
         """
@@ -324,35 +320,13 @@ class TestClientServerBase(object):
         """
         Instantiate server app
         """
-        return TestServerBase(self._run_sciond(addr), data, finished, addr)
+        return TestServerBase(data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
         """
         Instantiate client app
         """
-        return TestClientBase(self._run_sciond(src), data, finished, src, dst,
-                              port, retries=self.retries)
-
-    def _run_sciond(self, addr):
-        api_addr = SCIOND_API_SOCKDIR + "%s_%s.sock" % (
-                self.NAME, addr.isd_as)
-        if addr.isd_as not in self.scionds:
-            logging.debug("Starting sciond for %s", addr.isd_as)
-            # Local api on, random port, random api port
-            self.scionds[addr.isd_as] = start_sciond(
-                addr, api=True, api_addr=api_addr)
-        return api_addr
-
-    def _stop_scionds(self):
-        for sd in self.scionds.values():
-            sd.stop()
-
-
-def start_sciond(addr, api=False, port=0, api_addr=None):
-    conf_dir = "%s/ISD%d/AS%d/endhost" % (
-        GEN_PATH, addr.isd_as[0], addr.isd_as[1])
-    return SCIONDaemon.start(
-        conf_dir, addr.host, api_addr=api_addr, run_local_api=api, port=port)
+        return TestClientBase(data, finished, src, dst, port, retries=self.retries)
 
 
 def _load_as_list():

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -62,7 +62,7 @@ class ResponseRV:
 
 class TestBase(object, metaclass=ABCMeta):
     def __init__(self, data, finished, addr, timeout=1.0, api_addr=None):
-        self.api_addr = api_addr or (SCIOND_API_SOCKDIR + "sd%s.sock" % (addr.isd_as))
+        self.api_addr = api_addr or get_sciond_api_addr(addr)
         self.data = data
         self.finished = finished
         self.addr = addr
@@ -345,6 +345,10 @@ def _parse_locs(as_str, as_list):
     copied = copy.copy(as_list)
     random.shuffle(copied)
     return copied
+
+
+def get_sciond_api_addr(addr):
+    return os.path.join(SCIOND_API_SOCKDIR, "sd%s.sock" % addr.isd_as)
 
 
 def setup_main(name, parser=None):

--- a/test/integration/cert_req_test.py
+++ b/test/integration/cert_req_test.py
@@ -23,6 +23,7 @@ import sys
 import threading
 
 # SCION
+from endhost.sciond import SCIOND_API_SOCKDIR
 import lib.app.sciond as lib_sciond
 from lib.main import main_wrapper
 from lib.packet.cert_mgmt import CertChainRequest, TRCRequest
@@ -38,7 +39,8 @@ from test.integration.base_cli_srv import (
 
 
 class TestCertClient(TestClientBase):
-    def __init__(self, api_addr, finished, addr):
+    def __init__(self, finished, addr):
+        api_addr = SCIOND_API_SOCKDIR + "sd%s.sock" % (addr.isd_as)
         # We need the lib sciond here already.
         connector = lib_sciond.init(api_addr)
         cs_info = lib_sciond.get_service_info(
@@ -46,7 +48,7 @@ class TestCertClient(TestClientBase):
         cs = cs_info.host_info(0)
         cs_addr = SCIONAddr.from_values(addr.isd_as, cs.ipv4() or cs.ipv6())
         self.cert_done = False
-        super().__init__(api_addr, "", finished, addr, cs_addr, cs.p.port)
+        super().__init__("", finished, addr, cs_addr, cs.p.port)
 
     def _get_path(self, api):
         pass  # No path required. All queries go to local CS
@@ -87,7 +89,7 @@ class TestCertClient(TestClientBase):
 class TestCertReq(TestClientServerBase):
     NAME = "CertReqTest"
 
-    def _run(self):
+    def run(self):
         for isd_as in self.src_ias:
             if not self._run_test(isd_as):
                 sys.exit(1)
@@ -104,7 +106,7 @@ class TestCertReq(TestClientServerBase):
         return False
 
     def _create_client(self, finished, addr):
-        return TestCertClient(self._run_sciond(addr), finished, addr)
+        return TestCertClient(finished, addr)
 
 
 def main():

--- a/test/integration/cert_req_test.py
+++ b/test/integration/cert_req_test.py
@@ -23,7 +23,6 @@ import sys
 import threading
 
 # SCION
-from endhost.sciond import SCIOND_API_SOCKDIR
 import lib.app.sciond as lib_sciond
 from lib.main import main_wrapper
 from lib.packet.cert_mgmt import CertChainRequest, TRCRequest
@@ -32,6 +31,7 @@ from lib.packet.scion import SCIONL4Packet, build_base_hdrs
 from lib.packet.scion_addr import SCIONAddr
 from lib.types import ServiceType
 from test.integration.base_cli_srv import (
+    get_sciond_api_addr,
     setup_main,
     TestClientBase,
     TestClientServerBase,
@@ -40,9 +40,8 @@ from test.integration.base_cli_srv import (
 
 class TestCertClient(TestClientBase):
     def __init__(self, finished, addr):
-        api_addr = SCIOND_API_SOCKDIR + "sd%s.sock" % (addr.isd_as)
         # We need the lib sciond here already.
-        connector = lib_sciond.init(api_addr)
+        connector = lib_sciond.init(get_sciond_api_addr(addr))
         cs_info = lib_sciond.get_service_info(
             [ServiceType.CS], connector=connector)[ServiceType.CS]
         cs = cs_info.host_info(0)

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -114,10 +114,10 @@ class TestClientServerExtension(TestClientServerBase):
     NAME = "CliSrvExt"
 
     def _create_server(self, data, finished, addr):
-        return ExtServer(self._run_sciond(addr), data, finished, addr)
+        return ExtServer(data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
-        return ExtClient(self._run_sciond(src), data, finished, src, dst, port)
+        return ExtClient(data, finished, src, dst, port)
 
 
 def main():

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -140,11 +140,10 @@ class TestEnd2End(TestClientServerBase):
     NAME = "End2End"
 
     def _create_server(self, data, finished, addr):
-        return E2EServer(self._run_sciond(addr), data, finished, addr)
+        return E2EServer(data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
-        return E2EClient(self._run_sciond(src), data, finished, src, dst, port,
-                         retries=self.retries)
+        return E2EClient(data, finished, src, dst, port, retries=self.retries)
 
 
 def main():

--- a/test/integration/mpudp_test.py
+++ b/test/integration/mpudp_test.py
@@ -131,11 +131,10 @@ class TestMPUDP(TestClientServerBase):
     NAME = "MPUDP"
 
     def _create_server(self, data, finished, addr):
-        return MPUDPServer(self._run_sciond(addr), data, finished, addr)
+        return MPUDPServer(data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
-        return MPUDPClient(self._run_sciond(src), data, finished, src, dst,
-                           port)
+        return MPUDPClient(data, finished, src, dst, port)
 
 
 def main():

--- a/test/integration/scmp_echo_test.py
+++ b/test/integration/scmp_echo_test.py
@@ -95,11 +95,10 @@ class TestSCMPEcho(TestClientServerBase):
         self.thread_name = "E2E.MainThread"
 
     def _create_server(self, data, finished, addr):
-        return SCMPEchoServer(self._run_sciond(addr), data, finished, addr)
+        return SCMPEchoServer(data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
-        return SCMPEchoClient(self._run_sciond(src), data, finished, src, dst,
-                              port)
+        return SCMPEchoClient(data, finished, src, dst, port)
 
 
 def main():

--- a/test/integration/scmp_error_test.py
+++ b/test/integration/scmp_error_test.py
@@ -368,8 +368,8 @@ class SCMPErrorTest(TestClientServerBase):
         data = ("%s<->%s" % (src, dst)).encode("UTF-8")
         for cls_ in GEN_LIST:
             logging.info("===========> Testing: %s", cls_.DESC)
-            client = cls_(self._run_sciond(src), copy.deepcopy(data), None,
-                          copy.deepcopy(src), copy.deepcopy(dst), 0, api=True)
+            client = cls_(copy.deepcopy(data), None, copy.deepcopy(src),
+                          copy.deepcopy(dst), 0, api=True)
             if not client.run():
                 return False
         return True

--- a/test/integration/sibra_ext_test.py
+++ b/test/integration/sibra_ext_test.py
@@ -174,11 +174,10 @@ class SIBRATest(TestClientServerBase):
         return super()._check_result(client, server)
 
     def _create_server(self, data, finished, addr):
-        return SibraServer(self._run_sciond(addr), data, finished, addr)
+        return SibraServer(data, finished, addr)
 
     def _create_client(self, data, finished, src, dst, port):
-        return SibraClient(self._run_sciond(src), data, finished, src, dst,
-                           port)
+        return SibraClient(data, finished, src, dst, port)
 
 
 def main():

--- a/test/integration/ssp_test.py
+++ b/test/integration/ssp_test.py
@@ -153,12 +153,10 @@ class TestSSP(TestClientServerBase):
     NAME = "SSP"
 
     def _create_server(self, data, finished, addr):
-        return SSPServer(self._run_sciond(addr), data, finished, addr,
-                         timeout=6.0)
+        return SSPServer(data, finished, addr, timeout=6.0)
 
     def _create_client(self, data, finished, src, dst, port):
-        return SSPClient(self._run_sciond(src), data, finished, src, dst, port,
-                         timeout=6.0)
+        return SSPClient(data, finished, src, dst, port, timeout=6.0)
 
 
 def main():


### PR DESCRIPTION
Make integration tests use the local SCIOND instance that gets spawned as part of the infrastructure. Also _try_sciond_api now stops trying to get a path when the connection to SCIOND fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1034)
<!-- Reviewable:end -->
