### PR TITLE
Don't use docker run --privileged.

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -67,7 +67,7 @@ cmd_clean() {
 }
 
 cmd_run() {
-    local args="-i -t --privileged -h scion"
+    local args="-i -t -h scion --tmpfs /run/shm:size=25% $DOCKER_ARGS"
     args+=" -v $PWD/htmlcov:/home/scion/go/src/github.com/netsec-ethz/scion/htmlcov"
     args+=" -v $PWD/logs:/home/scion/go/src/github.com/netsec-ethz/scion/logs"
     args+=" -v $PWD/sphinx-doc/_build:/home/scion/go/src/github.com/netsec-ethz/scion/sphinx-doc/_build"

--- a/docker.sh
+++ b/docker.sh
@@ -67,7 +67,8 @@ cmd_clean() {
 }
 
 cmd_run() {
-    local args="-i -t -h scion --tmpfs /run/shm:size=25% $DOCKER_ARGS"
+    # Allow container to mount filesystems: https://github.com/docker/docker/issues/9950#issuecomment-176480007
+    local args="-i -t -h scion $DOCKER_ARGS --security-opt apparmor:unconfined --cap-add SYS_ADMIN"
     args+=" -v $PWD/htmlcov:/home/scion/go/src/github.com/netsec-ethz/scion/htmlcov"
     args+=" -v $PWD/logs:/home/scion/go/src/github.com/netsec-ethz/scion/logs"
     args+=" -v $PWD/sphinx-doc/_build:/home/scion/go/src/github.com/netsec-ethz/scion/sphinx-doc/_build"

--- a/docker/profile
+++ b/docker/profile
@@ -10,11 +10,6 @@ alias cdscion="cd $BASEDIR"
 # Note: you still can't /re-attach/ to a screen session.
 tty &>/dev/null && exec >/dev/tty 2>/dev/tty </dev/tty
 
-# Setup environment
-# LTS 16 does not have this directory, so make it
-sudo mkdir -p /run/shm
-sudo mount -t tmpfs -o size=25% none /run/shm
-
 # Can't be fixed during build due to
 # https://github.com/docker/docker/issues/6828
 sudo chmod g+s /usr/bin/screen

--- a/topology/mininet/README.md
+++ b/topology/mininet/README.md
@@ -21,3 +21,9 @@ Once you're done looking around, you can type Ctrl+D to shutdown the Mininet env
 ```
 user@ubuntu:~/scion$ sudo mn -c
 ```
+
+### Running inside docker
+If you want to run the mininet network inside docker, you need to make sure docker is using the `--privileged` flag. You can specify it like this:
+```
+DOCKER_ARGS=--privileged ./docker.sh run
+```

--- a/topology/mininet/pkgs_debian.txt
+++ b/topology/mininet/pkgs_debian.txt
@@ -1,3 +1,4 @@
+iproute
 iputils-ping
 mininet
 unzip


### PR DESCRIPTION
As of friday, `docker run --privileged ...` fails on circleci for
unclear reasons. While trying to work around this, i discovered that by
specifying a tmpfs for docker to mount, we don't actually _need_
--privileged for normal operation.

NB: the one thing that this breaks is mininet support. To run mininet
inside docker, use:

  `DOCKER_ARGS=--privileged ./docker.sh run`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1040)
<!-- Reviewable:end -->
