### PR TITLE
Go port of the SCIOND API

### DIFF
--- a/go/integration/end2end_test.go
+++ b/go/integration/end2end_test.go
@@ -1,0 +1,544 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/l4"
+	"github.com/netsec-ethz/scion/go/lib/libscion"
+	"github.com/netsec-ethz/scion/go/lib/sciond"
+	"github.com/netsec-ethz/scion/go/lib/sock/reliable"
+	"github.com/netsec-ethz/scion/go/lib/spath"
+	"github.com/netsec-ethz/scion/go/lib/spkt"
+	"gopkg.in/yaml.v2"
+)
+
+const DispPath = "/run/shm/dispatcher/default.sock"
+
+// RawPayload implements interface common.Payload for byte slices
+type RawPayload common.RawBytes
+
+func (pld RawPayload) String() string {
+	return common.RawBytes(pld).String()
+}
+
+func (pld RawPayload) Len() int {
+	return len(pld)
+}
+
+func (pld RawPayload) Copy() (common.Payload, *common.Error) {
+	newPld := make(RawPayload, pld.Len())
+	copy(newPld, pld)
+
+	return newPld, nil
+}
+
+func (pld RawPayload) Write(b common.RawBytes) (int, *common.Error) {
+	return copy(pld, b), nil
+}
+
+func InitIndices(fwdPath common.RawBytes) (infoIdx, hopIdx uint8, err error) {
+	infoIdx, hopIdx = 0, 1
+
+	info, ierr := spath.InfoFFromRaw(fwdPath[infoIdx*8 : infoIdx*8+8])
+	if ierr != nil {
+		return 0, 0, ierr
+	}
+	maxHopIdx := info.Hops
+
+	hop, ierr := spath.HopFFromRaw(fwdPath[hopIdx*8 : hopIdx*8+8])
+	if ierr != nil {
+		return 0, 0, ierr
+	}
+
+	if info.Up && hop.Xover {
+		hopIdx += 1
+		if hopIdx > maxHopIdx {
+			return 0, 0, common.NewError("Skipped entire path segment", "hopIdx", hopIdx,
+				"maxHopIdx", maxHopIdx)
+		}
+	}
+
+	for {
+		hop, ierr = spath.HopFFromRaw(fwdPath[hopIdx*8 : hopIdx*8+8])
+		if ierr != nil {
+			return 0, 0, ierr
+		}
+
+		if hop.VerifyOnly {
+			hopIdx += 1
+			if hopIdx > maxHopIdx {
+				return 0, 0, common.NewError("Skipped entire path segment", "hopIdx", hopIdx,
+					"maxHopIdx", maxHopIdx)
+			}
+		} else {
+			break
+		}
+	}
+
+	return infoIdx, hopIdx, nil
+}
+
+// Generates SCION Version 0 packets
+func CreateUDPPacket(srcIA *addr.ISD_AS, srcLocal addr.HostAddr, dstIA *addr.ISD_AS,
+	dstLocal addr.HostAddr, fwdPath common.RawBytes, data common.RawBytes,
+	srcPort uint16, dstPort uint16) (common.RawBytes, error) {
+	// SCION Version 0 common headers are 8-byte long
+	commonHeaderSize := 8
+	commonHeader := make([]byte, commonHeaderSize)
+	commonHeader[0] |= (uint8(dstLocal.Type()) >> 2) << 4
+	commonHeader[1] |= uint8(dstLocal.Type()) << 6
+	commonHeader[1] |= uint8(srcLocal.Type())
+
+	addrHeaderSize := dstLocal.Size() + srcLocal.Size() + dstIA.SizeOf() + srcIA.SizeOf()
+	addrHeader := make([]byte, addrHeaderSize)
+	// Pad to multiple of LineLen, 40 is max address header as defined by SCION specification
+	if addrHeaderSize > 40 {
+		return nil, common.NewError("Invalid address header size", "size", addrHeaderSize)
+	}
+	addrHeaderSize += (40 - addrHeaderSize) % 8
+
+	// We do not include the L4 header size in the total header size
+	totalHeaderSize := commonHeaderSize + addrHeaderSize + len(fwdPath)
+	totalPacketSize := totalHeaderSize + l4.UDPLen + len(data)
+
+	binary.BigEndian.PutUint16(commonHeader[2:4], uint16(totalPacketSize))
+	commonHeader[4] = uint8(totalHeaderSize)
+
+	// Create the packet using initial IF/HF pointers
+	_, hopIdx, err := InitIndices(fwdPath)
+	if err != nil {
+		return nil, err
+	}
+
+	commonHeader[5] = uint8(addrHeaderSize + commonHeaderSize)
+	commonHeader[6] = uint8(addrHeaderSize+commonHeaderSize) + (hopIdx * 8)
+
+	commonHeader[7] = uint8(common.L4UDP)
+
+	// Pack the address header
+	offset := 0
+	dstIA.Write(addrHeader[offset : offset+dstIA.SizeOf()])
+	offset += dstIA.SizeOf()
+	srcIA.Write(addrHeader[offset : offset+srcIA.SizeOf()])
+	offset += srcIA.SizeOf()
+	copy(addrHeader[offset:offset+dstLocal.Size()], dstLocal.Pack())
+	offset += dstLocal.Size()
+	copy(addrHeader[offset:offset+srcLocal.Size()], srcLocal.Pack())
+	// And the padding, if it exists, contains leftover zeroes
+
+	// Pack the L4 header
+	// TODO(scrye): Might want to refactor L4 stuff out of lib/common?
+	udpHeader := make([]byte, l4.UDPLen)
+
+	binary.BigEndian.PutUint16(udpHeader[0:2], srcPort)
+	binary.BigEndian.PutUint16(udpHeader[2:4], dstPort)
+	binary.BigEndian.PutUint16(udpHeader[4:6], uint16(len(data))+l4.UDPLen)
+
+	// Compute the checksum for SCION L4
+	// NOTE(scrye): is the checksum supposed to be this way? it breaks stack encap/decap
+	// principles (encapsulated UDP protocol looks at bytes from upper layer SCION protocol)
+	binary.BigEndian.PutUint16(udpHeader[6:8], libscion.Checksum(addrHeader[0:16],
+		commonHeader[7:8], udpHeader, data))
+
+	packet := make([]byte, 0)
+	packet = append(packet, commonHeader...)
+	packet = append(packet, addrHeader...)
+	packet = append(packet, fwdPath...)
+	packet = append(packet, udpHeader...)
+	packet = append(packet, data...)
+
+	return packet, nil
+}
+
+// ScnPktFromRaw parses an in-memory raw packet, useful when SCION packets are transported
+// via a lower-layer framing protocol (e.g., ReliableSocket)
+func ScnPktFromRaw(buf common.RawBytes) (*spkt.ScnPkt, error) {
+	offset := uint16(0)
+	scnPkt := new(spkt.ScnPkt)
+	// TODO(scrye): err is defined here to avoid nil interface issues
+	var err *common.Error
+
+	scnPkt.CmnHdr, err = spkt.CmnHdrFromRaw(buf[:8])
+	if err != nil {
+		return nil, err
+	}
+	offset += 8
+
+	scnPkt.DstIA = addr.IAFromRaw(buf[offset : offset+addr.IABytes])
+	offset += addr.IABytes
+
+	scnPkt.SrcIA = addr.IAFromRaw(buf[offset : offset+addr.IABytes])
+	offset += addr.IABytes
+
+	scnPkt.DstHost, err = addr.HostFromRaw(buf[offset:], scnPkt.CmnHdr.DstType)
+	if err != nil {
+		return nil, err
+	}
+	dstLen, err := addr.HostLen(scnPkt.CmnHdr.DstType)
+	if err != nil {
+		return nil, err
+	}
+	offset += uint16(dstLen)
+
+	scnPkt.SrcHost, err = addr.HostFromRaw(buf[offset:], scnPkt.CmnHdr.SrcType)
+	if err != nil {
+		return nil, err
+	}
+	srcLen, err := addr.HostLen(scnPkt.CmnHdr.SrcType)
+	if err != nil {
+		return nil, err
+	}
+	offset += uint16(srcLen)
+
+	// Skip padding, NB: SCION states addr.HostLenIPv6 is largest accepted address size
+	if dstLen > addr.HostLenIPv6 {
+		return nil, common.NewError("Address too large", "dstLen", dstLen)
+	}
+	if srcLen > addr.HostLenIPv6 {
+		return nil, common.NewError("Address too large", "srcLen", srcLen)
+	}
+	addrPadLen := uint8((2*addr.HostLenIPv6 - dstLen - srcLen) % 8)
+	offset += uint16(addrPadLen)
+
+	addrHeaderLen := addrPadLen + srcLen + dstLen + 2*addr.IABytes
+
+	// Compute forwarding path length, lengths are in the last byte of the 8-byte InfoField
+	//pathLength := uint16(0)
+	pathLength := uint16(scnPkt.CmnHdr.HdrLen) - uint16(spkt.CmnHdrLen) - uint16(addrHeaderLen)
+	offset += pathLength
+
+	scnPkt.Path = new(spath.Path)
+	scnPkt.Path.Raw = make(common.RawBytes, pathLength)
+	copy(scnPkt.Path.Raw, buf[offset-pathLength:offset])
+	scnPkt.Path.InfOff = scnPkt.CmnHdr.CurrInfoF
+	scnPkt.Path.HopOff = scnPkt.CmnHdr.CurrHopF
+
+	// Jump directly after header
+	// NOTE(?): x8 lengths are suggested in the specification, but are not implemented in
+	// existing code.
+	offset = uint16(scnPkt.CmnHdr.HdrLen)
+
+	// Only unpack UDP for now
+	if scnPkt.CmnHdr.NextHdr != common.L4UDP {
+		return nil, common.NewError("Unsupported L4 protocol", "proto", scnPkt.CmnHdr.NextHdr)
+	}
+	scnPkt.L4, err = l4.UDPFromRaw(buf[offset : offset+l4.UDPLen])
+	if err != nil {
+		return nil, err
+	}
+	offset += l4.UDPLen
+
+	// Make a pristine copy of the payload field, in case applications toy around with it
+	// TODO(scrye): validate buffer length
+	payloadLength := scnPkt.CmnHdr.TotalLen - uint16(scnPkt.CmnHdr.HdrLen) - l4.UDPLen
+	scnPkt.Pld = make(RawPayload, payloadLength)
+
+	_, err = scnPkt.Pld.Write(buf[offset:])
+	if err != nil {
+		return nil, err
+	}
+
+	return scnPkt, nil
+}
+
+func Client(tc TestCase, t *testing.T) {
+	time.Sleep(100 * time.Millisecond)
+
+	// Value and error channels for client goroutine
+	v, e := make(chan string, 1), make(chan error, 1)
+
+	go func() {
+		// Test AS request/reply functionality before entering the sending loop
+		sciond, err := sciond.Connect(fmt.Sprintf("/run/shm/sciond/sd%s.sock", tc.srcIA.String()))
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		defer sciond.Close()
+
+		// Ask SCIOND for the forwarding path
+		pathReply, err := sciond.Paths(tc.srcIA, tc.dstIA, 5, false, false)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if pathReply.ErrorCode != 0 {
+			t.Fatalf("Path error: %s", pathReply.ErrorCode)
+		}
+
+		// If no path, finish test successfully
+		if len(pathReply.Entries[0].Path.FwdPath) == 0 {
+			return
+		}
+
+		// Choose the first path
+		fwdPath := pathReply.Entries[0].Path.FwdPath
+		firstHop := pathReply.Entries[0].HostInfo
+
+		// Register with dispatcher
+		regAddr := reliable.AppAddr{Addr: tc.srcLocal, Port: tc.srcPort}
+		dispatcher, err := reliable.Register(DispPath, tc.srcIA, regAddr)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		defer dispatcher.Close()
+
+		// Create packet
+		packet, err := CreateUDPPacket(tc.srcIA, tc.srcLocal, tc.dstIA, tc.dstLocal, fwdPath,
+			tc.request, tc.srcPort, tc.dstPort)
+
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// Send payload
+		a, _ := addr.HostFromRaw(firstHop.Addrs.Ipv4, addr.HostTypeIPv4)
+		_, err = dispatcher.WriteTo(packet, reliable.AppAddr{Addr: a, Port: firstHop.Port})
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		message := make([]byte, 256)
+
+		_, _, err = dispatcher.ReadFrom(message)
+		if err != nil {
+			e <- common.NewError("err", err)
+		}
+
+		scnPkt, err := ScnPktFromRaw(message)
+		if err != nil {
+			e <- err
+		}
+
+		// Send received message to parent
+		s := string([]byte(scnPkt.Pld.(RawPayload)))
+		v <- s
+
+	}()
+
+	var message string
+
+	select {
+	case message = <-v:
+	case err := <-e:
+		t.Fatalf("Error %v", err)
+	case <-time.After(time.Second * 3):
+		t.Fatalf("Timed out waiting for message.")
+	}
+
+	if message != string(tc.reply) {
+		t.Fatalf("Received message %v, expected %v", message, string(tc.request))
+	}
+}
+
+func Server(tc TestCase, t *testing.T) {
+	// Value and error channels for client goroutine
+	v, e := make(chan string, 1), make(chan error, 1)
+
+	// Launch communication part of server as separate goroutine
+	go func() {
+		// Register with dispatcher
+		regAddr := reliable.AppAddr{Addr: tc.dstLocal, Port: tc.dstPort}
+		dispatcher, err := reliable.Register(DispPath, tc.dstIA, regAddr)
+		if err != nil {
+			e <- err
+			return
+		}
+		defer dispatcher.Close()
+
+		message := make([]byte, 256)
+		_, br, err := dispatcher.ReadFrom(message)
+		if err != nil {
+			e <- common.NewError("Unable to read from dispatcher", "err", err)
+			return
+		}
+
+		scnPkt, err := ScnPktFromRaw(message)
+		if err != nil {
+			e <- err
+			return
+		}
+
+		s := string([]byte(scnPkt.Pld.(RawPayload)))
+		v <- s
+
+		// TODO(scrye): ierr is used to avoid nil stored in interface
+		ierr := scnPkt.Reverse()
+		if ierr != nil {
+			e <- err
+			return
+		}
+
+		udpHeader, ok := scnPkt.L4.(*l4.UDP)
+		if ok == false {
+			e <- common.NewError("Type assertion scnPkt.L4.(*l4.UDP) failed")
+			return
+		}
+
+		packet, err := CreateUDPPacket(scnPkt.SrcIA, scnPkt.SrcHost, scnPkt.DstIA,
+			scnPkt.DstHost, []byte(scnPkt.Path.Raw), tc.reply, udpHeader.SrcPort, udpHeader.DstPort)
+		if err != nil {
+			e <- err
+			return
+		}
+
+		_, err = dispatcher.WriteTo(packet, br)
+		if err != nil {
+			e <- err
+			return
+		}
+
+		e <- nil
+	}()
+
+	var message string
+
+	select {
+	case err := <-e:
+		if err != nil {
+			t.Fatalf("Error %v", err)
+		}
+	case <-time.After(time.Second * 3):
+		t.Fatalf("Timed out waiting for message")
+	}
+
+	message = <-v
+
+	if message != string(tc.request) {
+		t.Fatalf("Message mismatch. Expected %v, actual %v", string(tc.request), message)
+	}
+
+}
+
+type TestCase struct {
+	srcIA *addr.ISD_AS
+	dstIA *addr.ISD_AS
+
+	srcLocal addr.HostAddr
+	dstLocal addr.HostAddr
+
+	srcPort uint16
+	dstPort uint16
+
+	request []byte
+	reply   []byte
+}
+
+func generateTests(clients []*addr.ISD_AS, servers []*addr.ISD_AS, count int) []TestCase {
+	tests := make([]TestCase, 0, 0)
+	var cIndex, sIndex int32
+
+	for i := 0; i < count; i++ {
+		for {
+			cIndex = rand.Int31n(int32(len(clients)))
+			sIndex = rand.Int31n(int32(len(servers)))
+			if cIndex != sIndex {
+				break
+			}
+		}
+
+		tc := TestCase{srcIA: clients[cIndex], dstIA: servers[sIndex],
+			srcPort: uint16(40000 + 2*i), dstPort: uint16(40001 + 2*i)}
+		tests = append(tests, tc)
+	}
+
+	return tests
+}
+
+type ASList struct {
+	Core    []string `yaml:"Core"`
+	NonCore []string `yaml:"Non-core"`
+}
+
+func loadASList(t *testing.T) []*addr.ISD_AS {
+	f, err := os.Open("../../gen/as_list.yml")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	var aslist ASList
+	yaml.Unmarshal(b, &aslist)
+
+	asList := make([]*addr.ISD_AS, 0)
+	for _, asString := range aslist.Core {
+		as, err := addr.IAFromString(asString)
+		if err != nil {
+			t.Fatalf("Could not parse as name %v.", asString)
+		}
+
+		asList = append(asList, as)
+	}
+
+	for _, asString := range aslist.NonCore {
+		as, err := addr.IAFromString(asString)
+		if err != nil {
+			t.Fatalf("Could not parse as name %v.", asString)
+		}
+
+		asList = append(asList, as)
+	}
+
+	return asList
+}
+
+func ClientServer(tc TestCase, t *testing.T) {
+	tc.srcLocal = addr.HostFromIP(net.IPv4(127, 0, 0, 1))
+	tc.dstLocal = addr.HostFromIP(net.IPv4(127, 0, 0, 1))
+
+	tc.request = []byte("ping!")
+	tc.reply = []byte("pong!")
+
+	t.Logf("(%v,%v,%v):%v <-> (%v,%v,%v):%v", tc.srcIA.I, tc.srcIA.A, tc.srcLocal, tc.srcPort,
+		tc.dstIA.I, tc.dstIA.A, tc.dstLocal, tc.dstPort)
+	t.Run(fmt.Sprintf("server"), func(t *testing.T) {
+		t.Parallel()
+		Server(tc, t)
+	})
+
+	t.Run(fmt.Sprintf("client"), func(t *testing.T) {
+		t.Parallel()
+		Client(tc, t)
+	})
+}
+
+func TestE2E(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	asSrcList := loadASList(t)
+	asDstList := loadASList(t)
+
+	// Generate random pairs of sources and destinations
+	testCases := generateTests(asSrcList, asDstList, 10)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v->%v", tc.srcIA, tc.dstIA), func(t *testing.T) {
+			ClientServer(tc, t)
+		})
+	}
+}

