### PR TITLE
Cert sync with book

### DIFF
--- a/topology/Default.topo
+++ b/topology/Default.topo
@@ -43,16 +43,16 @@ ASes:
     certificate_servers: 3
     cert_issuer: 1-13
   1-17:
-    cert_issuer: 1-14
+    cert_issuer: 1-11
     mtu: 1450
   1-18:
-    cert_issuer: 1-15
+    cert_issuer: 1-12
   1-19:
     path_servers: 2
     certificate_servers: 3
-    cert_issuer: 1-16
+    cert_issuer: 1-13
   1-10:
-    cert_issuer: 1-19
+    cert_issuer: 1-13
   2-21:
     core: true
     mtu: 1280
@@ -64,9 +64,9 @@ ASes:
     cert_issuer: 2-22
     certificate_servers: 3
   2-25:
-    cert_issuer: 2-23
+    cert_issuer: 2-21
   2-26:
-    cert_issuer: 2-24
+    cert_issuer: 2-22
 CAs:
   CA1-1:
     ISD: 1

--- a/topology/Wide.topo
+++ b/topology/Wide.topo
@@ -16,8 +16,8 @@ ASes:
   2-4: {cert_issuer: 2-2}
   3-1: {core: true}
   3-3: {cert_issuer: 3-1}
-  3-4: {cert_issuer: 3-3}
-  3-5: {cert_issuer: 3-3}
+  3-4: {cert_issuer: 3-1}
+  3-5: {cert_issuer: 3-1}
   4-1: {core: true}
   5-1: {core: true}
   5-2: {core: true}


### PR DESCRIPTION
In the current implementation every AS gets a certificate issued by its parent AS, thus creating long certificate chains.
This PR contains the following changes:

- Clear separation between core and non-core AS certificates

- Core AS certificates are signed and verified based on online root keys

- Only core ASes issue certificates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1117)
<!-- Reviewable:end -->
