### PR TITLE
Fix 2 issues with dependencies.

### DIFF
--- a/env/common.sh
+++ b/env/common.sh
@@ -8,7 +8,7 @@ lower() {
 }
 
 pip_installed() {
-    "${1:?}" --disable-pip-version-check freeze | lower | LC_ALL=C sort
+    "${1:?}" --disable-pip-version-check freeze --all | lower | LC_ALL=C sort
 }
 
 pip_reqs() {

--- a/tools/ci/build_prep
+++ b/tools/ci/build_prep
@@ -10,7 +10,7 @@ tar xf ~/go_vendor.tar.gz -C go/vendor/
 # last built. If any has, fail at the end of the build.
 ./tools/ci/run ./docker/deps_check
 # Install any new dependencies, to test code that depends on them.
-./env/deps
+APTARGS=-y ./env/deps
 # Syncing should be a no-op, just need installation to run
 make -C go deps
 cp sub/web/web_scion/settings/private.dist.py sub/web/web_scion/settings/private.py


### PR DESCRIPTION
- `pip freeze` does not include pip, setuptools, distribute, wheel in
  the output, which breaks `env/pip3/check` if any of those are
  specified in the requirements.txt.
- Run ./env/deps with APTARGS=-y in `tools/ci/build_prep`, otherwise it
  will immediately fail because it can't read an answer from stdin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1086)
<!-- Reviewable:end -->