--- a/go/integration/sciond_test.go
+++ b/go/integration/sciond_test.go
@@ -1,0 +1,96 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+	"fmt"
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/sciond"
+)
+
+func SubtestPaths(t *testing.T, connector *sciond.Connector) {
+	srcIA, _ := addr.IAFromString("0-0")
+	dstIA, _ := addr.IAFromString("1-12")
+	_, err := connector.Paths(srcIA, dstIA, 5, false, false)
+	
+	if err != nil {
+		t.Fatalf("Error: %v.", err)
+	}
+}
+
+func SubtestASInfo(t *testing.T, connector *sciond.Connector) {
+	ia, _ := addr.IAFromString("1-12")
+	_, err := connector.ASInfo(ia)
+
+	if err != nil {
+		t.Fatalf("Error: %v.", err)
+	}
+}
+	
+func SubtestIFInfo(t *testing.T, connector *sciond.Connector) {
+	testCases := [][]uint64{
+		{51, 93, 3, 4},
+		{51, 93, 3, 4},
+		{51, 93, 1, 51},
+		{7, 8, 9, 10}}
+	
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			_, err := connector.IFInfo(tc)
+
+			if err != nil {
+				t.Fatal("Error: %v.", err)
+			}
+		})
+	}
+}
+
+func SubtestSVCInfo(t *testing.T, connector *sciond.Connector) {
+	testCases := [][]addr.HostSVC{
+		{addr.SvcBS},
+		{addr.SvcPS},
+		{addr.SvcCS},
+		{addr.HostSVC(4)},
+		{addr.SvcPS, addr.SvcCS}}
+	
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			_, err := connector.SVCInfo(tc)
+
+			if err != nil {
+				t.Fatal("Error: %s.", err)
+			}
+		})
+	}
+}
+
+func TestASInfo(t *testing.T) {
+	connector, err := sciond.Connect("/run/shm/sciond/sd1-10.sock")
+	if err != nil {
+		t.Fatalf("Error: %v.", err)
+	}
+
+	t.Run("ASInfo", func(t *testing.T) {SubtestASInfo(t, connector)})
+	t.Run("ASInfo cache", func(t *testing.T) {SubtestASInfo(t, connector)})
+	t.Run("Paths", func(t *testing.T) {SubtestPaths(t, connector)})
+	t.Run("IFs", func(t *testing.T) {SubtestIFInfo(t, connector)})
+	t.Run("SVCs", func(t *testing.T) {SubtestSVCInfo(t, connector)})
+	
+	err = connector.Close()
+	if err != nil {
+		t.Fatalf("Error: %v.", err)
+	}
+}

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -37,7 +37,7 @@ const (
 
 func IAFromRaw(b common.RawBytes) *ISD_AS {
 	iaInt := common.Order.Uint32(b)
-	return &ISD_AS{I: int(iaInt >> 20), A: int(iaInt & 0x000FFFFF)}
+	return IAFromUint32(iaInt)
 }
 
 func IAFromString(s string) (*ISD_AS, error) {
@@ -58,8 +58,16 @@ func IAFromString(s string) (*ISD_AS, error) {
 	return &ISD_AS{I: isd, A: as}, nil
 }
 
+func IAFromUint32(iaInt uint32) *ISD_AS {
+	return &ISD_AS{I: int(iaInt >> 20), A: int(iaInt & 0x000FFFFF)}
+}
+
 func (ia *ISD_AS) Write(b common.RawBytes) {
-	common.Order.PutUint32(b, uint32((ia.I<<20)|(ia.A&0x000FFFFF)))
+	common.Order.PutUint32(b, ia.Uint32())
+}
+
+func (ia *ISD_AS) Uint32() uint32 {
+	return uint32((ia.I<<20)|(ia.A&0x000FFFFF))
 }
 
 func (ia *ISD_AS) SizeOf() int {

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -1,0 +1,255 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sciond queries local SCIOND servers for information.
+//
+// To query a SCIOND server, a connection must be established to one using Connect. The returned
+// structure can then be queried for information about Paths, ASes, available SCION
+// services and interface IDs of border rotuers.
+// 
+// API calls return the entire answer of SCIOND.
+// Fields prefixed with Raw (e.g., RawErrorCode) contain data in the format received from SCIOND.
+// These are rarely useful, and the same fields without the prefix (e.g., ErrorCode) should be used
+// instead.
+package sciond
+
+import (
+	"net"
+	"math/rand"
+	"time"
+	"strconv"
+	"sync/atomic"
+	"zombiezen.com/go/capnproto2"
+	"zombiezen.com/go/capnproto2/pogs"
+	"github.com/patrickmn/go-cache"
+	"github.com/netsec-ethz/scion/go/proto"
+	"github.com/netsec-ethz/scion/go/lib/sock/reliable"
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+// Time to live for cache entries
+const (
+	ASInfoTTL = time.Hour
+	IFInfoTTL = time.Hour
+	SVCInfoTTL = 10 * time.Second
+)
+
+// A Connector is used to query a local SCIOND server. The Connector maintains an internal
+// cache for interface, service and AS information. All Connector methods block until either
+// an error occurs, or the method successfully returns.
+type Connector struct {
+	conn net.Conn
+	requestID uint64
+
+	ifInfos *cache.Cache
+	svcInfos *cache.Cache
+	asInfos *cache.Cache
+}
+
+func (c *Connector) nextID() uint64 {
+	return atomic.AddUint64(&c.requestID, 1)
+}
+
+func (c *Connector) sendRequest(request *SCIONDMsg) error {
+	message, arena, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	root, _ := proto.NewRootSCIONDMsg(arena)
+	err := pogs.Insert(proto.SCIONDMsg_TypeID, root.Struct, request)
+	if err != nil {
+		return err
+	}
+
+	packedMsg, err := message.MarshalPacked()
+	if err != nil {
+		return err
+	}
+
+	_, err = c.conn.Write(packedMsg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Connector) receiveReply() (*SCIONDMsg, error) {
+	reply, err := capnp.NewPackedDecoder(c.conn).Decode()
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	rootPtr, err := reply.RootPtr()
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	message := new(SCIONDMsg)
+	err = pogs.Extract(message, proto.SCIONDMsg_TypeID, rootPtr.Struct())
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+	return message, nil
+}
+
+// Paths requests from SCIOND a set of end to end paths between src and dst. max specifices the
+// maximum number of paths returned.
+func (c *Connector) Paths(src, dst *addr.ISD_AS, max uint16, flush bool, sibra bool) (*PathReply, error) {
+	request := &SCIONDMsg{Id: c.nextID(), Which: proto.SCIONDMsg_Which_pathReq}
+	request.PathReq.Dst = dst.Uint32()
+	request.PathReq.Src = src.Uint32()
+	request.PathReq.MaxPaths = max
+	request.PathReq.Flags.Flush = flush
+	request.PathReq.Flags.Sibra = sibra
+
+	err := c.sendRequest(request)
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	reply, err := c.receiveReply()
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	// Expose "pretty" ISD-ASes
+	reply.PathReply.prepare()
+
+	return &reply.PathReply, nil
+}
+
+// ASInfo requests from SCIOND information about AS ia.
+func (c *Connector) ASInfo(ia *addr.ISD_AS) (*ASInfoReply, error) {
+	// Check if information for this ISD-AS is cached
+	key := ia.String()
+	value, found := c.asInfos.Get(key)
+	if found {
+		return value.(*ASInfoReply), nil
+	}
+
+	// Value not in cache, so we ask SCIOND
+	request := &SCIONDMsg{Id: c.nextID(), Which: proto.SCIONDMsg_Which_asInfoReq}
+	request.AsInfoReq.Isdas = ia.Uint32()
+	err := c.sendRequest(request)
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	reply, err := c.receiveReply()
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	// Expose "pretty" ISD-ASes
+	reply.AsInfoReply.prepare()
+
+	// Cache result
+	c.asInfos.Set(key, &reply.AsInfoReply, cache.DefaultExpiration)
+
+	return &reply.AsInfoReply, nil
+}
+
+// IFInfo requests from SCIOND information about addresses and ports of border routers (BRs).
+// Splice ifs contains interface IDs of BRs. If unset, all BRs are
+// returned.
+func (c *Connector) IFInfo(ifs []uint64) (*IFInfoReply, error) {
+	// Store uncached interface IDs
+	uncachedIfs := make([]uint64, 0, 128)
+	cachedEntries := make([]IFInfoReplyEntry, 0)
+	for _, iface := range ifs {
+		key := strconv.FormatUint(iface, 10)
+		value, found := c.ifInfos.Get(key)
+		if found {
+			cachedEntries = append(cachedEntries, value.(IFInfoReplyEntry))
+		} else {
+			uncachedIfs = append(uncachedIfs, iface)
+		}
+	}
+
+	if len(uncachedIfs) == 0 {
+		return &IFInfoReply{Entries: cachedEntries}, nil
+	}
+
+	// Some values were not in the cache, so we ask SCIOND for them
+	request := &SCIONDMsg{Id: c.nextID(), Which: proto.SCIONDMsg_Which_ifInfoRequest}
+	request.IfInfoRequest.IfIDs = append([]uint64(nil), uncachedIfs...)
+	err := c.sendRequest(request)
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	reply, err := c.receiveReply()
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+	
+	// Add new information to cache
+	// If SCIOND does not find HostInfo for a requested IFID, the
+	// null answer is not added to the cache.
+	for _, entry := range reply.IfInfoReply.Entries {
+		key := strconv.FormatUint(entry.IfID, 10)
+		c.ifInfos.Set(key, entry, cache.DefaultExpiration)
+	}
+
+	// Append old cached entries to our reply
+	reply.IfInfoReply.Entries = append(reply.IfInfoReply.Entries, cachedEntries...)
+
+	return &reply.IfInfoReply, nil
+}
+
+// SVCInfo requests from SCIOND information about addresses and ports of infrastructure services.
+// Splice svcTypes contains a list of desired service types. If unset, all service types are
+// returned.
+func (c *Connector) SVCInfo(svcTypes []addr.HostSVC) (*ServiceInfoReply, error) {
+	request := &SCIONDMsg{Id: c.nextID(), Which: proto.SCIONDMsg_Which_serviceInfoRequest}
+	request.ServiceInfoRequest.ServiceTypes = append([]addr.HostSVC(nil), svcTypes...)
+	err := c.sendRequest(request)
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+
+	reply, err := c.receiveReply()
+	if err != nil {
+		return nil, common.NewError("err", err)
+	}
+	return &reply.ServiceInfoReply, nil
+}
+
+// Connect connects to a SCIOND server listening on socketName. Future method calls on the
+// returned Connector request information from SCIOND. The information is not
+// guaranteed to be fresh, as the returned connector caches ASInfo replies for ASInfoTTL time,
+// IFInfo replies for IFInfoTTL time and SVCInfo for SVCInfoTTL time.
+func Connect(socketName string) (*Connector, error) {
+	conn, err := reliable.Dial(socketName)
+	if err != nil {
+		return nil, err
+	}
+
+	c := new(Connector)
+	c.conn = conn
+
+	rand.Seed(time.Now().UnixNano())
+	c.requestID = rand.Uint64() % (1 << 32)
+
+	cleanupInterval := time.Minute
+	c.asInfos = cache.New(ASInfoTTL, cleanupInterval)
+	c.ifInfos = cache.New(IFInfoTTL, cleanupInterval)
+	c.svcInfos = cache.New(SVCInfoTTL, cleanupInterval)
+
+	return c, nil
+}
+
+// Close shuts down the connection to a SCIOND server.
+func (c *Connector) Close() error {
+	return c.conn.Close()
+}

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -1,0 +1,194 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sciond
+
+import (
+	"fmt"
+	"github.com/netsec-ethz/scion/go/proto"
+	"github.com/netsec-ethz/scion/go/lib/addr"
+)
+
+type PathErrorCode uint16
+
+const (
+	ErrorOk PathErrorCode = 0
+	ErrorNoPaths PathErrorCode = 1
+	ErrorPSTimeout PathErrorCode = 2
+	ErrorInternal PathErrorCode = 3
+)
+
+func (c PathErrorCode) String() string {
+	switch c {
+	case ErrorOk:
+		return "OK"
+	case ErrorNoPaths:
+		return "No paths available"
+	case ErrorPSTimeout:
+		return "SCIOND timed out while requesting paths"
+	case ErrorInternal:
+		return "SCIOND experienced an internal error"
+	default:
+		return fmt.Sprintf("Unknown error (%v)", c)
+	}
+}
+
+type SCIONDMsg struct {
+	Id	uint64
+	Which proto.SCIONDMsg_Which
+	PathReq PathReq
+	PathReply PathReply
+	AsInfoReq ASInfoReq
+	AsInfoReply	ASInfoReply
+	RevNotification RevNotification
+	IfInfoRequest IFInfoRequest
+	IfInfoReply IFInfoReply
+	ServiceInfoRequest ServiceInfoRequest
+	ServiceInfoReply ServiceInfoReply
+}
+
+type PathReq struct {
+	Dst uint32
+	Src uint32
+	MaxPaths uint16
+	Flags struct {
+		Flush bool
+		Sibra bool
+	}
+}
+
+type PathReply struct {
+	RawErrorCode uint16 `capnp:"errorCode"`
+	ErrorCode PathErrorCode
+	Entries []PathReplyEntry
+}
+
+func (reply *PathReply) prepare() {
+	for i, _ := range reply.Entries {
+		for j, _ := range reply.Entries[i].Path.Interfaces {
+			reply.Entries[i].Path.Interfaces[j].IA =
+				addr.IAFromUint32(reply.Entries[i].Path.Interfaces[j].RawIsdas)
+		}
+	}
+
+	reply.ErrorCode = PathErrorCode(reply.RawErrorCode)
+}
+
+type PathReplyEntry struct {
+	Path FwdPathMeta
+	HostInfo HostInfo
+}
+
+type HostInfo struct {
+	Port uint16
+	Addrs struct {
+		Ipv4 []byte
+		Ipv6 []byte
+	}
+}
+
+type FwdPathMeta struct {
+	FwdPath []byte
+	Mtu uint16
+	Interfaces []PathInterface
+}
+
+type PathInterface struct {
+	RawIsdas uint32 `capnp:"isdas"`
+	IfID uint64
+	IA *addr.ISD_AS `capnp:"-"`
+}
+
+func (entry PathInterface)String() string {
+	return fmt.Sprintf("%v.%v", entry.IA, entry.IfID)
+}
+
+type ASInfoReq struct {
+	Isdas uint32
+}
+
+type ASInfoReply struct {
+	Entries []ASInfoReplyEntry
+}
+
+type ASInfoReplyEntry struct {
+	RawIsdas uint32 `capnp:"isdas"`
+	IA *addr.ISD_AS `capnp:"-"`
+	Mtu uint16
+	IsCore bool
+}
+
+func (reply *ASInfoReply) prepare() {
+	for index,_ := range reply.Entries {
+		reply.Entries[index].IA = addr.IAFromUint32(reply.Entries[index].RawIsdas)
+	}
+}
+
+func (entry ASInfoReplyEntry) String() string {
+	return fmt.Sprintf("ia:%v, mtu:%v, core:%t", entry.IA, entry.Mtu, entry.IsCore)
+}
+
+type RevNotification struct {
+	RevInfo RevInfo
+}
+
+type RevInfo struct {
+	IfID uint64
+	Epoch uint16
+	Nonce []byte
+	Sibling []SiblingHash
+	PrevRoot []byte
+	NextRoot []byte
+	Isdas uint32
+}
+
+type SiblingHash struct {
+	IsLeft bool
+	Hash []byte
+}
+
+type IFInfoRequest struct {
+	IfIDs []uint64
+}
+
+type IFInfoReply struct {
+	Entries []IFInfoReplyEntry
+}
+
+type IFInfoReplyEntry struct {
+	IfID uint64
+	HostInfo HostInfo
+}
+
+func (reply *IFInfoReply) prepare() {
+	// do nothing
+}
+
+type ServiceInfoRequest struct {
+	ServiceTypes []addr.HostSVC
+}
+
+type ServiceInfoReply struct {
+	Entries []ServiceInfoReplyEntry
+}
+
+type ServiceInfoReplyEntry struct {
+	ServiceType addr.HostSVC
+	Ttl uint32
+	HostInfos []HostInfo
+}
+
+func (reply *ServiceInfoReply) prepare() {
+
+}

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -1,0 +1,307 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reliable implements the SCION ReliableSocket protocol
+//
+// Servers should first call Listen on a UNIX socket address, and then call
+// Accept on the received Listener.
+//
+// Clients should either call:
+//   Dial, if they do not want to register a receiving address with the remote end
+//     (e.g., when connecting to SCIOND);
+//   Register, to register the address argument with the remote end
+//     (e.g., when connecting to a dispatcher).
+//
+// The connections are not thread safe.
+//
+package reliable
+
+// ReliableSocket common header message format:
+//   8-bytes: COOKIE (0xde00ad01be02ef03)
+//   1-byte: ADDR TYPE (NONE=0, IPv4=1, IPv6=2, SVC=3, UNIX=4)
+//   4-byte: data length, in Little Endian byte order
+//   var-byte: Destination address (0 bytes for SCIOND API)
+//     +2-byte: If destination address not NONE, destination port
+//   var-byte: Payload
+//
+// ReliableSocket registration message format:
+//  13-bytes: [Common header with address type NONE]
+//   1-byte: Command (bit mask with 0x02=SCMP enable, 0x01 always set)
+//   1-byte: L4 Proto (IANA number)
+//   4-bytes: ISD-AS
+//   2-bytes: Registered port
+//   1-byte: Address type
+//   var-byte: Address
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+// MaxLength contains the maximum payload length for the ReliableSocket framing protocol.
+const MaxLength = 2000
+
+var cookie = []byte{0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef, 0x03}
+
+const (
+	hdrLen           = 13
+	regBaseHeaderLen = 9
+	regCommandField  = 0x03
+)
+
+// Conn implements the ReliableSocket framing protocol over UNIX sockets.
+type Conn struct {
+	*net.UnixConn
+}
+
+// AppAddr is a L3 + L4 address container, it currently only supports UDP for L4.
+type AppAddr struct {
+	Addr addr.HostAddr
+	Port uint16
+}
+
+// Dial connects to the UNIX socket specified by address.
+func Dial(address string) (*Conn, error) {
+	c, err := net.Dial("unix", address)
+	if err != nil {
+		return &Conn{}, common.NewError("Unable to connect", "address", address)
+	}
+	return &Conn{c.(*net.UnixConn)}, nil
+}
+
+// Register connects to a SCION Dispatcher listening on a UNIX socket specified by dispatcher.
+// Future messages for address a in AS ia which arrive at the dispatcher can be read by
+// calling Read on the returned Conn structure.
+func Register(dispatcher string, ia *addr.ISD_AS, a AppAddr) (*Conn, error) {
+	c, err := Dial(dispatcher)
+	if err != nil {
+		return c, common.NewError("Failed to dial", "err", err)
+	}
+
+	request := make([]byte, regBaseHeaderLen+a.Addr.Size())
+	offset := 0
+
+	// Enable SCMP
+	request[offset] = regCommandField
+	offset++
+
+	request[offset] = byte(common.L4UDP)
+	offset++
+
+	ia.Write(request[offset : offset+4])
+	offset += 4
+
+	binary.BigEndian.PutUint16(request[offset:offset+2], a.Port)
+	offset += 2
+
+	if a.Addr.Type() == addr.HostTypeNone {
+		return c, common.NewError("Cannot register NoneType address")
+	}
+	request[offset] = byte(a.Addr.Type())
+	offset++
+
+	copy(request[offset:], a.Addr.Pack())
+
+	_, err = c.Write(request)
+	if err != nil {
+		return c, err
+	}
+
+	// Read the registration confirmation
+	reply := make([]byte, 2)
+	n, err := c.Read(reply)
+	if err != nil {
+		return c, err
+	}
+
+	// TODO(scrye): Fix the dispatcher replying with ports in little-endian
+	replyPort := binary.LittleEndian.Uint16(reply[0:n])
+
+	if a.Port != replyPort {
+		return c, common.NewError("Port mismatch when registering with dispatcher", "expected",
+			a.Port, "actual", replyPort)
+	}
+
+	return c, nil
+}
+
+// Read blocks until it reads the next framed message payload from conn and stores it in b.
+// b must be large enough to fit the entire message. No addressing data is returned,
+// only the payload. On error, return value n is always 0 and may not contain the
+// correct number of bytes read from the socket.
+func (conn *Conn) Read(b []byte) (int, error) {
+	n, _, err := conn.ReadFrom(b)
+	if err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}
+
+// ReadFrom works similarly to Read. In addition to Read, it also returns the last hop
+// (usually, the border router) which sent the message.
+func (conn *Conn) ReadFrom(b []byte) (n int, br AppAddr, err error) {
+	header := make([]byte, hdrLen)
+	_, err = io.ReadFull(conn.UnixConn, header)
+	if err != nil {
+		return 0, br, err
+	}
+
+	offset := 0
+	if bytes.Compare(header[offset:offset+len(cookie)], cookie) != 0 {
+		return 0, br, common.NewError("Protocol desynchronized", "conn", conn)
+	}
+	offset += len(cookie)
+
+	rcvdAddrType := addr.HostAddrType(header[offset])
+	offset++
+
+	// Force endianness (although endianness not explicit in SCIOND)
+	length := binary.LittleEndian.Uint32(header[offset : offset+4])
+	offset += 4
+
+	// Skip address bytes
+	switch rcvdAddrType {
+	case addr.HostTypeNone:
+		// Nothing to skip
+	case addr.HostTypeIPv4, addr.HostTypeIPv6, addr.HostTypeSVC:
+		addrLen, _ := addr.HostLen(rcvdAddrType)
+		// Add 2 bytes for port
+		skipBuf := make([]byte, addrLen+2)
+		n, err = io.ReadFull(conn.UnixConn, skipBuf)
+		if err != nil {
+			return 0, br, err
+		}
+
+		br.Port = binary.LittleEndian.Uint16(skipBuf[addrLen : addrLen+2])
+		// NOTE: ierr is used to avoid nil stored in interface issue
+		var ierr *common.Error
+		br.Addr, ierr = addr.HostFromRaw(skipBuf[0:addrLen], rcvdAddrType)
+		if ierr != nil {
+			return 0, br, common.NewError("Unable to parse address", "address", skipBuf[0:addrLen])
+		}
+	default:
+		return 0, br, common.NewError("Unknown address type", "type", rcvdAddrType)
+	}
+
+	// Read the payload
+	if length > uint32(len(b)) {
+		return 0, br, common.NewError("Insufficient buffer size", "have", len(b), "need", length)
+	}
+
+	n, err = io.ReadFull(conn.UnixConn, b[:length])
+	if err != nil {
+		return 0, br, err
+	}
+
+	return n, br, nil
+}
+
+// Write blocks until it sends b as a single framed message through conn.
+// On error, return value n is always 0 and may not contain the correct number of
+// bytes written to the socket. On success, return value n is always len(b).
+func (conn *Conn) Write(b []byte) (n int, err error) {
+	a, _ := addr.HostFromRaw(nil, addr.HostTypeNone)
+	return conn.WriteTo(b, AppAddr{Addr: a, Port: 0})
+}
+
+// WriteTo works similarly to Write. In addition to Write, the header of the message will
+// contain the address and port information in br.
+func (conn *Conn) WriteTo(b []byte, br AppAddr) (n int, err error) {
+	if len(b) > MaxLength {
+		return 0, common.NewError("Payload exceed max length", "len", len(b), "max", MaxLength)
+	}
+
+	var destLength int
+	switch br.Addr.Type() {
+	case addr.HostTypeNone:
+	case addr.HostTypeIPv4, addr.HostTypeIPv6, addr.HostTypeSVC:
+		// Add 2 bytes for L4 port
+		destLength += br.Addr.Size() + 2
+	default:
+		return 0, fmt.Errorf("Unknown address type (%d)", br.Addr.Type())
+	}
+
+	header := make([]byte, hdrLen+destLength)
+	offset := 0
+
+	copy(header[offset:offset+len(cookie)], cookie)
+	offset += len(cookie)
+
+	header[offset] = byte(br.Addr.Type())
+	offset++
+
+	// TODO(scrye): fix endianness (SCIOND expects machine order)
+	binary.LittleEndian.PutUint32(header[offset:offset+4], uint32(len(b)))
+	offset += 4
+
+	if br.Addr.Type() == addr.HostTypeIPv4 || br.Addr.Type() == addr.HostTypeIPv6 ||
+		br.Addr.Type() == addr.HostTypeSVC {
+		copy(header[offset:], br.Addr.Pack())
+		offset += br.Addr.Size()
+
+		// TODO(scrye): fix endianness (dispatcher expects machine order)
+		binary.LittleEndian.PutUint16(header[offset:offset+2], br.Port)
+		offset += 2
+	}
+
+	_, err = io.Copy(conn.UnixConn, bytes.NewReader(header))
+	if err != nil {
+		return 0, err
+	}
+
+	ntmp, err := io.Copy(conn.UnixConn, bytes.NewReader(b))
+	return int(ntmp), err
+}
+
+func (conn *Conn) String() string {
+	return fmt.Sprintf("&{laddr: %v, raddr: %v}", conn.UnixConn.LocalAddr(),
+		conn.UnixConn.RemoteAddr())
+}
+
+// Listener listens on Unix sockets and returns Conn sockets on Accept().
+type Listener struct {
+	*net.UnixListener
+}
+
+// Listen listens on UNIX socket laddr.
+func Listen(laddr string) (*Listener, error) {
+	l, err := net.Listen("unix", laddr)
+	if err != nil {
+		return &Listener{}, common.NewError("Unable to listen on address", "addr", laddr)
+	}
+
+	return &Listener{l.(*net.UnixListener)}, nil
+}
+
+// Accept returns sockets which implement the SCION ReliableSocket protocol for reading
+// and writing.
+func (listener *Listener) Accept() (*Conn, error) {
+	c, err := listener.UnixListener.Accept()
+	if err != nil {
+		return &Conn{}, common.NewError("Unable to accept", "listener", listener)
+	}
+
+	return &Conn{c.(*net.UnixConn)}, nil
+}
+
+func (listener *Listener) String() string {
+	return fmt.Sprintf("&{addr: %v}", listener.UnixListener.Addr())
+}

--- a/go/lib/sock/reliable/reliable_test.go
+++ b/go/lib/sock/reliable/reliable_test.go
@@ -1,0 +1,140 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reliable
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+)
+
+const (
+	sockName = "/tmp/unixtest.sock"
+)
+
+func Server(t *testing.T, message string) {
+	t.Parallel()
+
+	os.Remove(sockName)
+
+	listener, err := Listen(sockName)
+	if err != nil {
+		t.Fatalf("Error: %v.", err)
+	}
+
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	n, err := conn.Write([]byte(message))
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	if n != len(message) {
+		t.Fatalf("Error: expected to write %v bytes, wrote %v.", len(message), n)
+	}
+
+	err = conn.Close()
+	if err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+}
+
+func Client(t *testing.T, expected string) {
+	t.Parallel()
+
+	e := make(chan error, 1)
+	v := make(chan interface{}, 1)
+
+	go func() {
+		// Sleep to avoid connecting before server is up
+		time.Sleep(200 * time.Millisecond)
+		conn, err := Dial(sockName)
+		e <- err
+		if err == nil {
+			v <- conn
+		}
+	}()
+
+	select {
+	case err := <-e:
+		if err != nil {
+			t.Fatalf("%v", err.Error())
+		}
+	case <-time.After(time.Second * 3):
+		t.Fatalf("Dial timed out for socket %v", sockName)
+	}
+	conn := (<-v).(*Conn)
+
+	go func() {
+		message := make([]byte, MaxLength)
+		n, err := conn.Read(message)
+		e <- err
+		if err == nil {
+			v <- string(message[:n])
+		}
+	}()
+
+	select {
+	case err := <-e:
+		if err != nil {
+			t.Fatalf("%v", err.Error())
+		}
+	case <-time.After(time.Second * 3):
+		t.Fatalf("Read timed out for socket %v", sockName)
+	}
+
+	actual := (<-v).(string)
+	if expected != actual {
+		t.Fatal("message mismatch", "expected", expected, "actual", actual)
+	}
+
+	err := conn.Close()
+	if err != nil {
+		t.Fatal("close failed", "err", err)
+	}
+}
+
+func TestConnection(t *testing.T) {
+	t.Run("Server", func(t *testing.T) { Server(t, "ping") })
+	t.Run("Client", func(t *testing.T) { Client(t, "ping") })
+}
+
+func ExampleRegister(t *testing.T) {
+	dispatcher := "/run/shm/dispatcher/default.sock"
+	e := make(chan error)
+
+	go func() {
+		ia, _ := addr.IAFromString("1-10")
+		host := addr.HostFromIP(net.IPv4(127, 0, 0, 42))
+		port := uint16(40001)
+
+		_, err := Register(dispatcher, ia, AppAddr{Addr: host, Port: port})
+		e <- err
+	}()
+
+	select {
+	case err := <-e:
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+	case <-time.After(time.Second * 3):
+		t.Fatalf("Dispatcher registration timed out")
+	}
+}

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -20,10 +20,12 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/l4"
 	"github.com/netsec-ethz/scion/go/lib/spath"
 	"github.com/netsec-ethz/scion/go/lib/util"
+	"fmt"
 )
 
 // SCION Packet structure.
 type ScnPkt struct {
+	CmnHdr  *CmnHdr
 	DstIA   *addr.ISD_AS
 	SrcIA   *addr.ISD_AS
 	DstHost addr.HostAddr
@@ -33,6 +35,12 @@ type ScnPkt struct {
 	E2EExt  []common.Extension
 	L4      l4.L4Header
 	Pld     common.Payload
+}
+
+func (scnPkt ScnPkt) String() string {
+	return fmt.Sprintf("%v DstIA:%v SrcIA:%v DstHost:%v SrcHost:%v HBHExt:%v E2EExt:%v L4:(%v)",
+		scnPkt.CmnHdr, scnPkt.DstIA, scnPkt.SrcIA, scnPkt.DstHost, scnPkt.SrcHost,
+		scnPkt.HBHExt, scnPkt.E2EExt, scnPkt.L4)
 }
 
 func (s *ScnPkt) Copy() *ScnPkt {


### PR DESCRIPTION
Implements the ReliableSocket protocol for SCION Dispatcher and SCIOND communication.

Includes a simplified Go version of the Python End2End tests in `go/integration`.  The tests do not handle SCMP or Revocation message at the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1085)
<!-- Reviewable:end -->
