### PR TITLE
Make base Dockerfile work with newer versions of Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
 
     build:
         docker:
-            - image: kormat/scion_base@sha256:59b0a1265d8d0b7867923ef022b901e3d70335d7a1b31711b739b527c4d749ed
+            - image: kormat/scion_base@sha256:053c79af26c38834a6b6dca282f4415469ef7df4bb0af238c6fec75724ef53ce
         <<: *job
         steps:
             - checkout

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -28,7 +28,7 @@ COPY env/common.sh env/
 
 # Debian packages
 COPY env/debian env/debian
-RUN apt-get update && APTARGS=-y env/debian/deps && apt-get clean
+RUN sudo apt-get update && APTARGS=-y env/debian/deps && sudo apt-get clean
 
 # Pip3 packages
 COPY env/pip3 env/pip3
@@ -52,10 +52,11 @@ COPY env/go env/go
 RUN env/go/deps
 
 # Cleanup
-RUN rm -r env
+RUN sudo rm -r env
 
 # Vendored go packages
 COPY go/vendor/ go/vendor
+RUN sudo chown -R scion .
 RUN \
     set -ex; cd go; govendor sync -v; govendor install ./vendor/...; \
     cd vendor; tar caf ~/go_vendor.tar.gz --owner=scion $(find * -maxdepth 0 -type d); \
@@ -71,7 +72,7 @@ COPY docker/profile $HOME/.profile
 COPY docker/screenrc $HOME/.screenrc
 # Install ZK config
 COPY docker/zoo.cfg /etc/zookeeper/conf/
-RUN echo 'JAVA_OPTS="-Xmx150m" # Added by Dockerfile.base' >> /etc/zookeeper/conf/environment
+RUN sudo sh -c "echo 'JAVA_OPTS=-Xmx150m # Added by Dockerfile.base' >> /etc/zookeeper/conf/environment"
 
 # Fix ownership one last time:
 RUN sudo chown -R scion: $HOME


### PR DESCRIPTION
Docker 17.x seems to not tolerate a lack of permissions quite as well as
older versions did. Thus, sprinkle a few `sudo`s into the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1106)
<!-- Reviewable:end -->
