### PR TITLE
Fix case where core BS/PS aren't informed about revocations.

### DIFF
--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -194,25 +194,8 @@ func (rp *RtrPkt) processSCMP() (HookResult, *common.Error) {
 	// FIXME(shitz): rate-limit revocations
 	hdr := rp.l4.(*scmp.Hdr)
 	switch {
-	case rp.DirFrom == DirExternal && hdr.Class == scmp.C_Path &&
-		hdr.Type == scmp.T_P_RevokedIF:
-		var args RevTokenCallbackArgs
-		pld := rp.pld.(*scmp.Payload)
-		args.RevInfo = pld.Info.(*scmp.InfoRevocation).RevToken
-		if rp.srcIA.I == rp.Ctx.Conf.IA.I && rp.isDownstreamRouter() {
-			// Forward to PS and BS if router is downstream of the failed interface.
-			args.Addrs = append(args.Addrs, addr.SvcBS)
-			if len(rp.Ctx.Conf.TopoMeta.T.PS) > 0 {
-				args.Addrs = append(args.Addrs, addr.SvcPS)
-			}
-		} else if rp.dstIA.Eq(rp.Ctx.Conf.IA) && len(rp.Ctx.Conf.TopoMeta.T.PS) > 0 {
-			// Forward to PS if we are in the AS of the destination.
-			args.Addrs = append(args.Addrs, addr.SvcPS)
-		}
-
-		if len(args.Addrs) > 0 {
-			callbacks.revTokenF(args)
-		}
+	case rp.DirFrom == DirExternal && hdr.Class == scmp.C_Path && hdr.Type == scmp.T_P_RevokedIF:
+		rp.processSCMPRevocation()
 	default:
 		rp.Error("Unsupported destination SCMP payload", "class", hdr.Class,
 			"type", hdr.Type)
@@ -220,9 +203,36 @@ func (rp *RtrPkt) processSCMP() (HookResult, *common.Error) {
 	return HookFinish, nil
 }
 
-func (rp *RtrPkt) isDownstreamRouter() bool {
+// processSCMPRevocation handles SCMP revocations.
+// There are 3 cases where the router does more than just forward an SCMP revocation message.
+// 1. The revocation was received on a core interface, and the destination is in this ISD. In this
+//    case the revocation is forked, and forwarded to the local BS and PS services. This prevents
+//    the BS from propagating/registering revoked core PCBs. The destination check ensures that this
+//    is only done for revocations which impact the local ISD.
+// 2. The revocation was received from a parent AS, and the revoked interface is in the same ISD.
+//    In this case the revocation is also forked to the local BS and PS services. This ensures that
+//    ASes downstream of a revoked interface get informed quickly.
+// 3. The revocation's destination is the local AS. The revocation notification is forked to the
+//    local PS, to ensure that it stops providing segments with revoked interfaces to clients.
+func (rp *RtrPkt) processSCMPRevocation() {
+	var args RevTokenCallbackArgs
+	pld := rp.pld.(*scmp.Payload)
+	args.RevInfo = pld.Info.(*scmp.InfoRevocation).RevToken
 	intf := rp.Ctx.Conf.Net.IFs[*rp.ifCurr]
-	return intf.Type == "PARENT"
+	if (rp.dstIA.I == rp.Ctx.Conf.IA.I && intf.Type == topology.LinkCore) ||
+		(rp.srcIA.I == rp.Ctx.Conf.IA.I && intf.Type == topology.LinkParent) {
+		// Case 1 & 2
+		args.Addrs = append(args.Addrs, addr.SvcBS)
+		if len(rp.Ctx.Conf.TopoMeta.T.PS) > 0 {
+			args.Addrs = append(args.Addrs, addr.SvcPS)
+		}
+	} else if rp.dstIA.Eq(rp.Ctx.Conf.IA) && len(rp.Ctx.Conf.TopoMeta.T.PS) > 0 {
+		// Case 3
+		args.Addrs = append(args.Addrs, addr.SvcPS)
+	}
+	if len(args.Addrs) > 0 {
+		callbacks.revTokenF(args)
+	}
 }
 
 // getSVCNamesMap returns the slice of instance names and addresses for a given

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -594,11 +594,11 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
     def _handle_scmp_revocation(self, pld, meta):
         rev_info = RevocationInfo.from_raw(pld.info.rev_info)
-        logging.debug("Received revocation via SCMP:\n%s", rev_info.short_desc())
+        logging.debug("Received revocation via SCMP: %s", rev_info.short_desc())
         self._process_revocation(rev_info)
 
     def _handle_revocation(self, rev_info, meta):
-        logging.debug("Received revocation via TCP/UDP:\n%s", rev_info.short_desc())
+        logging.debug("Received revocation via TCP/UDP: %s", rev_info.short_desc())
         if not self._validate_revocation(rev_info):
             return
         self._process_revocation(rev_info)

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -594,11 +594,11 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
     def _handle_scmp_revocation(self, pld, meta):
         rev_info = RevocationInfo.from_raw(pld.info.rev_info)
-        logging.debug("Received revocation via SCMP: %s", rev_info.short_desc())
+        logging.debug("Received revocation via SCMP: %s (from %s)", rev_info.short_desc(), meta)
         self._process_revocation(rev_info)
 
     def _handle_revocation(self, rev_info, meta):
-        logging.debug("Received revocation via TCP/UDP: %s", rev_info.short_desc())
+        logging.debug("Received revocation via TCP/UDP: %s (from %s)", rev_info.short_desc(), meta)
         if not self._validate_revocation(rev_info):
             return
         self._process_revocation(rev_info)
@@ -711,7 +711,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 ifid_states = [(req.p.ifID, self.ifid_state[req.p.ifID])]
             else:
                 logging.error("Received ifstate request from %s for unknown "
-                              "interface %s.", meta.get_addr(), req.p.ifID)
+                              "interface %s.", meta, req.p.ifID)
                 return
 
             for (ifid, state) in ifid_states:

--- a/infrastructure/cert_server/main.py
+++ b/infrastructure/cert_server/main.py
@@ -181,7 +181,7 @@ class CertServer(SCIONElement):
                 logging.warning(
                     "Dropping CC request from %s for %sv%s: "
                     "CC not found && requester is not local)",
-                    meta.get_addr(), *key)
+                    meta, *key)
             else:
                 self.cc_requests.put((key, (meta, req)))
             return
@@ -228,7 +228,7 @@ class CertServer(SCIONElement):
         meta = req_info[0]
         cert_chain = self.trust_store.get_cert(isd_as, ver)
         self.send_meta(CertChainReply.from_values(cert_chain), meta)
-        logging.info("Cert chain for %sv%s sent to %s:%s", isd_as, ver, meta.get_addr(), meta.port)
+        logging.info("Cert chain for %sv%s sent to %s", isd_as, ver, meta)
 
     def process_trc_request(self, req, meta):
         """Process a TRC request."""
@@ -241,7 +241,7 @@ class CertServer(SCIONElement):
                 logging.warning(
                     "Dropping TRC request from %s for %sv%s: "
                     "TRC not found && requester is not local)",
-                    meta.get_addr(), *key)
+                    meta, *key)
             else:
                 self.trc_requests.put((key, (meta, req)))
             return
