### PR TITLE
Fix two type bugs in extension handling in Go

### DIFF
--- a/go/border/rpkt/extn_traceroute.go
+++ b/go/border/rpkt/extn_traceroute.go
@@ -58,7 +58,7 @@ func (t *rTraceroute) Add(entry *spkt.TracerouteEntry) *common.Error {
 	if t.NumHops == t.TotalHops {
 		return common.NewError("Header already full", "entries", t.NumHops)
 	}
-	offset := common.ExtnFirstLineLen + common.LineLen*t.NumHops
+	offset := common.ExtnFirstLineLen + common.LineLen*int(t.NumHops)
 	entry.IA.Write(t.raw[offset:])
 	offset += addr.IABytes
 	common.Order.PutUint16(t.raw[offset:], entry.IfID)
@@ -108,7 +108,8 @@ func (t *rTraceroute) Process() (HookResult, *common.Error) {
 		IA: *conf.C.IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
 	}
 	if err := t.Add(&entry); err != nil {
-		t.Error("Unable to add entry", err)
+		err.Ctx = append(err.Ctx, "raw", t.rp.Raw)
+		t.Error("Unable to add entry", err.Ctx...)
 	}
 	// Update the raw buffer with the number of hops.
 	t.raw[0] = t.NumHops

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -126,7 +126,7 @@ func (rp *RtrPkt) parseHopExtns() *common.Error {
 			break
 		}
 		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[*offset+2]}
-		hdrLen := int((rp.Raw[*offset+1] + 1) * common.LineLen)
+		hdrLen := (int(rp.Raw[*offset+1]) + 1) * common.LineLen
 		e, err := rp.extnParseHBH(
 			currExtn, *offset+common.ExtnSubHdrLen, *offset+hdrLen, len(rp.idxs.hbhExt))
 		if err != nil {

--- a/lib/packet/ext/traceroute.py
+++ b/lib/packet/ext/traceroute.py
@@ -27,7 +27,7 @@ from lib.types import ExtHopByHopType
 
 class TracerouteExt(HopByHopExtension):
     """
-    0          8         16       24        32            48               64
+    0b         8         16       24        32            48               64
     | next hdr | hdr len |  0x00  | hops_no |         (padding)            |
     |    ISD_0      |          AS_0         |    IFID_0   |   Timestamp_0  |
     |    ISD_1      |          AS_1         |    IFID_1   |   Timestamp_1  |

--- a/tools/pktprint.py
+++ b/tools/pktprint.py
@@ -26,7 +26,7 @@ import lib.packet.scion
 
 raw = "".join(sys.argv[1].split())
 hexes = bytes.fromhex(raw)
-p = lib.packet.scion.SCIONBasePacket(hexes)
+p = lib.packet.scion.SCIONExtPacket(hexes)
 print("=============> Packet:\n%s" % p)
 print("=============> Validate: %s" % p.validate(len(hexes)))
 print("=============> Payload:\n%s" % p.parse_payload())


### PR DESCRIPTION
Also fix a logging statement, and switch pktprint to using
SCIONExtPacket so that extension headers are parsed and printed as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1063)
<!-- Reviewable:end -->
