### PR TITLE
Add second order DRKey to CertServer

### DIFF
--- a/proto/drkey_mgmt.capnp
+++ b/proto/drkey_mgmt.capnp
@@ -27,10 +27,66 @@ struct DRKeyRep {
     trcVer @7 :UInt32;     # Version of TRC, of signing cert
 }
 
+struct DRKeyHostHolder {
+    type @0 :UInt8; # AddrType
+    host @1 :Data;  # Host address
+}
+
+struct DRKeyProtocolReq {
+    protocol @0 :UInt32;  # Protocol identifier
+    reqID @1 :UInt64;     # Request identifier
+    timestamp @2 :UInt64; # Timestamp
+    reqType @3 :UInt8;    # Requested DRKeyProtoKeyType
+    srcIA @4 :UInt32;     # Src ISD-AS of the requested DRKey
+    dstIA @5 :UInt32;     # Dst ISD-AS of the requested DRKey
+    addIA :union {        # Additional ISD-AS of the requested DRKey (optional)
+        unset @6 :Void;
+        ia @7 :UInt32;
+    }
+    srcHost :union {      # Src Host of the request DRKey (optional)
+        unset @8 :Void;
+        holder @9 :DRKeyHostHolder;
+    }
+    dstHost :union {      # Dst Host of the request DRKey (optional)
+        unset @10 :Void;
+        holder @11 :DRKeyHostHolder;
+    }
+    addHost :union {      # Additional Host of the request DRKey (optional)
+        unset @12 :Void;
+        holder @13 :DRKeyHostHolder;
+    }
+    misc :union {         # Additional information for DRKey derivation (optional)
+        unset @14 :Void;
+        opt @15 :MiscOPTReq;
+    }
+}
+
+struct DRKeyProtocolRep {
+    reqID @0 :UInt64;     # Request identifier
+    timestamp @1 :UInt64; # Timestamp
+    drkey @2 :Data;       # Derived DRKey
+    expTime @3 :UInt64;   # Expiration time of DRKey
+    misc :union {         # Additional information (optional)
+        unset @4 :Void;
+        opt @5 :MiscOPTRep;
+    }
+}
+
 struct DRKeyMgmt {
     union {
         unset @0 :Void;
         drkeyReq @1 :DRKeyReq;
         drkeyRep @2 :DRKeyRep;
+        drkeyProtocolReq @3 :DRKeyProtocolReq;
+        drkeyProtocolRep @4 :DRKeyProtocolRep;
     }
+}
+
+struct MiscOPTReq {
+    sessionID @0 :Data;    # Session id (16B)
+    path @1 :List(UInt32); # List of ASes on the path.
+}
+
+struct MiscOPTRep {
+    drkeys @0 :List(Data); # List of DRKeys for ASes on the path.
 }

--- a/python/lib/drkey/drkey_mgmt.py
+++ b/python/lib/drkey/drkey_mgmt.py
@@ -21,7 +21,9 @@ import capnp  # noqa
 # SCION
 import proto.drkey_mgmt_capnp as P
 
+from lib.drkey.types import DRKeyMiscType
 from lib.errors import SCIONParseError
+from lib.packet.host_addr import haddr_parse
 from lib.packet.packet_base import SCIONPayloadBaseProto
 from lib.packet.scion_addr import ISD_AS
 from lib.types import DRKeyMgmtType, PayloadClass
@@ -107,9 +109,160 @@ class DRKeyReply(DRKeyMgmtBase):
                    self.p.certVerDst, self.p.trcVer, self.p.timestamp))
 
 
