### PR TITLE
Few prerequisites for #952

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -577,7 +577,7 @@ class SCIONDaemon(SCIONElement):
             return
         req = PathSegmentReq.from_values(self.addr.isd_as, dst_ia, flags=flags)
         logging.debug("Sending path request (%s) to [%s]:%s", req.short_desc(), addr, port)
-        meta = self.DefaultMeta.from_values(host=addr, port=port)
+        meta = self._build_meta(host=addr, port=port)
         self.send_meta(req, meta)
 
     def _calc_core_segs(self, dst_isd, up_segs, down_segs):

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -47,10 +47,8 @@ from lib.errors import (
     SCIONParseError,
     SCIONServiceLookupError,
 )
-from lib.flagtypes import TCPFlags
-from lib.msg_meta import TCPMetadata, UDPMetadata
+from lib.msg_meta import UDPMetadata
 from lib.path_seg_meta import PathSegMeta
-from lib.packet.ext.one_hop_path import OneHopPathExt
 from lib.packet.opaque_field import HopOpaqueField, InfoOpaqueField
 from lib.packet.path import SCIONPath
 from lib.packet.path_mgmt.ifstate import (
@@ -203,13 +201,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         pcb.add_asm(asm)
         pcb.sign(self.signing_key)
         one_hop_path = self._create_one_hop_path(egress_if)
-        if self.DefaultMeta == TCPMetadata:
-            return pcb, self.DefaultMeta.from_values(
-                ia=dst_ia, host=SVCType.BS_A, path=one_hop_path,
-                flags=TCPFlags.ONEHOPPATH)
-        return pcb, UDPMetadata.from_values(
-            ia=dst_ia, host=SVCType.BS_A, path=one_hop_path,
-            ext_hdrs=[OneHopPathExt()])
+        return pcb, self._build_meta(ia=dst_ia, host=SVCType.BS_A,
+                                     path=one_hop_path, one_hop=True)
 
     def _create_one_hop_path(self, egress_if):
         ts = int(SCIONTime.get_time())

--- a/infrastructure/beacon_server/core.py
+++ b/infrastructure/beacon_server/core.py
@@ -113,10 +113,10 @@ class CoreBeaconServer(BeaconServer):
             # If there are no local path servers, stop here.
             return
         records = PathRecordsReg.from_values({PST.CORE: [pcb]})
-        meta = self.DefaultMeta.from_values(host=addr, port=port)
+        meta = self._build_meta(host=addr, port=port, reuse=True)
         self.send_meta(records.copy(), meta)
         addr, port = self.dns_query_topo(SIBRA_SERVICE)[0]
-        meta = self.DefaultMeta.from_values(host=addr, port=port)
+        meta = self._build_meta(host=addr, port=port, reuse=True)
         self.send_meta(records, meta)
 
     def _filter_pcb(self, pcb, dst_ia=None):

--- a/infrastructure/beacon_server/local.py
+++ b/infrastructure/beacon_server/local.py
@@ -59,10 +59,10 @@ class LocalBeaconServer(BeaconServer):
         """
         records = PathRecordsReg.from_values({PST.UP: [pcb]})
         addr, port = self.dns_query_topo(PATH_SERVICE)[0]
-        meta = self.DefaultMeta.from_values(host=addr, port=port)
+        meta = self._build_meta(host=addr, port=port)
         self.send_meta(records.copy(), meta)
         addr, port = self.dns_query_topo(SIBRA_SERVICE)[0]
-        meta = self.DefaultMeta.from_values(host=addr, port=port)
+        meta = self._build_meta(host=addr, port=port)
         self.send_meta(records, meta)
 
     def register_down_segment(self, pcb):
@@ -72,8 +72,7 @@ class LocalBeaconServer(BeaconServer):
         core_path = pcb.get_path(reverse_direction=True)
         records = PathRecordsReg.from_values({PST.DOWN: [pcb]})
         dst_ia = pcb.asm(0).isd_as()
-        meta = self.DefaultMeta.from_values(
-            ia=dst_ia, host=SVCType.PS_A, path=core_path)
+        meta = self._build_meta(ia=dst_ia, host=SVCType.PS_A, path=core_path, reuse=True)
         self.send_meta(records, meta)
 
     def register_segments(self):

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -438,8 +438,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         src_ia = pcb.first_ia()
         while targets:
             seg_req = targets.pop(0)
-            meta = self.DefaultMeta.from_values(ia=src_ia, path=path,
-                                                host=SVCType.PS_A)
+            meta = self._build_meta(ia=src_ia, path=path, host=SVCType.PS_A, reuse=True)
             self.send_meta(seg_req, meta)
             logging.info("Waiting request (%s) sent via %s",
                          seg_req.short_desc(), pcb.short_desc())

--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -193,7 +193,7 @@ class CorePathServer(PathServer):
             logging.warning("send_to_master: abandoning as there is no master")
             return
         addr, port = master.addr(0)
-        meta = self.DefaultMeta.from_values(host=addr, port=port)
+        meta = self._build_meta(host=addr, port=port, reuse=True)
         self.send_meta(pld.copy(), meta)
 
     def _query_master(self, dst_ia, src_ia=None, flags=()):
@@ -228,8 +228,8 @@ class CorePathServer(PathServer):
                 logging.warning("Segment to AS %s not found.", isd_as)
                 continue
             cseg = csegs[0].get_path(reverse_direction=True)
-            meta = self.DefaultMeta.from_values(ia=isd_as, path=cseg,
-                                                host=SVCType.PS_A)
+            meta = self._build_meta(ia=isd_as, path=cseg,
+                                    host=SVCType.PS_A, reuse=True)
             self.send_meta(rep_recs.copy(), meta)
 
     def path_resolution(self, req, meta, new_request=True):
@@ -343,8 +343,8 @@ class CorePathServer(PathServer):
             logging.info("Down-Segment request for different ISD, "
                          "forwarding request to CPS in %s via %s",
                          dst_ia, cseg.short_desc())
-            meta = self.DefaultMeta.from_values(ia=dst_ia, path=path,
-                                                host=SVCType.PS_A)
+            meta = self._build_meta(ia=dst_ia, path=path,
+                                    host=SVCType.PS_A, reuse=True)
             self.send_meta(seg_req, meta)
         else:
             # If no core segment was available, add request to waiting targets.

--- a/infrastructure/path_server/local.py
+++ b/infrastructure/path_server/local.py
@@ -151,8 +151,8 @@ class LocalPathServer(PathServer):
         logging.info('Send request to core (%s) via %s',
                      req.short_desc(), pcb.short_desc())
         path = pcb.get_path(reverse_direction=True)
-        meta = self.DefaultMeta.from_values(ia=pcb.first_ia(), path=path,
-                                            host=SVCType.PS_A)
+        meta = self._build_meta(ia=pcb.first_ia(), path=path,
+                                host=SVCType.PS_A, reuse=True)
         self.send_meta(req.copy(), meta)
 
     def _forward_revocation(self, rev_info, meta):
@@ -180,6 +180,5 @@ class LocalPathServer(PathServer):
         path = seg.get_path(reverse_direction=True)
         logging.info("Forwarding Revocation to %s using path:\n%s" %
                      (core_ia, seg.short_desc()))
-        meta = self.DefaultMeta.from_values(ia=core_ia, path=path,
-                                            host=SVCType.PS_A)
+        meta = self._build_meta(ia=core_ia, path=path, host=SVCType.PS_A)
         self.send_meta(rev_info.copy(), meta)

--- a/lib/msg_meta.py
+++ b/lib/msg_meta.py
@@ -30,13 +30,15 @@ class MetadataBase(object):
         self.ext_hdr = ()
 
     @classmethod
-    def from_values(cls, ia=None, host=None, path=None, ext_hdrs=(), port=0):
+    def from_values(cls, ia=None, host=None, path=None, ext_hdrs=(),
+                    reuse=False, port=0):
         inst = cls()
         inst.ia = ia
         inst.host = host
         inst.path = path
         inst.ext_hdrs = ext_hdrs
         inst.port = port
+        inst.reuse = reuse  # Indicates to reuse a socket (useful for TCP)
         return inst
 
     def get_addr(self):


### PR DESCRIPTION
This PR:
- increases limit for open files in dispatcher. Dispatcher opens many files and with TCP (during a heavy load) it goes beyond the default limit (1024)
- introduces `_build_meta()` for creating UDP/TCP meta objects
- introduces the `reuse` flag, that allows to indicate that a given msg should be sent via a shared (TCP) socket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1067)
<!-- Reviewable:end -->
