### PR TITLE
Locking for router config

### DIFF
--- a/go/border/conf/conf.go
+++ b/go/border/conf/conf.go
@@ -36,10 +36,6 @@ import (
 
 // Conf is the main config structure.
 type Conf struct {
-	// Every time something from Conf is read (modified), the read(write) lock has to
-	// be acquired. EXCEPTION: Reading IA doesn't need a lock, since that information
-	// cannot change over the lifetime of the router.
-	sync.RWMutex
 	// TopoMeta contains the names of all local infrastructure elements, a map
 	// of interface IDs to routers, and the actual topology.
 	TopoMeta *topology.TopoMeta

--- a/go/border/error.go
+++ b/go/border/error.go
@@ -58,8 +58,9 @@ func (r *Router) handlePktError(rp *rpkt.RtrPkt, perr *common.Error, desc string
 	if err != nil {
 		return
 	}
+	config := conf.GetConfig()
 	// Certain errors are not respondable to if the source lies in a remote AS.
-	if !srcIA.Eq(conf.C.IA) {
+	if !srcIA.Eq(config.IA) {
 		switch sdata.CT.Class {
 		case scmp.C_CmnHdr:
 			switch sdata.CT.Type {
@@ -123,7 +124,8 @@ func (r *Router) createSCMPErrorReply(rp *rpkt.RtrPkt, ct scmp.ClassType,
 		return nil, err
 	}
 	// Only (potentially) call IncPath if the dest is not in the local AS.
-	if !dstIA.Eq(conf.C.IA) {
+	config := conf.GetConfig()
+	if !dstIA.Eq(config.IA) {
 		hopF, err := reply.HopF()
 		if err != nil {
 			return nil, err
@@ -173,7 +175,8 @@ func (r *Router) createReplyScnPkt(rp *rpkt.RtrPkt) (*spkt.ScnPkt, *common.Error
 		return nil, err
 	}
 	// Use the ingress address as the source host
-	sp.SrcIA = conf.C.IA
+	config := conf.GetConfig()
+	sp.SrcIA = config.IA
 	sp.SrcHost = addr.HostFromIP(rp.Ingress.Dst.IP)
 	return sp, nil
 }
@@ -181,8 +184,9 @@ func (r *Router) createReplyScnPkt(rp *rpkt.RtrPkt) (*spkt.ScnPkt, *common.Error
 // replyEgress calculates the corresponding egress function and destination
 // address to use when replying to a packet.
 func (r *Router) replyEgress(rp *rpkt.RtrPkt) (rpkt.EgressPair, *common.Error) {
+	config := conf.GetConfig()
 	if rp.DirFrom == rpkt.DirLocal {
-		locIdx := conf.C.Net.LocAddrMap[rp.Ingress.Dst.String()]
+		locIdx := config.Net.LocAddrMap[rp.Ingress.Dst.String()]
 		return rpkt.EgressPair{F: r.locOutFs[locIdx], Dst: rp.Ingress.Src}, nil
 	}
 	intf, err := rp.IFCurr()

--- a/go/border/ifid.go
+++ b/go/border/ifid.go
@@ -44,7 +44,8 @@ func (r *Router) SyncInterface() {
 }
 
 func (r *Router) GenIFIDPkts() {
-	for ifid := range conf.C.Net.IFs {
+	config := conf.GetConfig()
+	for ifid := range config.Net.IFs {
 		r.GenIFIDPkt(ifid)
 	}
 }
@@ -52,11 +53,12 @@ func (r *Router) GenIFIDPkts() {
 // GenIFIDPkt generates IFID packets.
 func (r *Router) GenIFIDPkt(ifid spath.IntfID) {
 	logger := log.New("ifid", ifid)
-	intf := conf.C.Net.IFs[ifid]
+	config := conf.GetConfig()
+	intf := config.Net.IFs[ifid]
 	srcAddr := intf.IFAddr.PublicAddr()
 	// Create base packet
 	rp, err := rpkt.RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
+		SrcIA: config.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
 		DstIA: intf.RemoteIA, DstHost: addr.HostFromIP(intf.RemoteAddr.IP),
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: uint16(intf.RemoteAddr.Port)},
 	}, rpkt.DirExternal)

--- a/go/border/ifstate.go
+++ b/go/border/ifstate.go
@@ -54,13 +54,14 @@ func (r *Router) IFStateUpdate() {
 // GenIFStateReq generates an Interface State request packet to the local
 // beacon service.
 func (r *Router) GenIFStateReq() {
+	config := conf.GetConfig()
 	// Pick first local address from topology as source.
-	srcAddr := conf.C.Net.LocAddr[0].PublicAddr()
+	srcAddr := config.Net.LocAddr[0].PublicAddr()
 	dstHost := addr.SvcBS.Multicast()
 	// Create base packet
 	rp, err := rpkt.RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
-		DstIA: conf.C.IA, DstHost: dstHost,
+		SrcIA: config.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
+		DstIA: config.IA, DstHost: dstHost,
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: 0},
 	}, rpkt.DirLocal)
 	if err != nil {
@@ -117,7 +118,8 @@ func (r *Router) ProcessIFStates(ifStates proto.IFStateInfos) {
 		}
 	}
 	// Lock local IFState config for writing, and replace existing map
-	conf.C.IFStates.Lock()
-	conf.C.IFStates.M = m
-	conf.C.IFStates.Unlock()
+	config := conf.GetConfig()
+	config.IFStates.Lock()
+	config.IFStates.M = m
+	config.IFStates.Unlock()
 }

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -84,12 +84,13 @@ func (r *Router) decodeRevToken(b common.RawBytes) *proto.RevInfo {
 
 // fwdRevInfo forwards RevInfo payloads to a designated local host.
 func (r *Router) fwdRevInfo(revInfo *proto.RevInfo, dstHost addr.HostAddr) {
+	config := conf.GetConfig()
 	// Pick first local address from topology as source.
-	srcAddr := conf.C.Net.LocAddr[0].PublicAddr()
+	srcAddr := config.Net.LocAddr[0].PublicAddr()
 	// Create base packet
 	rp, err := rpkt.RtrPktFromScnPkt(&spkt.ScnPkt{
-		SrcIA: conf.C.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
-		DstIA: conf.C.IA, DstHost: dstHost,
+		SrcIA: config.IA, SrcHost: addr.HostFromIP(srcAddr.IP),
+		DstIA: config.IA, DstHost: dstHost,
 		L4: &l4.UDP{SrcPort: uint16(srcAddr.Port), DstPort: 0},
 	}, rpkt.DirLocal)
 	if err != nil {

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -60,11 +60,12 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		return HookError, nil, err
 	}
 	// Retrieve the previous HopF, create a new HopF for this AS, and write it into the path header.
+	config := conf.GetConfig()
 	prevIdx := o.rp.CmnHdr.CurrHopF - spath.HopFieldLength
 	prevHof := o.rp.Raw[prevIdx+1 : o.rp.CmnHdr.CurrHopF]
-	inIF := conf.C.Net.IFAddrMap[o.rp.Ingress.Dst.String()]
+	inIF := config.Net.IFAddrMap[o.rp.Ingress.Dst.String()]
 	hopF := spath.NewHopField(o.rp.Raw[o.rp.CmnHdr.CurrHopF:], inIF, 0)
-	mac, err := hopF.CalcMac(conf.C.HFGenBlock, infoF.TsInt, prevHof)
+	mac, err := hopF.CalcMac(config.HFGenBlock, infoF.TsInt, prevHof)
 	if err != nil {
 		return HookError, nil, err
 	}

--- a/go/border/rpkt/extn_traceroute.go
+++ b/go/border/rpkt/extn_traceroute.go
@@ -105,7 +105,7 @@ func (t *rTraceroute) Process() (HookResult, *common.Error) {
 	// Take the current time in milliseconds, and truncate it to 16bits.
 	ts := (time.Now().UnixNano() / 1000) % (1 << 16)
 	entry := spkt.TracerouteEntry{
-		IA: *conf.C.IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
+		IA: *conf.GetConfig().IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
 	}
 	if err := t.Add(&entry); err != nil {
 		t.Error("Unable to add entry", err)

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -41,7 +41,8 @@ func (rp *RtrPkt) Parse() *common.Error {
 	if _, err := rp.DstIA(); err != nil {
 		return err
 	}
-	if *rp.dstIA == *conf.C.IA {
+	config := conf.GetConfig()
+	if *rp.dstIA == *config.IA {
 		// If the destination is local, parse the destination host as well.
 		if _, err := rp.DstHost(); err != nil {
 			return err
@@ -62,7 +63,7 @@ func (rp *RtrPkt) Parse() *common.Error {
 	if _, err := rp.IFNext(); err != nil {
 		return err
 	}
-	if *rp.dstIA != *conf.C.IA {
+	if *rp.dstIA != *config.IA {
 		// If the destination isn't local, parse the next interface ID as well.
 		if _, err := rp.IFNext(); err != nil {
 			return err
@@ -154,7 +155,8 @@ func (rp *RtrPkt) setDirTo() {
 		assert.Must(rp.DirFrom != DirUnset, rp.ErrStr("DirFrom must not be DirUnset."))
 		assert.Must(rp.ifCurr != nil, rp.ErrStr("rp.ifCurr must not be nil."))
 	}
-	if *rp.dstIA != *conf.C.IA {
+	config := conf.GetConfig()
+	if *rp.dstIA != *config.IA {
 		// Packet is not destined to the local AS, so it can't be DirSelf.
 		if rp.DirFrom == DirLocal {
 			rp.DirTo = DirExternal
@@ -166,12 +168,12 @@ func (rp *RtrPkt) setDirTo() {
 		return
 	}
 	// Local AS is the destination, so figure out if it's DirLocal or DirSelf.
-	intf := conf.C.Net.IFs[*rp.ifCurr]
+	intf := config.Net.IFs[*rp.ifCurr]
 	var intfHost addr.HostAddr
 	if rp.DirFrom == DirExternal {
 		intfHost = addr.HostFromIP(intf.IFAddr.PublicAddr().IP)
 	} else {
-		intfHost = addr.HostFromIP(conf.C.Net.LocAddr[intf.LocAddrIdx].PublicAddr().IP)
+		intfHost = addr.HostFromIP(config.Net.LocAddr[intf.LocAddrIdx].PublicAddr().IP)
 	}
 	if addr.HostEq(rp.dstHost, intfHost) {
 		rp.DirTo = DirSelf

--- a/go/border/rpkt/validate.go
+++ b/go/border/rpkt/validate.go
@@ -32,7 +32,7 @@ const (
 // Validate performs basic validation of a packet, including calling any
 // registered validation hooks.
 func (rp *RtrPkt) Validate() *common.Error {
-	intf, ok := conf.C.Net.IFs[*rp.ifCurr]
+	intf, ok := conf.GetConfig().Net.IFs[*rp.ifCurr]
 	if !ok {
 		return common.NewError(errCurrIntfInvalid, "ifid", *rp.ifCurr)
 	}

--- a/go/border/setup-hsr.go
+++ b/go/border/setup-hsr.go
@@ -66,8 +66,9 @@ func setupHSRAddLocal(r *Router, idx int, over *overlay.UDP,
 	if _, hsr := hsrIPMap[bind.IP.String()]; !hsr {
 		return rpkt.HookContinue, nil
 	}
+	config := conf.GetConfig()
 	var ifids []spath.IntfID
-	for _, intf := range conf.C.Net.IFs {
+	for _, intf := range config.Net.IFs {
 		if intf.LocAddrIdx == idx {
 			ifids = append(ifids, intf.Id)
 		}
@@ -98,7 +99,7 @@ func setupHSRNetFinish(r *Router) (rpkt.HookResult, *common.Error) {
 	if len(hsrAddrMs) == 0 {
 		return rpkt.HookContinue, nil
 	}
-	err := hsr.Init(filepath.Join(conf.C.Dir, fmt.Sprintf("%s.zlog.conf", r.Id)),
+	err := hsr.Init(filepath.Join(conf.GetConfig().Dir, fmt.Sprintf("%s.zlog.conf", r.Id)),
 		flag.Args(), hsrAddrMs)
 	if err != nil {
 		return rpkt.HookError, err


### PR DESCRIPTION
This PR adds a lock around the router config to prepare for updating topology information without restarting the router.

There now is a package level lock in `conf` and the global configuration object can only be acquired by calling `conf.GetConfig()` which protects access to the configuration object by a RWMutex. When loading a new config, the new config first gets completely loaded before the global reference is updated (protected by a write lock).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1037)
<!-- Reviewable:end -->