+class DRKeyProtocolRequest(DRKeyMgmtBase):
+    """ DRKey protocol request for second order DRKey. """
+    NAME = "DRKeyProtocolRequest"
+    PAYLOAD_TYPE = DRKeyMgmtType.PROTOCOL_REQUEST
+    P_CLS = P.DRKeyProtocolReq
+
+    class Params(object):
+        timestamp = None        # int (format: drkey_time())
+        request_type = None     # DRKeyProtoKeyType (4 > x >= 0)
+        request_id = None       # int
+        protocol = None         # DRKeyProtocols
+        src_ia = None           # ISD_AS
+        dst_ia = None           # ISD_AS
+        add_ia = None           # ISD_AS
+        src_host = None         # HostAddrBase
+        dst_host = None         # HostAddrBase
+        add_host = None         # HostAddrBase
+        misc = None             # DRKeyMiscType
+
+    @classmethod
+    def _parse_host(cls, union):
+        if union.which() == "holder":
+            return haddr_parse(union.holder.type, union.holder.host)
+        return None
+
+    @classmethod
+    def _parse_misc(cls, union):
+        type_ = union.which()
+        misc_map = {
+            DRKeyMiscType.UNSET: lambda x: None,
+        }
+        handler = misc_map.get(type_)
+        if not handler:
+            raise SCIONParseError("Unsupported misc type: %s" % type_)
+        return handler(getattr(union, type_))
+
+    @classmethod
+    def _set_misc(cls, union, misc):
+        # Mapping DRKeyMiscBase -> DRKeyMiscType
+        misc_map = {
+        }
+        type_ = misc_map.get(type(misc))
+        if not type_:
+            raise SCIONParseError("Unsupported misc type: %s" % type(misc))
+        setattr(union, type_, misc.p)
+
+    def __init__(self, p):
+        super().__init__(p)
+
+        self.src_ia = ISD_AS(p.srcIA)
+        self.dst_ia = ISD_AS(p.dstIA)
+        if p.addIA.which() == "ia":
+            self.add_ia = ISD_AS(p.addIA.ia)
+        else:
+            self.add_ia = None
+        self.src_host = self._parse_host(p.srcHost)
+        self.dst_host = self._parse_host(p.dstHost)
+        self.add_host = self._parse_host(p.addHost)
+        self.misc = self._parse_misc(p.misc)
+
+    @classmethod
+    def from_values(cls, params):  # pragma: no cover
+        """
+        Get the DRKeyProtocolRequest from values.
+
+        :param Params params: object holding the necessary parameters.
+        :returns: the resulting DRKeyProtocolRequest.
+        :rtype: DRKeyProtocolRequest
+        """
+        proto = cls.P_CLS.new_message(
+            reqType=params.request_type, srcIA=params.src_ia.int(), dstIA=params.dst_ia.int(),
+            protocol=params.protocol, reqID=params.request_id, timestamp=params.timestamp)
+        if params.add_ia:
+            proto.addIA.ia = params.add_ia.int()
+        if params.src_host:
+            proto.srcHost.holder = P.DRKeyHostHolder.new_message(
+                type=params.src_host.TYPE, host=params.src_host.pack())
+        if params.dst_host:
+            proto.dstHost.holder = P.DRKeyHostHolder.new_message(
+                type=params.dst_host.TYPE, host=params.dst_host.pack())
+        if params.add_host:
+            proto.addHost.holder = P.DRKeyHostHolder.new_message(
+                type=params.add_host.TYPE, host=params.add_host.pack())
+        if params.misc:
+            cls._set_misc(proto.misc, params.misc)
+        return cls(proto)
+
+    def tuple(self):
+        return (self.p.reqType, self.p.protocol, self.src_host, self.dst_host,
+                self.add_host, self.src_ia, self.dst_ia, self.add_ia)
+
+    def short_desc(self):
+        return "ID: %s ReqType: %s Src (%s,%s) Dst: (%s,%s) Add: (%s,%s)" % (
+            self.p.reqID, self.p.reqType, self.src_ia, self.src_host,
+            self.dst_ia, self.dst_host, self.add_ia, self.dst_host)
+
+
+class DRKeyProtocolReply(DRKeyMgmtBase):
+    """ DRKey protocol reply for second order DRKey. """
+    NAME = "DRKeyProtocolReply"
+    PAYLOAD_TYPE = DRKeyMgmtType.PROTOCOL_REPLY
+    P_CLS = P.DRKeyProtocolRep
+
+    @classmethod
+    def _parse_misc(cls, union):
+        type_ = union.which()
+        misc_map = {
+            DRKeyMiscType.UNSET: lambda x: None,
+        }
+        handler = misc_map.get(type_)
+        if not handler:
+            raise SCIONParseError("Unsupported misc type: %s" % type_)
+        return handler(getattr(union, type_))
+
+    @classmethod
+    def _set_misc(cls, union, misc):
+        # Mapping DRKeyMiscBase -> DRKeyMiscType
+        misc_map = {
+        }
+        type_ = misc_map.get(type(misc))
+        if not type_:
+            raise SCIONParseError("Unsupported misc type: %s" % type(misc))
+        setattr(union, type_, misc.p)
+
+    def __init__(self, p):
+        super().__init__(p)
+        self.misc = self._parse_misc(p.misc)
+
+    @classmethod
+    def from_values(cls, req_id, drkey, exp_time, timestamp, misc=None):   # pragma: no cover
+        """
+        Get DRKeyProtocolReply from values.
+
+        :param int req_id: id of the corresponding request.
+        :param bytes drkey: the protocol DRKey.
+        :param int exp_time: expiration time of the protocol DRKey
+        :param int timestamp: timestamp of the creation time.
+        :param misc:
+        :returns: the resulting DRKeyProtocolReply
+        :rtype: DRKeyProtocolReply
+        """
+        proto = cls.P_CLS.new_message(
+            reqID=req_id, drkey=drkey, expTime=exp_time, timestamp=timestamp)
+        if misc:
+            cls._set_misc(proto.misc, misc)
+        return cls(proto)
+
+    def short_desc(self):
+        return "ID: %s expTime: %s" % (self.p.reqID, self.p.expTime)
+
+
 def parse_drkeymgmt_payload(wrapper):  # pragma: no cover
     type_ = wrapper.which()
