### PR TITLE
Reduce ZK memory usage, and various fixes.

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -71,6 +71,7 @@ COPY docker/profile $HOME/.profile
 COPY docker/screenrc $HOME/.screenrc
 # Install ZK config
 COPY docker/zoo.cfg /etc/zookeeper/conf/
+RUN echo 'JAVA_OPTS="-Xmx150m" # Added by Dockerfile.base' >> /etc/zookeeper/conf/environment
 
 # Fix ownership one last time:
 RUN sudo chown -R scion: $HOME

--- a/lib/util.py
+++ b/lib/util.py
@@ -284,12 +284,14 @@ def handle_signals():
 def _signal_handler(signum, _):
     """Basic signal handler function."""
     text = "Received %s" % _SIG_MAP[signum]
-    if signum in (signal.SIGTERM, signal.SIGINT):
+    if signum == signal.SIGTERM:
         logging.info(text)
         sys.exit(0)
+    elif signum == signal.SIGINT:
+        logging.info(text)
     else:
         logging.error(text)
-        sys.exit(1)
+    sys.exit(1)
 
 
 def iso_timestamp(ts):  # pragma: no cover

--- a/lib/zk/zk.py
+++ b/lib/zk/zk.py
@@ -197,8 +197,12 @@ class Zookeeper(object):
         if clid is None:
             # Protect against a race-condition.
             return
-        logging.debug("Connection to Zookeeper succeeded (Session: %s)",
-                      hex(clid[0]))
+        try:
+            zk_peer = self.kazoo._connection._socket.getpeername()
+        except AttributeError:
+            zk_peer = "?", "?"
+        logging.debug("Connection to Zookeeper succeeded (Session: %s, ZK: [%s]:%s)",
+                      hex(clid[0]), zk_peer[0], zk_peer[1])
         try:
             self.ensure_path(self.prefix, abs=True)
             # Use a copy of the dictionary values, as the dictioary is changed

--- a/test/lib/util_test.py
+++ b/test/lib/util_test.py
@@ -17,7 +17,7 @@
 """
 # Stdlib
 import builtins
-from signal import SIGQUIT, SIGTERM
+from signal import SIGINT, SIGQUIT, SIGTERM
 from unittest.mock import patch, call, mock_open, MagicMock
 
 # External packages
@@ -291,10 +291,18 @@ class TestSignalHandler(object):
     """
     @patch("lib.util.sys.exit", autospec=True)
     @patch("lib.util.logging.info", autospec=True)
-    def test_basic(self, info, exit):
-        _signal_handler(SIGTERM, "")
+    def test_term(self, info, exit):
+        exit.side_effect = SystemExit
+        ntools.assert_raises(SystemExit, _signal_handler, SIGTERM, "")
         ntools.ok_(info.called)
         exit.assert_called_once_with(0)
+
+    @patch("lib.util.sys.exit", autospec=True)
+    @patch("lib.util.logging.info", autospec=True)
+    def test_int(self, info, exit):
+        _signal_handler(SIGINT, "")
+        ntools.ok_(info.called)
+        exit.assert_called_once_with(1)
 
     @patch("lib.util.sys.exit", autospec=True)
     @patch("lib.util.logging.error", autospec=True)

--- a/topology/Zookeeper.yml
+++ b/topology/Zookeeper.yml
@@ -7,7 +7,9 @@ Default:
   clientPort: 2181
   leaderPort: 2888
   electionPort: 3888
-Environment:
+Config:
   CLASSPATH: /usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar
   ZOOMAIN: org.apache.zookeeper.server.quorum.QuorumPeerMain
-  ZOO_LOG4J_PROP: INFOROLLINGFILE
+Environment:
+  ZOO_LOG4J_PROP: INFO,ROLLINGFILE
+  JAVA_TOOL_OPTIONS: "-Xmx50M"

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -815,6 +815,9 @@ class SupervisorGenerator(object):
                 prog['environment'] += ',SCIOND_PATH="%s"' % path
         if elem.startswith("br") and self.router == "go":
             prog['environment'] += ',GODEBUG="cgocheck=0"'
+        if elem.startswith("zk") and self.zk_config["Environment"]:
+            for k, v in self.zk_config["Environment"].items():
+                prog['environment'] += ',%s="%s"' % (k, v)
         config["program:%s" % elem] = prog
         text = StringIO()
         config.write(text)
@@ -848,7 +851,7 @@ class SupervisorGenerator(object):
         entry = {
             'autostart': 'false' if self.mininet else 'false',
             'autorestart': 'false',
-            'environment': 'PYTHONPATH=.',
+            'environment': 'PYTHONPATH=.,TZ=UTC',
             'stdout_logfile': "NONE",
             'stderr_logfile': "NONE",
             'startretries': 0,
@@ -967,12 +970,12 @@ class ZKTopo(object):
         base_dir = os.path.join(out_dir, topo_id.ISD(), topo_id.AS(), name)
         cfg_path = os.path.join(base_dir, "zoo.cfg")
         class_path = ":".join([
-            base_dir, self.zk_config["Environment"]["CLASSPATH"],
+            base_dir, self.zk_config["Config"]["CLASSPATH"],
         ])
         return [
             "java", "-cp", class_path,
             '-Dzookeeper.log.file=logs/%s.log' % name,
-            self.zk_config["Environment"]["ZOOMAIN"], cfg_path,
+            self.zk_config["Config"]["ZOOMAIN"], cfg_path,
         ]
 
 


### PR DESCRIPTION
- Restrict the host ZK to 150M heap size under docker/circleci.
- Restrict the managed ZKs to 50M heap size.
- Log the address and port of the zookeeper instance that kazoo
  connected to.
- Fix ZK logging to use a rolling log file.
- Set TZ=UTC for all elements (ZK was using localtime until now).
- Change python signal handling to exit(1) after a ctrl-c.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1084)
<!-- Reviewable:end -->
