### PR TITLE
Fix a long-standing subtle timing bug in lib.requests

### DIFF
--- a/lib/requests.py
+++ b/lib/requests.py
@@ -97,7 +97,6 @@ class RequestHandler(object):
                 self._answer_reqs(k)
 
     def _add_req(self, key, request):
-        self._req_map.setdefault(key, [])
         self._expire_reqs(key)
         if not self._check(key):
             self._fetch(key, request)

--- a/lib/requests.py
+++ b/lib/requests.py
@@ -99,9 +99,7 @@ class RequestHandler(object):
     def _add_req(self, key, request):
         self._req_map.setdefault(key, [])
         self._expire_reqs(key)
-        if not self._check(key) and len(self._req_map[key]) == 0:
-            # Don't already have the answer, and there were no outstanding
-            # requests, so send a new query
+        if not self._check(key):
             self._fetch(key, request)
         self._req_map[key].append((SCIONTime.get_time(), request))
 

--- a/test/lib/requests_test.py
+++ b/test/lib/requests_test.py
@@ -27,7 +27,7 @@ import nose.tools as ntools
 from lib.requests import (
     RequestHandler,
 )
-from test.testcommon import assert_these_calls, create_mock
+from test.testcommon import assert_these_calls, create_mock, create_mock_full
 
 
 class TestRequestHandlerRun(object):
@@ -54,9 +54,8 @@ class TestRequestHandlerAddReq(object):
     """
     Unit tests for lib.requests.RequestHandler._add_req
     """
-    def _setup(self, time_, check_ret=False):
-        check = create_mock()
-        check.return_value = check_ret
+    def _setup(self, time_, check_ret):
+        check = create_mock_full(return_value=check_ret)
         fetch = create_mock()
         inst = RequestHandler("queue", check, fetch, "reply")
         inst._expire_reqs = create_mock()
@@ -65,7 +64,7 @@ class TestRequestHandlerAddReq(object):
 
     @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
     def test_no_ans_no_query(self, time_):
-        inst = self._setup(time_)
+        inst = self._setup(time_, False)
         # Call
         inst._add_req("key", "req")
         # Tests
@@ -75,18 +74,8 @@ class TestRequestHandlerAddReq(object):
         ntools.eq_(inst._req_map["key"], [(2, "req")])
 
     @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
-    def test_no_ans_query(self, time_):
-        inst = self._setup(time_)
-        inst._req_map["key"] = [(1, "oldreq")]
-        # Call
-        inst._add_req("key", "req")
-        # Tests
-        ntools.assert_false(inst._fetch.called)
-        ntools.eq_(inst._req_map["key"], [(1, "oldreq"), (2, "req")])
-
-    @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
     def test_ans(self, time_):
-        inst = self._setup(time_)
+        inst = self._setup(time_, True)
         inst._req_map["key"] = [(1, "oldreq")]
         # Call
         inst._add_req("key", "req")


### PR DESCRIPTION
If lib.requests gets requests for X faster than the requests expire, and
if the first query it sends doesn't succeed, no new query is sent. This
has been seen to cause up to ~30s between path queries sent by sciond,
for example.

This patch is a simple but brute-force fix - every request now causes a
query to be sent. In the future we will want more intelligent handling
of repeated queries, but this will at least fix this bug for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1044)
<!-- Reviewable:end -->
