### PR TITLE
Fix handling of timeouts in sciond

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -196,6 +196,7 @@ class SCIONDaemon(SCIONElement):
         if not ret:
             return
         with self.req_path_lock:
+            # .items() makes a copy on an expiring dict, so deleting entries is safe.
             for key, e in self.requested_paths.items():
                 if self.path_resolution(*key):
                     e.set()


### PR DESCRIPTION
Sciond currently never removes a timed-out query from
self.requested_paths. This means that any future queries for that
destination will never cause sciond to send queries to the path server.
This change fixes that by switching to an expiring dict, which will
naturally clean up old queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1065)
<!-- Reviewable:end -->
