### PR TITLE
Fix handling of reversed one-hop-path packets in the BR.

### DIFF
--- a/go/border/ifstate/ifstate.go
+++ b/go/border/ifstate/ifstate.go
@@ -78,9 +78,19 @@ func Process(ifStates proto.IFStateInfos) {
 		}
 		m[ifid] = State{P: info, RawRev: rawRev}
 		gauge := metrics.IFState.WithLabelValues(fmt.Sprintf("intf:%d", ifid))
+		oldState, ok := S.M[ifid]
+		if !ok {
+			log.Info("IFState: intf added", "ifid", ifid, "active", info.Active())
+		}
 		if info.Active() {
+			if ok && !oldState.P.Active() {
+				log.Info("IFState: intf activated", "ifid", ifid)
+			}
 			gauge.Set(1)
 		} else {
+			if ok && oldState.P.Active() {
+				log.Info("IFState: intf deactivated", "ifid", ifid)
+			}
 			gauge.Set(0)
 		}
 	}

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -51,8 +51,8 @@ func (r *Router) RevInfoFwd() {
 		if revInfo == nil {
 			continue
 		}
+		log.Debug("Forwarding revocation", "revInfo", revInfo.Pretty(), "targets", args.Addrs)
 		for _, svcAddr := range args.Addrs {
-			log.Debug("Forwarding revocation.", "target", svcAddr, "revInfo", revInfo)
 			r.fwdRevInfo(revInfo, &svcAddr)
 		}
 	}

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -62,7 +62,6 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 	}
 	if currHopF.Ingress != 0 || currHopF.Egress != 0 {
 		// The current hop field has already been generated.
-		o.Debug("HopF: not regenning", "currHopF", currHopF)
 		return HookContinue, nil, nil
 	}
 	infoF, err := o.rp.InfoF()

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -56,6 +56,15 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		// instead.
 		return HookContinue, nil, nil
 	}
+	currHopF, err := spath.HopFFromRaw(o.rp.Raw[o.rp.CmnHdr.CurrHopF:])
+	if err != nil {
+		return HookError, nil, err
+	}
+	if currHopF.Ingress != 0 || currHopF.Egress != 0 {
+		// The current hop field has already been generated.
+		o.Debug("HopF: not regenning", "currHopF", currHopF)
+		return HookContinue, nil, nil
+	}
 	infoF, err := o.rp.InfoF()
 	if err != nil {
 		return HookError, nil, err

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -36,7 +36,10 @@ const (
 )
 
 func IAFromRaw(b common.RawBytes) *ISD_AS {
-	iaInt := common.Order.Uint32(b)
+	return IAFromInt(int(common.Order.Uint32(b)))
+}
+
+func IAFromInt(iaInt int) *ISD_AS {
 	return &ISD_AS{I: int(iaInt >> 20), A: int(iaInt & 0x000FFFFF)}
 }
 

--- a/go/proto/rev_info.go
+++ b/go/proto/rev_info.go
@@ -1,0 +1,26 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proto
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+)
+
+func (s RevInfo) Pretty() string {
+	return fmt.Sprintf("IA: %s IfID: %d Epoch: %d",
+		addr.IAFromInt(int(s.Isdas())), s.IfID(), s.Epoch())
+}


### PR DESCRIPTION
If a one-hop-path packet causes an error, the reversed packet's
extension will be incorrectly handled by the next router, causing it to
corrupt the hop field. This change adds a check to make sure the hop
field hasn't already been generated, and if it has to skip generating a
new one.

Also:
- Log when interfaces are added/activated/deactivated.
- Add pretty-printing represntation of a revocation info proto object to
  reduce the logging noise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1102)
<!-- Reviewable:end -->
