### PR TITLE
Display zk party members usefully.

### DIFF
--- a/lib/zk/party.py
+++ b/lib/zk/party.py
@@ -17,12 +17,14 @@
 """
 # Stdlib
 import logging
+from base64 import b64decode
 
 # External packages
 from kazoo.exceptions import ConnectionLoss, SessionExpiredError
 
 # SCION
 from lib.zk.errors import ZkNoConnection
+from lib.zk.id import ZkID
 
 
 class ZkParty(object):
@@ -63,10 +65,12 @@ class ZkParty(object):
         """If the autojoin parameter was set to True, join the party."""
         if self._autojoin:
             self.join()
-        entries = self.list()
-        names = set([entry.split("\0")[0] for entry in entries])
+        entries = []
+        for e in self.list():
+            raw = b64decode(e)
+            entries.append(ZkID.from_raw(raw))
         logging.debug("Current party (%s) members are: %s", self._path,
-                      sorted(names))
+                      [str(e) for e in entries])
 
     def list(self):
         """


### PR DESCRIPTION
The current code just prints out the base64-encoded ZkID capnp like
this:

`Current party (/1-11/ps/party) members are: ['EApQAQIFCxARBUoRCRf/cHMxLTExLTEAAABRBAEBDQGLdREBIgl/SQ==', 'EApQAQIFCxARBUoRCRf/cHMxLTExLTIAAABRBAEBDQFndREBIgl/Sg==']`

With this change:

`Current party (/1-11/ps/party) members are: ['ISD-AS: 1-11 Id: ps1-11-1 ([127.0.0.73]:30091)']`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1080)
<!-- Reviewable:end -->