-    for c in (DRKeyRequest, DRKeyReply):
+    for c in (DRKeyRequest, DRKeyReply, DRKeyProtocolRequest, DRKeyProtocolReply):
         if c.PAYLOAD_TYPE == type_:
             return c(getattr(wrapper, type_))
     raise SCIONParseError("Unsupported DRKey management type: %s" % type_)

--- a/python/lib/drkey/suite.py
+++ b/python/lib/drkey/suite.py
@@ -27,6 +27,15 @@ from lib.crypto.asymcrypto import encrypt, decrypt, sign
 from lib.crypto.symcrypto import mac
 from lib.drkey.drkey_mgmt import DRKeyReply, DRKeyRequest
 from lib.drkey.util import drkey_time
+from lib.errors import SCIONKeyError
+
+# Available protocols
+_protocol_map = {
+    # DRKeyProtocols -> DRKeyProtocolBase
+}
+
+for v in _protocol_map.values():
+    assert v and len(v.PREFIX) <= 255
 
 ##################
 # DRKey Request  #
@@ -148,3 +157,78 @@ def decrypt_drkey(cipher, private_key, public_key):
     :raises: CryptoError
     """
     return decrypt(cipher, private_key, PublicKey(public_key))
+
+##################
+# DRKey Protocol #
+##################
+
+
+def get_drkey_proto_req_verifer(protocol):
+    """
+    Returns the DRKeyProtocolBase.verify_request function according to the protocol.
+
+    :param int protocol: protocol identifier.
+    :returns: the protocol request verifier.
+    :raises SCIONKeyError
+    """
+    try:
+        return _protocol_map[protocol].verify_request
+    except KeyError:
+        raise SCIONKeyError("Protocol %s not supported", protocol)
+
+
+def get_required_drkeys_handler(protocol):
+    """
+    Returns the DRKeyProtocolBase.required_drkeys function according to the protocol.
+
+    :param int protocol: protocol identifier.
+    :returns: the handler returning required first order DRKeys.
+    :raises SCIONKeyError
+    """
+
+    try:
+        return _protocol_map[protocol].required_drkeys
+    except KeyError:
+        raise SCIONKeyError("Protocol %s not supported", protocol)
+
+
+def get_drkey_generator(protocol):
+    """
+    Returns the DRKeyProtocolBase.generate_drkey function according to the protocol.
+
+   :param int protocol: protocol identifier.
+   :returns: the protocol DRKey generator.
+   :raises SCIONKeyError
+   """
+    try:
+        return _protocol_map[protocol].generate_drkey
+    except KeyError:
+        raise SCIONKeyError("Protocol %s not supported", protocol)
+
+
+def get_drkey_misc_rep_generator(protocol):
+    """
+    Returns the DRKeyProtocolBase.generate_misc_reply function according to the protocol.
+
+    :param int protocol: protocol identifier.
+    :returns: the protocol misc generator.
+    :raises SCIONKeyError
+    """
+    try:
+        return _protocol_map[protocol].generate_misc_reply
+    except KeyError:
+        raise SCIONKeyError("Protocol %s not supported", protocol)
+
+
+def get_drkey_misc_rep_parser(protocol):
+    """
+    Returns the DRKeyProtocolBase.parse_misc_reply function according to the protocol.
+
+   :param int protocol: protocol identifier.
+   :returns: the protocol misc parser.
+   :raises SCIONKeyError
+   """
+    try:
+        return _protocol_map[protocol].parse_misc_reply
+    except KeyError:
+        raise SCIONKeyError("Protocol %s not supported", protocol)

--- a/python/lib/drkey/types.py
+++ b/python/lib/drkey/types.py
@@ -18,9 +18,201 @@
 For all type classes used in DRKey
 """
 