@@ -293,7 +293,7 @@ class CertServer(SCIONElement):
         meta = req_info[0]
         trc = self.trust_store.get_trc(isd, ver)
         self.send_meta(TRCReply.from_values(trc), meta)
-        logging.info("TRC for %sv%s sent to %s:%s", isd, ver, meta.get_addr(), meta.port)
+        logging.info("TRC for %sv%s sent to %s", isd, ver, meta)
 
     def _get_path_via_api(self, isd_as, flush=False):
         flags = lib_sciond.PathRequestFlags(flush=flush)

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -218,7 +218,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         if rev_info in self.revocations:
             return False
         self.revocations.add(rev_info)
-        logging.debug("Received revocation from %s: %s", meta.get_addr(), rev_info.short_desc())
+        logging.debug("Received revocation from %s: %s", meta, rev_info.short_desc())
         self._revs_to_zk.append(rev_info.copy().pack())  # have to pack copy
         # Remove segments that contain the revoked interface.
         self._remove_revoked_segments(rev_info)

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -1044,7 +1044,7 @@ class SCIONElement(object):
             otherwise.
         """
         if rev_info.p.ifID == 0:
-            logging.warning("Received revocation for ifID 0. Ignoring.\n%s" %
+            logging.warning("Received revocation for ifID 0. Ignoring. %s" %
                             rev_info.short_desc())
             return False
         return True

--- a/lib/msg_meta.py
+++ b/lib/msg_meta.py
@@ -48,7 +48,7 @@ class MetadataBase(object):
         pass
 
     def __str__(self):
-        return str(self.get_addr())
+        return "%s:%d" % (self.get_addr(), self.port)
 
 
 class UDPMetadata(MetadataBase):

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -75,7 +75,7 @@ class E2EClient(TestClientBase):
                 scmp_hdr.type == SCMPPathClass.REVOKED_IF):
             scmp_pld = spkt.get_payload()
             rev_info = RevocationInfo.from_raw(scmp_pld.info.rev_info)
-            logging.info("Received revocation: %s", rev_info.short_desc())
+            logging.info("Received revocation: %s (from %s)", rev_info.short_desc(), spkt.addrs.src)
             lib_sciond.send_rev_notification(
                 rev_info, connector=self._connector)
             return ResponseRV.RETRY

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -75,7 +75,7 @@ class E2EClient(TestClientBase):
                 scmp_hdr.type == SCMPPathClass.REVOKED_IF):
             scmp_pld = spkt.get_payload()
             rev_info = RevocationInfo.from_raw(scmp_pld.info.rev_info)
-            logging.info("Received revocation for IF %d." % rev_info.p.ifID)
+            logging.info("Received revocation: %s", rev_info.short_desc())
             lib_sciond.send_rev_notification(
                 rev_info, connector=self._connector)
             return ResponseRV.RETRY

--- a/tools/zkcleanslate
+++ b/tools/zkcleanslate
@@ -13,6 +13,7 @@ from kazoo.handlers.threading import KazooTimeoutError
 
 # SCION
 from lib.topology import Topology
+from lib.defines import TOPO_FILE
 
 
 def main():
@@ -33,7 +34,7 @@ def main():
 
 def find_servers():
     for as_dir in glob.glob("gen/ISD*/AS*"):
-        t = Topology.from_file(os.path.join(as_dir, "endhost", "topology.yml"))
+        t = Topology.from_file(os.path.join(as_dir, "endhost", TOPO_FILE))
         for zk_host in t.zookeepers:
             yield zk_host
 


### PR DESCRIPTION
The bug can be reproduced by doing:

./test/integration/end2end_test.py 2-24 1-16
./supervisor/supervisor.sh mstop *:br1-13*
./test/integration/end2end_test.py --retries 3 2-24 1-16

That last step should fail to get any path by the third retry, as the
two core links to 1-13 are down. However, as the BS/PS don't receive the
revocations, the BS continues to register segments that passed through
1-13, and the PS continues to hand out these segments.

This change fixes the logic, so that a core AS will notifiy its BS/PS
services of revocations if the destination is a local AS. Running the
above steps with this change causes the second e2e test to (correctly)
fail to get any paths to 1-13.

Also:
- As RevocationInfo now has a `short_desc` method, stop putting them on a new
  line in logging statements.
- Log the `rev_info.short_desc()` in e2e, instead of just the interface.
- Fix tools/zkcleanslate to use the correct topo file name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1114)
<!-- Reviewable:end -->
