### PR TITLE
Format multi-line python log messages better.

### DIFF
--- a/lib/log.py
+++ b/lib/log.py
@@ -55,6 +55,10 @@ class _ConsoleErrorHandler(logging.StreamHandler):
 
 
 class _Rfc3339Formatter(logging.Formatter):
+    def format(self, record):  # pragma: no cover
+        lines = super().format(record).splitlines()
+        return "\n> ".join(lines)
+
     def formatTime(self, record, _):  # pragma: no cover
         # Not using lib.util.iso_timestamp here, to avoid potential import
         # loops.


### PR DESCRIPTION
This change adds a `> ` prefix to every additional line in a multi-line
log statement, matching the behaviour of the go logging library we use.
As well as being easier to read, this also simplifies some automated
processing of logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1081)
<!-- Reviewable:end -->