+# stdlib
+import struct
+
+# SCION
+from lib.crypto.symcrypto import mac
+from lib.packet.packet_base import Cerealizable
+from lib.types import TypeBase, AddrType
+
+
 ###########################
 # DRKey types
 ###########################
+
+# Block size of AES-128
+BLOCK_SIZE = 16
+
+
+class DRKeyProtoKeyType(TypeBase):
+    """ Available protocol DRKey types."""
+    AS_TO_AS = 0
+    AS_TO_HOST = 1
+    HOST_TO_HOST = 2
+    AS_TO_HOST_PAIR = 3
+
+
+class DRKeyProtocols(TypeBase):
+    """ Available protocols. Protocol must be registered in suite._protocol_map"""
+    OPT = 0
+    SCMP_AUTH = 1
+
+
+class DRKeyMiscType(TypeBase):
+    """ Available misc types. """
+    UNSET = "unset"
+    OPT = "opt"
+
+
+class DRKeyMiscBase(Cerealizable):
+    """ Basis for DRKeyProtocolRequest and DRKeyProtocolReply misc types. """
+    pass
+
+
+class DRKeyInputType(TypeBase):
+    """
+    Input type for second order DRKey derivation. The derivation has either 0, 1 or 2 addresses
+    as input. DRKeyInputType is used to protect against input which differs but could result in
+    the same DRKey: eg. [0.0.0.0, 0::0] and [0::0, 0.0.0.0] result in the same input except for
+    the DRKeyInputType.
+    """
+    _IPV4 = 1                   # 0001
+    _IPV6 = 2                   # 0010
+    _SVC = 3                    # 0011
+
+    NONE = 0                    # 0000
+    IPV4 = 4                    # 0100
+    IPV6 = 8                    # 1000
+    SVC = 12                    # 1100
+
+    IPV4_IPV4 = IPV4 | _IPV4    # 0101
+    IPV4_IPV6 = IPV4 | _IPV6    # 0110
+    IPV4_SVC = IPV4 | _SVC      # 0111
+
+    IPV6_IPV4 = IPV6 | _IPV4    # 1001
+    IPV6_IPV6 = IPV6 | _IPV4    # 1010
+    IPV6_SVC = IPV6 | _SVC      # 1011
+
+    SVC_IPV4 = SVC | _IPV4      # 1101
+    SVC_IPV6 = SVC | _IPV6      # 1110
+    SVC_SVC = SVC | _SVC        # 1111
+
+    @classmethod
+    def from_hosts(cls, first=None, second=None):
+        """
+        Returns the DRKeyInputType based on the input.
+        If second is set, first has to be set as well.
+
+        :param HostAddrBase first: first host in the input. (Can be None)
+        :param HostAddrBase second: second host in the input. (Can be None)
+        :returns: the input type.
+        :rtype: int
+        """
+        assert first or not second
+        input_type = cls.NONE
+        if not first:
+            return input_type
+        if first.TYPE == AddrType.IPV4:
+            input_type |= cls.IPV4
+        elif first.TYPE == AddrType.IPV6:
+            input_type |= cls.IPV6
+        elif first.TYPE == AddrType.SVC:
+            input_type |= cls.SVC
+        if not second:
+            return input_type
+        if second.TYPE == AddrType.IPV4:
+            input_type |= cls._IPV4
+        elif second.TYPE == AddrType.IPV6:
+            input_type |= cls._IPV6
+        elif second.TYPE == AddrType.SVC:
+            input_type |= cls.SVC
+        return input_type
+
+
+class DRKeyProtocolBase(object):
+    """ Base class for a DRKey protocol."""
+    # the prefix used for key derivation. At most 255 bytes.
+    PREFIX = b""
+
+    @staticmethod
+    def verify_request(request, meta):
+        """
+        Verify that a second order DRKey request is valid.
+        I.e. the requester is allowed to request the key the timestamp is recent, the
+        request is well formed.
+
+        :param DRKeyProtocolRequest request: the protocol DRKey request.
+        :param UDPMetadata meta: the metadata
+        :raises: SCIONVerificationError if the request is invalid.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def required_drkeys(request, meta):
+        """
+        Returns a list of the needed first order DRKey required to derive the second order
+        DRKey and misc.
+
+        :param DRKeyProtocolRequest request: the protocol DRKey request.
+        :param UDPMetadata meta: the metadata.
+        :returns: list of needed first order DRKeys.
+        :rtype: [FirstOrderDRKey]
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def generate_drkey(cls, drkeys, request, meta):
+        """
+        Generate the raw second order DRKey.
+
+        :param [FirstOrderDRKey] drkeys: list of the required first order DRKeys.
+        :param DRKeyProtocolRequest request: the protocol DRKey request.
+        :param UDPMetadata meta: the metadata.
+        :returns: the raw second order DRKey.
+        :rtype: bytes
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def _derive_drkey(cls, drkey, first=None, second=None):
+        """
+        Derive raw second order DRKey. Prepends the type of the input and the length of the
+        protocol prefix befor deriving.
+
+        :param FirstOrderDRKey drkey: First order DRKey used for derivation.
+        :param HostAddrBase first: First host address in the input
+        :param HostAddrBase second: Second host address in the input
+        :returns: the derived raw second order DRKey.
+        :rtype bytes
+        """
+        l = [struct.pack("!B", DRKeyInputType.from_hosts(first, second)),
+             struct.pack("!B", len(cls.PREFIX)), cls.PREFIX]
+        if first:
+            l.append(first.pack())
+        if second:
+            l.append(second.pack())
+        l.append(bytes(BLOCK_SIZE - (sum((len(e) for e in l)) % BLOCK_SIZE)))
+        return mac(drkey.drkey, b"".join(l))
+
+    @staticmethod
+    def generate_misc_reply(drkeys, request, meta):
+        """
+        Generate misc on the certificate server. (optional)
+        This misc is added to the DRKeyProtocolReply and sent to the end host.
+        If further processing is necessary on the end host, it can be done in
+        parse_misc_reply.
+
+        :param [FirstOrderDRKey] drkeys: list of the required first order DRKeys.
+        :param DRKeyProtocolRequest request: the protocol DRKey request.
+        :param UDPMetadata meta: the metadata.
+        :returns: the created misc or None.
+        :rtype: DRKeyMiscBase
+        """
+
+        return None
+
+    @staticmethod
+    def parse_misc_reply(request, reply):
+        """
+        Parse can do further manipulations on DRKeyProtocolReply.misc,
+        based on both the DRKeyProtocolRequest and DRKeyProtocolReply.
+        (optional)
+
+        :param DRKeyProtocolRequest request: the protocol DRKey request.
+        :param DRKeyProtocolReply reply: the protocol DRKey reply.
+        """
+        pass
 
 
 class DRKeySecretValue(object):
@@ -74,4 +266,67 @@ class FirstOrderDRKey(BaseDRKey):
         drkey = self.drkey.hex() if self.drkey else "None"
         return "FirstOrderDRKey (%s->%s): %s expires %s" % (
             self.src_ia, self.dst_ia, drkey, self.exp_time
+        )
+
+
+class SecondOrderDRKey(BaseDRKey):
+
+    def __init__(self, drkey, exp_time, key_type, protocol, src_ia, dst_ia,
+                 add_ia=None, src_host=None, dst_host=None, add_host=None):
+        """
+        Create second order DRKey.
+
+        :param bytes drkey: raw protocol DRKey.
+        :param int exp_time: expiration time of the protocol DRKey.
+        :param DRKeyProtoKeyType key_type: type of the protocol DRKey.
+        :param DRKeyProtocols protocol: the protocol.
+        :param ISD_AS src_ia: source ISD-AS of the DRKey.
+        :param ISD_AS dst_ia: destination ISD-AS of the DRKey.
+        :param ISD_AS add_ia: additional ISD-AS of the DRKey.
+        :param HostAddrBase src_host: source host of the DRKey.
+        :param HostAddrBase dst_host: destination host of the DRKey.
+        :param HostAddrBase add_host: additional host of the DRKey.
+        """
+        self.exp_time = exp_time
+        self.key_type = key_type
+        self.protocol = protocol
+        self.src_host = src_host
+        self.dst_host = dst_host
+        self.add_host = add_host
+        self.src_ia = src_ia
+        self.dst_ia = dst_ia
+        self.add_ia = add_ia
+        self.drkey = drkey
+
+    @classmethod
+    def from_protocol_exchange(cls, request, reply):
+        """
+        Generate second order DRKey from DRKeyProtocolRequest and DRKeyProtocolReply exchange.
+
+        :param DRKeyProtocolRequest request: the protocol DRKey request.
+        :param DRKeyProtocolReply reply: the protocol DRKey reply.
+        :returns: the resulting SecondOrderDRKey.
+        :rtype: SecondOrderDRKey
+        """
+        return cls(
+            reply.p.drkey, reply.p.expTime, request.p.reqType,
+            request.p.protocol, request.src_ia, request.dst_ia, request.add_ia,
+            request.src_host, request.dst_host, request.add_host
+        )
+
+    def tuple(self):
+        return (self.key_type, self.protocol, self.src_host, self.dst_host,
+                self.add_host, self.src_ia, self.dst_ia, self.add_ia)
+
+    def __str__(self):
+        src = "%s" % self.src_ia
+        src = "%s:%s" % (src, self.src_host) if self.src_host else src
+        dst = "%s" % self.dst_ia
+        dst = "%s:%s" % (dst, self.dst_host) if self.dst_host else dst
+        add = ";%s" % self.add_ia if self.add_ia else ""
+        add = "%s:%s" % (add, self.add_host) if self.add_host else add
+        drkey = self.drkey.hex() if self.drkey else "None"
+
+        return "SecondOrderDRKey (%s->%s%s): %s proto %s type %s expires %s" % (
+            src, dst, add, drkey, self.protocol, self.key_type, self.exp_time
         )

--- a/python/lib/types.py
+++ b/python/lib/types.py
@@ -140,6 +140,8 @@ class PathSegmentType(TypeBase):
 class DRKeyMgmtType(object):
     FIRST_ORDER_REQUEST = "drkeyReq"
     FIRST_ORDER_REPLY = "drkeyRep"
+    PROTOCOL_REQUEST = "drkeyProtocolReq"
+    PROTOCOL_REPLY = "drkeyProtocolRep"
 
 
 ############################


### PR DESCRIPTION
Add second order DRKey functionality to certificate server.
Based on PR #1099 .

Future PR's will introduce:
- second order DRKey functionality to SCIOND
- SCMPAuth protocol
- OPT protocol

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1119)
<!-- Reviewable:end -->
