### PR TITLE
Revocation epoch tolerance window

### DIFF
--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -104,7 +104,7 @@ func (rp *RtrPkt) validateLocalIF(ifid *spath.IntfID) *common.Error {
 		return nil
 	}
 	// Check that we have a revocation for the current epoch.
-	if revInfo.Epoch() < crypto.GetCurrentHashTreeEpoch() {
+	if !crypto.VerifyHashTreeEpoch(revInfo.Epoch()) {
 		// If the BR does not have a revocation for the current epoch, it considers
 		// the interface as active until it receives a new revocation.
 		ifstate.Activate(*ifid)

--- a/go/lib/crypto/htree.go
+++ b/go/lib/crypto/htree.go
@@ -26,7 +26,26 @@ const HashTreeTTL = 30 * 60
 // HashTreeEpochTime is the duration of one epoch (in seconds).
 const HashTreeEpochTime = 10
 
+// HashTreeEpochTolerance is the duration after a revocation expired within which a
+// revocation is still accepted by a verifier.
+const HashTreeEpochTolerance float64 = 2.0
+
+// GetCurrentHashTreeEpoch returns the current epoch within a TTL window.
 func GetCurrentHashTreeEpoch() uint16 {
 	window := time.Now().Unix() % HashTreeTTL
 	return uint16(window / HashTreeEpochTime)
+}
+
+// GetTimeSinceHashTreeEpoch returns the time (in s) since the start of the epoch.
+func GetTimeSinceHashTreeEpoch() float64 {
+	return float64(time.Now().UnixNano()%HashTreeEpochTime) / 1e9
+}
+
+// VerifyHashTreeEpoch verifies a given hash tree epoch. An epoch is valid if it is
+// equal to the current epoch or within the tolerance limit of the next epoch.
+func VerifyHashTreeEpoch(epoch uint16) bool {
+	currEpoch := GetCurrentHashTreeEpoch()
+	gapTime := GetTimeSinceHashTreeEpoch()
+	return (epoch == currEpoch ||
+		(currEpoch == epoch+1 && gapTime < HashTreeEpochTolerance))
 }

--- a/go/lib/crypto/htree.go
+++ b/go/lib/crypto/htree.go
@@ -31,9 +31,9 @@ const HashTreeEpochTime = 10
 const HashTreeEpochTolerance float64 = 2.0
 
 // GetCurrentHashTreeEpoch returns the current epoch within a TTL window.
-func GetCurrentHashTreeEpoch() uint16 {
+func GetCurrentHashTreeEpoch() uint64 {
 	window := time.Now().Unix() % HashTreeTTL
-	return uint16(window / HashTreeEpochTime)
+	return uint64(window / HashTreeEpochTime)
 }
 
 // GetTimeSinceHashTreeEpoch returns the time (in s) since the start of the epoch.
@@ -43,7 +43,7 @@ func GetTimeSinceHashTreeEpoch() float64 {
 
 // VerifyHashTreeEpoch verifies a given hash tree epoch. An epoch is valid if it is
 // equal to the current epoch or within the tolerance limit of the next epoch.
-func VerifyHashTreeEpoch(epoch uint16) bool {
+func VerifyHashTreeEpoch(epoch uint64) bool {
 	currEpoch := GetCurrentHashTreeEpoch()
 	gapTime := GetTimeSinceHashTreeEpoch()
 	return (epoch == currEpoch ||

--- a/go/lib/crypto/htree.go
+++ b/go/lib/crypto/htree.go
@@ -18,27 +18,29 @@ import (
 	"time"
 )
 
-// HashTreeTTL is the TTL of one hash tree (in seconds).
-// FIXME(shitz): This should really be matching spath.MaxTTL, but more importantly,
-// it needs to match the hash tree ttl used by the BS, which is currently set to 30 mins.
-const HashTreeTTL = 30 * 60
+const (
+	// HashTreeTTL is the TTL of one hash tree (in seconds).
+	// FIXME(shitz): This should really be matching spath.MaxTTL, but more importantly,
+	// it needs to match the hash tree ttl used by the BS, which is currently set to 30 mins.
+	HashTreeTTL = 30 * 60 * time.Second
 
-// HashTreeEpochTime is the duration of one epoch (in seconds).
-const HashTreeEpochTime = 10
+	// HashTreeEpochTime is the duration of one epoch (in seconds).
+	HashTreeEpochTime = 10 * time.Second
 
-// HashTreeEpochTolerance is the duration after a revocation expired within which a
-// revocation is still accepted by a verifier.
-const HashTreeEpochTolerance float64 = 2.0
+	// HashTreeEpochTolerance is the duration after a revocation expired within which a
+	// revocation is still accepted by a verifier.
+	HashTreeEpochTolerance = 2 * time.Second
+)
 
-// GetCurrentHashTreeEpoch returns the current epoch within a TTL window.
+// GetCurrentHashTreeEpoch returns the current epoch ID.
 func GetCurrentHashTreeEpoch() uint64 {
-	window := time.Now().Unix() % HashTreeTTL
-	return uint64(window / HashTreeEpochTime)
+	return uint64(time.Now().Unix() / int64(HashTreeEpochTime.Seconds()))
 }
 
-// GetTimeSinceHashTreeEpoch returns the time (in s) since the start of the epoch.
-func GetTimeSinceHashTreeEpoch() float64 {
-	return float64(time.Now().UnixNano()%HashTreeEpochTime) / 1e9
+// GetTimeSinceHashTreeEpoch returns the time since the start of the current epoch.
+func GetTimeSinceHashTreeEpoch() time.Duration {
+	nanoSecs := time.Now().UnixNano() % HashTreeEpochTime.Nanoseconds()
+	return time.Unix(0, nanoSecs).Sub(time.Unix(0, 0))
 }
 
 // VerifyHashTreeEpoch verifies a given hash tree epoch. An epoch is valid if it is

--- a/go/lib/crypto/htree.go
+++ b/go/lib/crypto/htree.go
@@ -37,17 +37,14 @@ func GetCurrentHashTreeEpoch() uint64 {
 	return uint64(time.Now().Unix() / int64(HashTreeEpochTime.Seconds()))
 }
 
-// GetTimeSinceHashTreeEpoch returns the time since the start of the current epoch.
-func GetTimeSinceHashTreeEpoch() time.Duration {
-	nanoSecs := time.Now().UnixNano() % HashTreeEpochTime.Nanoseconds()
-	return time.Unix(0, nanoSecs).Sub(time.Unix(0, 0))
+// GetTimeSinceHashTreeEpoch returns the time since the start of epoch.
+func GetTimeSinceHashTreeEpoch(epoch uint64) time.Duration {
+	epochStart := time.Unix(0, int64(epoch)*HashTreeEpochTime.Nanoseconds())
+	return time.Since(epochStart)
 }
 
 // VerifyHashTreeEpoch verifies a given hash tree epoch. An epoch is valid if it is
 // equal to the current epoch or within the tolerance limit of the next epoch.
 func VerifyHashTreeEpoch(epoch uint64) bool {
-	currEpoch := GetCurrentHashTreeEpoch()
-	gapTime := GetTimeSinceHashTreeEpoch()
-	return (epoch == currEpoch ||
-		(currEpoch == epoch+1 && gapTime < HashTreeEpochTolerance))
+	return GetTimeSinceHashTreeEpoch(epoch) < (HashTreeEpochTime + HashTreeEpochTolerance)
 }

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -70,6 +70,7 @@ from lib.path_store import PathPolicy
 from lib.thread import thread_safety_net, kill_self
 from lib.types import (
     CertMgmtType,
+    HashType,
     PathMgmtType as PMT,
     PayloadClass,
 )
@@ -165,8 +166,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
     def _init_hash_tree(self):
         ifs = list(self.ifid2br.keys())
-        self._hash_tree = ConnectedHashTree(self.addr.isd_as,
-                                            ifs, self.hashtree_gen_key)
+        self._hash_tree = ConnectedHashTree(
+            self.addr.isd_as, ifs, self.hashtree_gen_key, HashType.SHA256)
 
     def _get_ht_proof(self, if_id):
         with self._hash_tree_lock:
@@ -439,8 +440,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
             ht_start = time.time()
             ifs = list(self.ifid2br.keys())
-            tree = ConnectedHashTree.get_next_tree(self.addr.isd_as, ifs,
-                                                   self.hashtree_gen_key)
+            tree = ConnectedHashTree.get_next_tree(
+                self.addr.isd_as, ifs, self.hashtree_gen_key, HashType.SHA256)
             ht_end = time.time()
             with self._hash_tree_lock:
                 self._next_tree = tree

--- a/infrastructure/cert_server/main.py
+++ b/infrastructure/cert_server/main.py
@@ -182,7 +182,7 @@ class CertServer(SCIONElement):
                     "Dropping CC request from %s for %sv%s: "
                     "CC not found && requester is not local)",
                     meta.get_addr(), *key)
-            elif not req.p.cacheOnly:
+            else:
                 self.cc_requests.put((key, (meta, req)))
             return
         self._reply_cc(key, (meta, req))
@@ -242,7 +242,7 @@ class CertServer(SCIONElement):
                     "Dropping TRC request from %s for %sv%s: "
                     "TRC not found && requester is not local)",
                     meta.get_addr(), *key)
-            elif not req.p.cacheOnly:
+            else:
                 self.trc_requests.put((key, (meta, req)))
             return
         self._reply_trc(key, (meta, req))

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -439,8 +439,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             (seg_req, logger) = targets.pop(0)
             meta = self._build_meta(ia=src_ia, path=path, host=SVCType.PS_A, reuse=True)
             self.send_meta(seg_req, meta)
-            logger.info("Waiting request (%s) sent via %s",
-                        seg_req.short_desc(), pcb.short_desc())
+            logger.info("Waiting request (%s) sent to %s via %s",
+                        seg_req.short_desc(), meta, pcb.short_desc())
 
     def _share_via_zk(self):
         if not self._segs_to_zk:

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -341,7 +341,7 @@ class SCIONElement(object):
                     continue
                 self.requested_trcs.add((isd, ver))
             isd_as = ISD_AS.from_values(isd, 0)
-            trc_req = TRCRequest.from_values(isd_as, ver)
+            trc_req = TRCRequest.from_values(isd_as, ver, cache_only=True)
             logging.info("Requesting %sv%s TRC for PCB %s", isd, ver, seg_meta.seg.short_id())
             if not seg_meta.meta:
                 meta = self.get_cs()
@@ -367,7 +367,7 @@ class SCIONElement(object):
                 if (isd_as, ver) in self.requested_certs:
                     continue
                 self.requested_certs.add((isd_as, ver))
-            cert_req = CertChainRequest.from_values(isd_as, ver)
+            cert_req = CertChainRequest.from_values(isd_as, ver, cache_only=True)
             meta = seg_meta.meta
             if not meta:
                 meta = self.get_cs()

--- a/lib/crypto/symcrypto.py
+++ b/lib/crypto/symcrypto.py
@@ -16,12 +16,16 @@
 =====================================================
 """
 # Stdlib
-from hashlib import pbkdf2_hmac, sha256
+import hashlib
 
 # External packages
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.cmac import CMAC
+
+# SCION
+from lib.errors import SCIONTypeError
+from lib.types import HashType
 
 
 def mac(key, msg):
@@ -52,13 +56,26 @@ def kdf(secret, phrase):
     """
     Default key derivation function.
     """
-    return pbkdf2_hmac('sha256', secret, phrase, 1000)[:16]
+    return hashlib.pbkdf2_hmac('sha256', secret, phrase, 1000)[:16]
 
 
-def crypto_hash(data):
+def sha256(data):
     """
     Default hash function.
     """
-    digest = sha256()
+    digest = hashlib.sha256()
     digest.update(data)
     return digest.digest()
+
+
+# Default hash function
+crypto_hash = sha256
+
+
+def hash_func_for_type(type):
+    """
+    Returns a callable corresponding to 'type'.
+    """
+    if type == HashType.SHA256:
+        return sha256
+    raise SCIONTypeError("Unknown hash function type.")

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -134,7 +134,7 @@ MAX_HOST_ADDR_LEN = 16
 # Time per Epoch
 HASHTREE_EPOCH_TIME = 10
 # The tolerable error in epoch in seconds.
-HASHTREE_EPOCH_TOLERANCE = 5
+HASHTREE_EPOCH_TOLERANCE = 2
 # Max time to live
 HASHTREE_TTL = MAX_SEGMENT_TTL
 # Number of epochs in one TTL per interface

--- a/lib/packet/path_mgmt/rev_info.py
+++ b/lib/packet/path_mgmt/rev_info.py
@@ -67,9 +67,9 @@ class RevocationInfo(PathMgmtPayloadBase):
 
     def cmp_str(self):
         b = []
-        b.append(self.p.isdas.to_bytes(8, 'big'))
+        b.append(self.p.isdas.to_bytes(4, 'big'))
         b.append(self.p.ifID.to_bytes(8, 'big'))
-        b.append(self.p.epoch.to_bytes(2, 'big'))
+        b.append(self.p.epoch.to_bytes(8, 'big'))
         b.append(self.p.nonce)
         return b"".join(b)
 

--- a/lib/packet/path_mgmt/rev_info.py
+++ b/lib/packet/path_mgmt/rev_info.py
@@ -37,7 +37,7 @@ class RevocationInfo(PathMgmtPayloadBase):
 
     @classmethod
     def from_values(cls, isd_as, if_id, epoch, nonce, siblings, prev_root,
-                    next_root):
+                    next_root, hash_type):
         """
         Returns a RevocationInfo object with the specified values.
 
@@ -48,10 +48,11 @@ class RevocationInfo(PathMgmtPayloadBase):
         :param list[(bool, bytes)] siblings: Positions and hashes of siblings
         :param bytes prev_root: Hash of the tree root at time T-1
         :param bytes next_root: Hash of the tree root at time T+1
+        :param hash_type: The hash function needed to verify the revocation.
         """
         # Put the isd_as, if_id, epoch and nonce of the leaf into the proof.
         p = cls.P_CLS.new_message(isdas=int(isd_as), ifID=if_id, epoch=epoch,
-                                  nonce=nonce)
+                                  nonce=nonce, hashType=hash_type)
         # Put the list of sibling hashes (along with l/r) into the proof.
         sibs = p.init('siblings', len(siblings))
         for i, sibling in enumerate(siblings):

--- a/lib/sciond_api/path_meta.py
+++ b/lib/sciond_api/path_meta.py
@@ -54,7 +54,7 @@ class FwdPathMeta(Cerealizable):  # pragma: no cover
 
     def short_desc(self):
         if_str = ", ".join([if_.short_desc() for if_ in self.iter_ifs()])
-        return "MTU: %d Interfaces: %s" % (self.p.mtu, if_str)
+        return "Interfaces: %s MTU: %d" % (if_str, self.p.mtu)
 
     def __eq__(self, other):
         return list(self.iter_ifs()) == list(other.iter_ifs())

--- a/lib/types.py
+++ b/lib/types.py
@@ -178,3 +178,10 @@ class SCIONDMsgType(TypeBase):
     IF_REPLY = "ifInfoReply"
     SERVICE_REQUEST = "serviceInfoRequest"
     SERVICE_REPLY = "serviceInfoReply"
+
+
+#######################
+# Hash function types
+#######################
+class HashType(TypeBase):
+    SHA256 = 0

--- a/proto/rev_info.capnp
+++ b/proto/rev_info.capnp
@@ -10,10 +10,11 @@ struct SiblingHash {
 
 struct RevInfo {
 	ifID @0 :UInt64;  # ID of the interface to be revoked
-	epoch @1 :UInt16;  # Epoch for which interface is to be revoked
+	epoch @1 :UInt64;  # Epoch for which interface is to be revoked
 	nonce @2 :Data;  # Nonce corresponding to the (ifID,epoch) leaf in hashtree
 	siblings @3 :List(SiblingHash);  # Hash values of siblings, bottom to top
 	prevRoot @4 :Data;  # Root of the hashtree of previous time block (T-1)
 	nextRoot @5 :Data;  # Root of the hashtree of next time block (T+1)
 	isdas @6 :UInt32;  # ISD-AS of the revocation issuer.
+	hashType @7 :UInt16;  # The hash function type needed to verify the revocation.
 }

--- a/test/lib/crypto/hash_tree_test.py
+++ b/test/lib/crypto/hash_tree_test.py
@@ -32,6 +32,7 @@ from lib.defines import (
     HASHTREE_EPOCH_TOLERANCE,
 )
 from lib.packet.scion_addr import ISD_AS
+from lib.types import HashType
 from test.testcommon import create_mock_full
 
 
@@ -42,7 +43,7 @@ class TestHashTreeCalcTreeDepth(object):
     @patch("lib.crypto.hash_tree.HashTree._setup", autospec=True)
     def test_for_non2power(self, _):
         # Setup
-        inst = HashTree(ISD_AS("1-11"), "if_ids", "seed")
+        inst = HashTree(ISD_AS("1-11"), "if_ids", "seed", HashType.SHA256)
         # Call
         inst.calc_tree_depth(6)
         # Tests
@@ -53,7 +54,7 @@ class TestHashTreeCalcTreeDepth(object):
         # Setup
         if_ids = [1, 2, 3, 4]
         seed = b"abc"
-        inst = HashTree(ISD_AS("1-11"), if_ids, seed)
+        inst = HashTree(ISD_AS("1-11"), if_ids, seed, HashType.SHA256)
         # Call
         inst.calc_tree_depth(8)
         # Tests
@@ -65,14 +66,16 @@ class TestHashTreeCreateTree(object):
     Unit test for lib.crypto.hash_tree.HashTree.create_tree
     """
     @patch("lib.crypto.hash_tree.HashTree._setup", autospec=True)
-    def test(self, _):
+    @patch("lib.crypto.hash_tree.hash_func_for_type", autospec=True)
+    def test(self, hash_func_for_type, _):
         # Setup
         isd_as = ISD_AS("1-11")
         if_ids = [1, 2, 3]
         hashes = [b"s10", b"10s10", b"s20", b"20s20", b"s30", b"30s30",
                   b"0", b"30s300", b"10s1020s20", b"10s1020s2030s300"]
         hash_func = create_mock_full(side_effect=hashes)
-        inst = HashTree(isd_as, if_ids, b"s", hash_func)
+        hash_func_for_type.return_value = hash_func
+        inst = HashTree(isd_as, if_ids, b"s", HashType.SHA256)
         inst._n_epochs = 1
         inst._depth = 2
         # Call
@@ -88,14 +91,16 @@ class TestHashTreeGetProof(object):
     Unit test for lib.crypto.hash_tree.HashTree.get_proof
     """
     @patch("lib.crypto.hash_tree.HashTree._setup", autospec=True)
-    def test(self, _):
+    @patch("lib.crypto.hash_tree.hash_func_for_type", autospec=True)
+    def test(self, hash_func_for_type, _):
         # Setup
         isd_as = ISD_AS("1-11")
         if_ids = [1, 2, 3]
         hashes = [b"s10", b"10s10", b"s20", b"20s20", b"s30", b"30s30",
                   b"0", b"30s300", b"10s1020s20", b"10s1020s2030s300", b"s20"]
         hash_func = create_mock_full(side_effect=hashes)
-        inst = HashTree(isd_as, if_ids, b"s", hash_func)
+        hash_func_for_type.return_value = hash_func
+        inst = HashTree(isd_as, if_ids, b"s", HashType.SHA256)
         inst._n_epochs = 1
         inst._depth = 2
         inst.create_tree(if_ids)
@@ -119,11 +124,11 @@ class TestConnectedHashTreeUpdate(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
         root1_before_update = inst._ht1._nodes[0]
         root2_before_update = inst._ht2._nodes[0]
         # Call
-        new_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed")
+        new_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed", HashType.SHA256)
         inst.update(new_tree)
         # Tests
         root0_after_update = inst._ht0_root
@@ -136,21 +141,22 @@ class TestConnectedHashtreeGetPossibleHashes(object):
     """
     Unit test for lib.crypto.hash_tree.ConnectedHashTree.get_possible_hashes
     """
-    def test(self):
+    @patch("lib.crypto.hash_tree.hash_func_for_type", autospec=True)
+    def test(self, hash_func_for_type):
         # Setup
         siblings = []
         siblings.append(create_mock_full({"isLeft": True, "hash": "10s10"}))
         siblings.append(create_mock_full({"isLeft": False, "hash": "30s300"}))
         p = create_mock_full(
             {"ifID": 2, "epoch": 0, "nonce": b"s20", "siblings": siblings,
-             "prevRoot": "p", "nextRoot": "n"})
-        revProof = create_mock_full({"p": p})
+             "prevRoot": "p", "nextRoot": "n", "hashType": 0})
+        rev_info = create_mock_full({"p": p})
         hashes = ["20s20", "10s1020s20", "10s1020s2030s300",
                   "p10s1020s2030s300", "10s1020s2030s300n"]
         hash_func = create_mock_full(side_effect=hashes)
+        hash_func_for_type.return_value = hash_func
         # Call
-        hash01, hash12 = ConnectedHashTree.get_possible_hashes(
-            revProof, hash_func)
+        hash01, hash12 = ConnectedHashTree.get_possible_hashes(rev_info)
         # Tests
         ntools.eq_(hash01, "p10s1020s2030s300")
         ntools.eq_(hash12, "10s1020s2030s300n")
@@ -167,10 +173,10 @@ class TestConnectedHashTreeUpdateAndVerify(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
         root = inst.get_root()
         # Call
-        next_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed")
+        next_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed", HashType.SHA256)
         inst.update(next_tree)
         # Tests
         proof = inst.get_proof(35)  # if_id = 35.
@@ -182,12 +188,12 @@ class TestConnectedHashTreeUpdateAndVerify(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
         root = inst.get_root()
         # Call
-        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@1")
+        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@1", HashType.SHA256)
         inst.update(new_tree)
-        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@2")
+        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@2", HashType.SHA256)
         inst.update(new_tree)
         # Tests
         proof = inst.get_proof(35)  # if_id = 35.


### PR DESCRIPTION
BR uses now a tolerance window when verifying a revocation epoch. Reduce tolerance window to 2s (from 5s). Fixes #1077.

Additionally, the `RevInfo` now contains the hash function type needed to verify the revocation (fixes #854) and the `epoch` in `RevInfo` is now relative to 0 UNIX time (instead of the current TTL window). This fixes a bug when verifying the epoch from a different TTL window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1083)
<!-- Reviewable:end -->
