### PR TITLE
Limit docker to 4G of ram, increase shm size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
 
     build:
         docker:
-            - image: kormat/scion_base@sha256:ebd4289cb7a56cddcd7e2a1a3fbc098283b47f40d7fb0f1cc2b037f1b48d33b8
+            - image: kormat/scion_base@sha256:43229a96484225cfcf93c2dd0f76d0d676978cec44c0dc4dc03c1ca437f420f8
         <<: *job
         steps:
             - checkout

--- a/docker.sh
+++ b/docker.sh
@@ -77,7 +77,8 @@ cmd_clean() {
 }
 
 cmd_run() {
-    local args="-i -t -h scion $DOCKER_ARGS"
+    # Limit to 4G of ram, don't allow swapping.
+    local args="-i -t -h scion -m 4096M --memory-swap=4096M --shm-size=1024M $DOCKER_ARGS"
     args+=" -v $PWD/htmlcov:/home/scion/go/src/github.com/netsec-ethz/scion/htmlcov"
     args+=" -v $PWD/logs:/home/scion/go/src/github.com/netsec-ethz/scion/logs"
     args+=" -v $PWD/sphinx-doc/_build:/home/scion/go/src/github.com/netsec-ethz/scion/sphinx-doc/_build"


### PR DESCRIPTION
This matches the ram limit on circleci, and prevents zookeeper from
running out of space in the default 64MB /dev/shm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1058)
<!-- Reviewable:end -->
