### PR TITLE
Sync CurrINF, CurrHF, HdrLen, ExtHdrLen with Book

### DIFF
--- a/c/dispatcher/dispatcher.c
+++ b/c/dispatcher/dispatcher.c
@@ -788,7 +788,7 @@ void handle_data(int v6)
     }
 
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    if (sch->header_len > len || ntohs(sch->total_len) > len) {
+    if (sch->header_len * LINE_LEN > len || ntohs(sch->total_len) > len) {
         zlog_error(zc, "invalid SCION packet");
         return;
     }

--- a/c/lib/scion/extensions.c
+++ b/c/lib/scion/extensions.c
@@ -19,7 +19,7 @@ uint8_t * find_extension(uint8_t *buf, uint8_t ext_class, uint8_t ext_type)
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
     uint8_t next_header = sch->next_header;
     uint8_t curr_header = next_header;
-    uint8_t header_len = sch->header_len;
+    int header_len = sch->header_len * LINE_LEN;
     uint8_t *ptr = buf + header_len;
     uint8_t type = 0;
     while (!is_known_proto(curr_header)) {
@@ -28,7 +28,7 @@ uint8_t * find_extension(uint8_t *buf, uint8_t ext_class, uint8_t ext_type)
         type = *(ptr + 2);
         if (curr_header == ext_class && type == ext_type)
             return ptr;
-        uint8_t real_len = (header_len + 1) * SCION_EXT_LINE;
+        int real_len = header_len * SCION_EXT_LINE;
         curr_header = next_header;
         ptr += real_len;
     }
@@ -43,13 +43,13 @@ uint8_t * find_extension(uint8_t *buf, uint8_t ext_class, uint8_t ext_type)
 int get_total_ext_len(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    uint8_t *ptr = buf + sch->header_len;
+    uint8_t *ptr = buf + sch->header_len * LINE_LEN;
     int current_header = sch->next_header;
     int size = 0;
     while (!is_known_proto(current_header)) {
         current_header = *ptr;
         int header_len = *(ptr + 1);
-        header_len = (header_len + 1) * SCION_EXT_LINE;
+        header_len *= SCION_EXT_LINE;
         ptr += header_len;
         size += header_len;
     }

--- a/c/lib/scion/opaque_field.c
+++ b/c/lib/scion/opaque_field.c
@@ -15,7 +15,7 @@
 uint8_t * get_current_iof(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return buf + sch->current_iof;
+    return buf + sch->current_iof * LINE_LEN;
 }
 
 /*
@@ -26,7 +26,7 @@ uint8_t * get_current_iof(uint8_t *buf)
 uint8_t * get_current_hof(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return buf + sch->current_hof;
+    return buf + sch->current_hof * LINE_LEN;
 }
 
 /*

--- a/c/lib/scion/path.c
+++ b/c/lib/scion/path.c
@@ -57,22 +57,22 @@ int reverse_path(uint8_t *buf, uint8_t *reverse)
 
     /* Update current_iof pointer to reversed location */
     uint8_t *start = (uint8_t *)buf;
-    uint8_t *current_iof = sch->current_iof + start;
+    uint8_t *current_iof = sch->current_iof * LINE_LEN + start;
     /* Original current_iof pointer was at first IOF -> set to last */
     if (current_iof == iof[0])
-        sch->current_iof = iof[segments - 1] - start;
+        sch->current_iof = (iof[segments - 1] - start)/LINE_LEN;
     /* Original current_iof pointer was at last IOF -> set to first */
     else if (current_iof == iof[segments - 1])
-        sch->current_iof = iof[0] - start;
+        sch->current_iof = (iof[0] - start)/LINE_LEN;
 
     int of_count = segments;
     for (i = 0; i < segments; i++)
         of_count += hops[i];
     /* Get index of current HOF in OF list */
-    int hof_index = (sch->current_hof + start - original) / SCION_OF_LEN;
+    int hof_index = (sch->current_hof * LINE_LEN + start - original) / SCION_OF_LEN;
     hof_index = of_count - hof_index;
     /* Update current_hof pointer to reversed location */
-    sch->current_hof = original + hof_index * SCION_OF_LEN - start;
+    sch->current_hof = (original + hof_index * SCION_OF_LEN - start)/LINE_LEN;
 
     return 0;
 }

--- a/c/lib/scion/udp.c
+++ b/c/lib/scion/udp.c
@@ -17,7 +17,7 @@
 void build_scion_udp(uint8_t *buf, uint16_t src_port, uint16_t dst_port, uint16_t payload_len)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    SCIONUDPHeader *uhdr = (SCIONUDPHeader *)(buf + sch->header_len);
+    SCIONUDPHeader *uhdr = (SCIONUDPHeader *)(buf + sch->header_len * LINE_LEN);
     uhdr->src_port = src_port;
     uhdr->dst_port = dst_port;
     uhdr->len = payload_len;
@@ -32,7 +32,7 @@ void build_scion_udp(uint8_t *buf, uint16_t src_port, uint16_t dst_port, uint16_
 uint8_t get_payload_class(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return *(uint8_t *)((uint8_t *)sch + sch->header_len + sizeof(SCIONUDPHeader));
+    return *(uint8_t *)((uint8_t *)sch + sch->header_len * LINE_LEN + sizeof(SCIONUDPHeader));
 }
 
 /*
@@ -43,7 +43,7 @@ uint8_t get_payload_class(uint8_t *buf)
 uint8_t get_payload_type(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return *(uint8_t *)((uint8_t *)sch + sch->header_len + sizeof(SCIONUDPHeader) + 1);
+    return *(uint8_t *)((uint8_t *)sch + sch->header_len * LINE_LEN + sizeof(SCIONUDPHeader) + 1);
 }
 
 /*

--- a/c/lib/scion/udp.c
+++ b/c/lib/scion/udp.c
@@ -25,28 +25,6 @@ void build_scion_udp(uint8_t *buf, uint16_t src_port, uint16_t dst_port, uint16_
 }
 
 /*
- * Get payload class of SCION UDP packet
- * buf: Pointer to start of SCION packet
- * return value: Payload class
- */
-uint8_t get_payload_class(uint8_t *buf)
-{
-    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return *(uint8_t *)((uint8_t *)sch + sch->header_len * LINE_LEN + sizeof(SCIONUDPHeader));
-}
-
-/*
- * Get payload type of SCION UDP packet
- * buf: Pointer to start of SCION packet
- * return value: Payload type
- */
-uint8_t get_payload_type(uint8_t *buf)
-{
-    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return *(uint8_t *)((uint8_t *)sch + sch->header_len * LINE_LEN + sizeof(SCIONUDPHeader) + 1);
-}
-
-/*
  * Calculate UDP checksum
  * Same as regular IP/UDP checksum but IP addrs replaced with SCION addrs
  * buf: Pointer to start of SCION packet

--- a/c/lib/scion/udp.h
+++ b/c/lib/scion/udp.h
@@ -14,8 +14,6 @@ typedef struct {
 #pragma pack(pop)
 
 void build_scion_udp(uint8_t *buf, uint16_t src_port, uint16_t dst_port, uint16_t payload_len);
-uint8_t get_payload_class(uint8_t *buf);
-uint8_t get_payload_type(uint8_t *buf);
 uint16_t scion_udp_checksum(uint8_t *buf);
 void update_scion_udp_checksum(uint8_t *buf);
 void reverse_udp_header(uint8_t *l4ptr);

--- a/go/border/error.go
+++ b/go/border/error.go
@@ -89,6 +89,13 @@ func (r *Router) createSCMPErrorReply(rp *rpkt.RtrPkt, ct scmp.ClassType,
 	if err != nil {
 		return nil, err
 	}
+	if ct.Class == scmp.C_CmnHdr &&
+		(ct.Type == scmp.T_C_BadInfoFOffset || ct.Type == scmp.T_C_BadHopFOffset) {
+		// If the infoF or hopF offsets are bad, then don't include the path
+		// header in the response. This is only relevant for packets sent from the local AS,
+		// packets from external ASes are already filtered out in handlePktError() above.
+		sp.Path = nil
+	}
 	oldHBH := sp.HBHExt
 	sp.HBHExt = make([]common.Extension, 0, common.ExtnMaxHBH+1)
 	// Add new SCMP HBH extension at the start.

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -33,7 +33,7 @@ func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo Dir, ctx *rctx.Ctx) (*RtrPkt, *comm
 	rp := NewRtrPkt()
 	rp.Ctx = ctx
 	totalLen := sp.TotalLen()
-	hdrLen := sp.HdrLen()
+	hdrLen := sp.HdrLen() / common.LineLen
 	rp.TimeIn = monotime.Now()
 	rp.Id = logext.RandId(4)
 	rp.Logger = log.New("rpkt", rp.Id)
@@ -64,8 +64,8 @@ func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo Dir, ctx *rctx.Ctx) (*RtrPkt, *comm
 	rp.idxs.path = spkt.CmnHdrLen + sp.AddrLen()
 	if sp.Path != nil {
 		copy(rp.Raw[rp.idxs.path:], sp.Path.Raw)
-		rp.CmnHdr.CurrInfoF = uint8((rp.idxs.path + int(sp.Path.InfOff)) / common.LineLen)
-		rp.CmnHdr.CurrHopF = uint8((rp.idxs.path + int(sp.Path.HopOff)) / common.LineLen)
+		rp.CmnHdr.CurrInfoF = uint8((rp.idxs.path + sp.Path.InfOff) / common.LineLen)
+		rp.CmnHdr.CurrHopF = uint8((rp.idxs.path + sp.Path.HopOff) / common.LineLen)
 	}
 	// Fill in extensions
 	rp.idxs.l4 = int(hdrLen) * common.LineLen // Will be updated as necessary by extnAddHBH and extnAddE2E

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -56,7 +56,8 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		// instead.
 		return HookContinue, nil, nil
 	}
-	currHopF, err := spath.HopFFromRaw(o.rp.Raw[o.rp.CmnHdr.HopFOffBytes():])
+	hOff := o.rp.CmnHdr.HopFOffBytes()
+	currHopF, err := spath.HopFFromRaw(o.rp.Raw[hOff:])
 	if err != nil {
 		return HookError, nil, err
 	}
@@ -69,7 +70,6 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		return HookError, nil, err
 	}
 	// Retrieve the previous HopF, create a new HopF for this AS, and write it into the path header.
-	hOff := o.rp.CmnHdr.HopFOffBytes()
 	prevIdx := hOff - spath.HopFieldLength
 	prevHof := o.rp.Raw[prevIdx+1 : hOff]
 	inIFid := o.rp.Ingress.IfIDs[0]

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -56,7 +56,7 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		// instead.
 		return HookContinue, nil, nil
 	}
-	currHopF, err := spath.HopFFromRaw(o.rp.Raw[o.rp.CmnHdr.CurrHopF:])
+	currHopF, err := spath.HopFFromRaw(o.rp.Raw[int(o.rp.CmnHdr.CurrHopF)*common.LineLen:])
 	if err != nil {
 		return HookError, nil, err
 	}
@@ -69,10 +69,10 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		return HookError, nil, err
 	}
 	// Retrieve the previous HopF, create a new HopF for this AS, and write it into the path header.
-	prevIdx := o.rp.CmnHdr.CurrHopF - spath.HopFieldLength
-	prevHof := o.rp.Raw[prevIdx+1 : o.rp.CmnHdr.CurrHopF]
+	prevIdx := int(o.rp.CmnHdr.CurrHopF)*common.LineLen - spath.HopFieldLength
+	prevHof := o.rp.Raw[prevIdx+1 : int(o.rp.CmnHdr.CurrHopF)*common.LineLen]
 	inIFid := o.rp.Ingress.IfIDs[0]
-	hopF := spath.NewHopField(o.rp.Raw[o.rp.CmnHdr.CurrHopF:], inIFid, 0)
+	hopF := spath.NewHopField(o.rp.Raw[int(o.rp.CmnHdr.CurrHopF)*common.LineLen:], inIFid, 0)
 	hfmac := o.rp.Ctx.Conf.HFMacPool.Get().(hash.Hash)
 	mac, err := hopF.CalcMac(hfmac, infoF.TsInt, prevHof)
 	o.rp.Ctx.Conf.HFMacPool.Put(hfmac)

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -56,7 +56,7 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		// instead.
 		return HookContinue, nil, nil
 	}
-	currHopF, err := spath.HopFFromRaw(o.rp.Raw[int(o.rp.CmnHdr.CurrHopF)*common.LineLen:])
+	currHopF, err := spath.HopFFromRaw(o.rp.Raw[o.rp.CmnHdr.HopFOffBytes():])
 	if err != nil {
 		return HookError, nil, err
 	}
@@ -69,10 +69,11 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, *common.Error) {
 		return HookError, nil, err
 	}
 	// Retrieve the previous HopF, create a new HopF for this AS, and write it into the path header.
-	prevIdx := int(o.rp.CmnHdr.CurrHopF)*common.LineLen - spath.HopFieldLength
-	prevHof := o.rp.Raw[prevIdx+1 : int(o.rp.CmnHdr.CurrHopF)*common.LineLen]
+	hOff := o.rp.CmnHdr.HopFOffBytes()
+	prevIdx := hOff - spath.HopFieldLength
+	prevHof := o.rp.Raw[prevIdx+1 : hOff]
 	inIFid := o.rp.Ingress.IfIDs[0]
-	hopF := spath.NewHopField(o.rp.Raw[int(o.rp.CmnHdr.CurrHopF)*common.LineLen:], inIFid, 0)
+	hopF := spath.NewHopField(o.rp.Raw[hOff:], inIFid, 0)
 	hfmac := o.rp.Ctx.Conf.HFMacPool.Get().(hash.Hash)
 	mac, err := hopF.CalcMac(hfmac, infoF.TsInt, prevHof)
 	o.rp.Ctx.Conf.HFMacPool.Put(hfmac)

--- a/go/border/rpkt/extns.go
+++ b/go/border/rpkt/extns.go
@@ -135,7 +135,7 @@ func (rp *RtrPkt) extnOffsetNew(isHBH bool) (int, *uint8, *common.Error) {
 	if isHBH && len(rp.E2EExt) > 0 {
 		return 0, nil, common.NewError("HBH extension illegal to add after E2E extension")
 	}
-	offset := int(rp.CmnHdr.HdrLen)
+	offset := int(rp.CmnHdr.HdrLen) * common.LineLen
 	nextHdr := (*uint8)(&rp.CmnHdr.NextHdr)
 	for i, hIdx := range rp.idxs.hbhExt {
 		nextHdr = &rp.Raw[hIdx.Index]
@@ -167,7 +167,7 @@ func (rp *RtrPkt) extnWriteExtension(e common.Extension, isHBH bool) (int, int, 
 	*nextHdr = uint8(et.Class)
 	// Write extension sub-header into buffer
 	rp.Raw[offset] = uint8(common.L4None)
-	rp.Raw[offset+1] = uint8(eLen/common.LineLen) - 1
+	rp.Raw[offset+1] = uint8(eLen / common.LineLen)
 	rp.Raw[offset+2] = et.Type
 	// Write extension into buffer
 	if err := e.Write(rp.Raw[offset+common.ExtnSubHdrLen : offset+eLen]); err != nil {

--- a/go/border/rpkt/extns.go
+++ b/go/border/rpkt/extns.go
@@ -135,7 +135,7 @@ func (rp *RtrPkt) extnOffsetNew(isHBH bool) (int, *uint8, *common.Error) {
 	if isHBH && len(rp.E2EExt) > 0 {
 		return 0, nil, common.NewError("HBH extension illegal to add after E2E extension")
 	}
-	offset := int(rp.CmnHdr.HdrLen) * common.LineLen
+	offset := rp.CmnHdr.HdrLenBytes()
 	nextHdr := (*uint8)(&rp.CmnHdr.NextHdr)
 	for i, hIdx := range rp.idxs.hbhExt {
 		nextHdr = &rp.Raw[hIdx.Index]

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -82,7 +82,7 @@ func (rp *RtrPkt) findL4() (bool, *common.Error) {
 		}
 		// TODO(kormat): handle detecting unknown L4 protocols.
 		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[offset+2]}
-		hdrLen := int((rp.Raw[offset+1] + 1) * common.LineLen)
+		hdrLen := int(rp.Raw[offset+1]) * common.LineLen
 		rp.idxs.e2eExt = append(rp.idxs.e2eExt, extnIdx{currExtn, offset})
 		nextHdr = common.L4ProtocolType(rp.Raw[offset])
 		offset += hdrLen

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -103,10 +103,11 @@ func (rp *RtrPkt) parseBasic() *common.Error {
 	addrLen := int(addr.IABytes*2 + dstLen + srcLen)
 	addrPad := util.CalcPadding(addrLen, common.LineLen)
 	rp.idxs.path = spkt.CmnHdrLen + addrLen + addrPad
-	if rp.idxs.path > int(rp.CmnHdr.HdrLen) {
+	if rp.idxs.path > int(rp.CmnHdr.HdrLen)*common.LineLen {
 		// Can't generate SCMP error as we can't parse anything after the address header
 		return common.NewError("Header length indicated in common header is too small",
-			"min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen)
+			"min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen, "byteSize",
+			int(rp.CmnHdr.HdrLen)*common.LineLen)
 	}
 	return nil
 }
@@ -117,7 +118,7 @@ func (rp *RtrPkt) parseHopExtns() *common.Error {
 	// +1 to allow for a leading SCMP hop-by-hop extension.
 	rp.idxs.hbhExt = make([]extnIdx, 0, common.ExtnMaxHBH+1)
 	rp.idxs.nextHdrIdx.Type = rp.CmnHdr.NextHdr
-	rp.idxs.nextHdrIdx.Index = int(rp.CmnHdr.HdrLen)
+	rp.idxs.nextHdrIdx.Index = int(rp.CmnHdr.HdrLen) * common.LineLen
 	nextHdr := &rp.idxs.nextHdrIdx.Type
 	offset := &rp.idxs.nextHdrIdx.Index
 	for *offset < len(rp.Raw) {
@@ -126,7 +127,7 @@ func (rp *RtrPkt) parseHopExtns() *common.Error {
 			break
 		}
 		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[*offset+2]}
-		hdrLen := (int(rp.Raw[*offset+1]) + 1) * common.LineLen
+		hdrLen := int(rp.Raw[*offset+1]) * common.LineLen
 		e, err := rp.extnParseHBH(
 			currExtn, *offset+common.ExtnSubHdrLen, *offset+hdrLen, len(rp.idxs.hbhExt))
 		if err != nil {

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -102,12 +102,12 @@ func (rp *RtrPkt) parseBasic() *common.Error {
 	// Set index for path header.
 	addrLen := int(addr.IABytes*2 + dstLen + srcLen)
 	addrPad := util.CalcPadding(addrLen, common.LineLen)
+	hdrLen := rp.CmnHdr.HdrLenBytes()
 	rp.idxs.path = spkt.CmnHdrLen + addrLen + addrPad
-	if rp.idxs.path > int(rp.CmnHdr.HdrLen)*common.LineLen {
+	if rp.idxs.path > hdrLen {
 		// Can't generate SCMP error as we can't parse anything after the address header
 		return common.NewError("Header length indicated in common header is too small",
-			"min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen, "byteSize",
-			int(rp.CmnHdr.HdrLen)*common.LineLen)
+			"min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen, "byteSize", hdrLen)
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func (rp *RtrPkt) parseHopExtns() *common.Error {
 	// +1 to allow for a leading SCMP hop-by-hop extension.
 	rp.idxs.hbhExt = make([]extnIdx, 0, common.ExtnMaxHBH+1)
 	rp.idxs.nextHdrIdx.Type = rp.CmnHdr.NextHdr
-	rp.idxs.nextHdrIdx.Index = int(rp.CmnHdr.HdrLen) * common.LineLen
+	rp.idxs.nextHdrIdx.Index = rp.CmnHdr.HdrLenBytes()
 	nextHdr := &rp.idxs.nextHdrIdx.Type
 	offset := &rp.idxs.nextHdrIdx.Index
 	for *offset < len(rp.Raw) {

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -143,20 +143,21 @@ func (rp *RtrPkt) InfoF() (*spath.InfoField, *common.Error) {
 		}
 		// Check the common header path metadata validity, and if so extract
 		// the current Info Field.
+		hOff := rp.CmnHdr.InfoFOffBytes()
 		switch {
 		case rp.CmnHdr.CurrHopF == rp.CmnHdr.CurrInfoF:
 			// There is no path, so do nothing.
-		case rp.CmnHdr.CurrInfoF < uint8(rp.idxs.path/common.LineLen): // Error
+		case hOff < rp.idxs.path: // Error
 			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadInfoFOffset, nil)
-			return nil, common.NewErrorData("Info field too small", sdata,
+			return nil, common.NewErrorData("Info field index too small", sdata,
 				"min", rp.idxs.path/common.LineLen, "actual", rp.CmnHdr.CurrInfoF)
 		case rp.CmnHdr.CurrInfoF > rp.CmnHdr.HdrLen: // Error
 			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadInfoFOffset, nil)
-			return nil, common.NewErrorData("Info field too large", sdata,
+			return nil, common.NewErrorData("Info field index too large", sdata,
 				"max", rp.CmnHdr.HdrLen, "actual", rp.CmnHdr.CurrInfoF)
 		case rp.CmnHdr.CurrInfoF < rp.CmnHdr.HdrLen: // Parse
 			var err *common.Error
-			if rp.infoF, err = spath.InfoFFromRaw(rp.Raw[rp.CmnHdr.InfoFOffBytes():]); err != nil {
+			if rp.infoF, err = spath.InfoFFromRaw(rp.Raw[hOff:]); err != nil {
 				return nil, err
 			}
 		}
@@ -189,11 +190,11 @@ func (rp *RtrPkt) HopF() (*spath.HopField, *common.Error) {
 			// There is no path, so do nothing.
 		case hOff < iOff+spath.InfoFieldLength: // Error
 			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadHopFOffset, nil)
-			return nil, common.NewErrorData("Hop field too small", sdata, "min",
+			return nil, common.NewErrorData("Hop field index too small", sdata, "min",
 				(iOff+spath.InfoFieldLength)/common.LineLen, "actual", rp.CmnHdr.CurrHopF)
 		case rp.CmnHdr.CurrHopF >= rp.CmnHdr.HdrLen: // Error
 			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadHopFOffset, nil)
-			return nil, common.NewErrorData("Hop field too large", sdata, "max",
+			return nil, common.NewErrorData("Hop field index too large", sdata, "max",
 				(rp.CmnHdr.HdrLenBytes()-spath.HopFieldLength)/common.LineLen,
 				"actual", rp.CmnHdr.CurrHopF)
 		default: // Parse

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -269,9 +269,9 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, *common.Error) {
 	// SCION common header uses offsets relative to the start of the packet, so
 	// convert from one to the other.
 	sp.Path = &spath.Path{
-		Raw:    rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLen],
-		InfOff: rp.CmnHdr.CurrInfoF - uint8(rp.idxs.path),
-		HopOff: rp.CmnHdr.CurrHopF - uint8(rp.idxs.path),
+		Raw:    rp.Raw[rp.idxs.path : int(rp.CmnHdr.HdrLen)*common.LineLen],
+		InfOff: uint8(int(rp.CmnHdr.CurrInfoF)*common.LineLen - rp.idxs.path),
+		HopOff: uint8(int(rp.CmnHdr.CurrHopF)*common.LineLen - rp.idxs.path),
 	}
 	for _, re := range rp.HBHExt {
 		// Extract the higher-level SExtension (which is self-contained) from
@@ -310,9 +310,9 @@ func (rp *RtrPkt) GetRaw(blk scmp.RawBlock) common.RawBytes {
 	case scmp.RawAddrHdr:
 		return rp.Raw[rp.idxs.dstIA:rp.idxs.path]
 	case scmp.RawPathHdr:
-		return rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLen]
+		return rp.Raw[rp.idxs.path : int(rp.CmnHdr.HdrLen)*common.LineLen]
 	case scmp.RawExtHdrs:
-		return rp.Raw[rp.CmnHdr.HdrLen:rp.idxs.l4]
+		return rp.Raw[int(rp.CmnHdr.HdrLen)*common.LineLen : rp.idxs.l4]
 	case scmp.RawL4Hdr:
 		return rp.Raw[rp.idxs.l4:rp.idxs.pld]
 	}

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -269,9 +269,9 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, *common.Error) {
 	// SCION common header uses offsets relative to the start of the packet, so
 	// convert from one to the other.
 	sp.Path = &spath.Path{
-		Raw:    rp.Raw[rp.idxs.path : int(rp.CmnHdr.HdrLen)*common.LineLen],
-		InfOff: uint8(int(rp.CmnHdr.CurrInfoF)*common.LineLen - rp.idxs.path),
-		HopOff: uint8(int(rp.CmnHdr.CurrHopF)*common.LineLen - rp.idxs.path),
+		Raw:    rp.Raw[rp.idxs.path : rp.CmnHdr.HdrLenBytes()],
+		InfOff: rp.CmnHdr.InfoFOffBytes() - rp.idxs.path,
+		HopOff: rp.CmnHdr.HopFOffBytes() - rp.idxs.path,
 	}
 	for _, re := range rp.HBHExt {
 		// Extract the higher-level SExtension (which is self-contained) from
@@ -310,9 +310,9 @@ func (rp *RtrPkt) GetRaw(blk scmp.RawBlock) common.RawBytes {
 	case scmp.RawAddrHdr:
 		return rp.Raw[rp.idxs.dstIA:rp.idxs.path]
 	case scmp.RawPathHdr:
-		return rp.Raw[rp.idxs.path : int(rp.CmnHdr.HdrLen)*common.LineLen]
+		return rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLenBytes()]
 	case scmp.RawExtHdrs:
-		return rp.Raw[int(rp.CmnHdr.HdrLen)*common.LineLen : rp.idxs.l4]
+		return rp.Raw[rp.CmnHdr.HdrLenBytes():rp.idxs.l4]
 	case scmp.RawL4Hdr:
 		return rp.Raw[rp.idxs.l4:rp.idxs.pld]
 	}

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -269,7 +269,7 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, *common.Error) {
 	// SCION common header uses offsets relative to the start of the packet, so
 	// convert from one to the other.
 	sp.Path = &spath.Path{
-		Raw:    rp.Raw[rp.idxs.path : rp.CmnHdr.HdrLenBytes()],
+		Raw:    rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLenBytes()],
 		InfOff: rp.CmnHdr.InfoFOffBytes() - rp.idxs.path,
 		HopOff: rp.CmnHdr.HopFOffBytes() - rp.idxs.path,
 	}

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -28,8 +28,8 @@ const (
 
 type Path struct {
 	Raw    common.RawBytes
-	InfOff uint8 // Offset of current Info Field
-	HopOff uint8 // Offset of current Hop Field
+	InfOff int // Offset of current Info Field
+	HopOff int // Offset of current Hop Field
 }
 
 func (p *Path) Copy() *Path {
@@ -66,7 +66,7 @@ func (p *Path) Reverse() *common.Error {
 	switch {
 	case p.InfOff == 0:
 		newInfIdx = len(infOffs) - 1
-	case p.InfOff == uint8(infOffs[len(infOffs)-1]):
+	case p.InfOff == infOffs[len(infOffs)-1]:
 		newInfIdx = 0
 	default:
 		newInfIdx = 1
@@ -75,7 +75,7 @@ func (p *Path) Reverse() *common.Error {
 	// Fill in reversed path, starting with last segment.
 	for i := len(infoFs) - 1; i >= 0; i-- {
 		if idx == newInfIdx {
-			p.InfOff = uint8(revOff)
+			p.InfOff = revOff
 		}
 		infoF := infoFs[i]
 		infoF.Up = !infoF.Up // Reverse Up flag
@@ -93,7 +93,7 @@ func (p *Path) Reverse() *common.Error {
 	}
 
 	// Calculate Hop Field offset.
-	p.HopOff = uint8(len(p.Raw)) - p.HopOff
+	p.HopOff = len(p.Raw) - p.HopOff
 
 	// Update path with reversed copy.
 	p.Raw = revRaw

--- a/go/lib/spath/path_test.go
+++ b/go/lib/spath/path_test.go
@@ -31,29 +31,29 @@ type pathCase struct {
 var pathReverseCases = []struct {
 	in      []pathCase
 	out     []pathCase
-	inOffs  [][2]uint8
-	outOffs [][2]uint8
+	inOffs  [][2]int
+	outOffs [][2]int
 }{
 	// 1 segment, 2 hops
 	{
 		[]pathCase{{true, []uint8{11, 12}}},
 		[]pathCase{{false, []uint8{12, 11}}},
-		[][2]uint8{{0, 8}, {0, 16}},
-		[][2]uint8{{0, 16}, {0, 8}},
+		[][2]int{{0, 8}, {0, 16}},
+		[][2]int{{0, 16}, {0, 8}},
 	},
 	// 1 segment, 5 hops
 	{
 		[]pathCase{{true, []uint8{11, 12, 13, 14, 15}}},
 		[]pathCase{{false, []uint8{15, 14, 13, 12, 11}}},
-		[][2]uint8{{0, 8}, {0, 16}, {0, 24}, {0, 32}, {0, 40}},
-		[][2]uint8{{0, 40}, {0, 32}, {0, 24}, {0, 16}, {0, 8}},
+		[][2]int{{0, 8}, {0, 16}, {0, 24}, {0, 32}, {0, 40}},
+		[][2]int{{0, 40}, {0, 32}, {0, 24}, {0, 16}, {0, 8}},
 	},
 	// 2 segments, 5 hops
 	{
 		[]pathCase{{true, []uint8{11, 12}}, {false, []uint8{13, 14, 15}}},
 		[]pathCase{{true, []uint8{15, 14, 13}}, {false, []uint8{12, 11}}},
-		[][2]uint8{{0, 8}, {0, 16}, {24, 32}, {24, 40}, {24, 48}},
-		[][2]uint8{{32, 48}, {32, 40}, {0, 24}, {0, 16}, {0, 8}},
+		[][2]int{{0, 8}, {0, 16}, {24, 32}, {24, 40}, {24, 48}},
+		[][2]int{{32, 48}, {32, 40}, {0, 24}, {0, 16}, {0, 8}},
 	},
 	// 3 segments, 9 hops
 	{
@@ -67,10 +67,10 @@ var pathReverseCases = []struct {
 			{true, []uint8{16, 15, 14, 13}},
 			{false, []uint8{12, 11}},
 		},
-		[][2]uint8{
+		[][2]int{
 			{0, 8}, {0, 16}, {24, 32}, {24, 40}, {24, 48}, {24, 56}, {64, 72}, {64, 80}, {64, 88},
 		},
-		[][2]uint8{
+		[][2]int{
 			{72, 88}, {72, 80}, {32, 64}, {32, 56}, {32, 48}, {32, 40}, {0, 24}, {0, 16}, {0, 8},
 		},
 	},
@@ -109,7 +109,7 @@ func Test_Path_Reverse(t *testing.T) {
 	}
 }
 
-func mkPathRevCase(in []pathCase, inInfOff, inHopfOff uint8) *Path {
+func mkPathRevCase(in []pathCase, inInfOff, inHopfOff int) *Path {
 	path := &Path{InfOff: inInfOff, HopOff: inHopfOff}
 	plen := 0
 	for _, seg := range in {

--- a/go/lib/spkt/cmnhdr.go
+++ b/go/lib/spkt/cmnhdr.go
@@ -100,6 +100,18 @@ func (c *CmnHdr) UpdatePathOffsets(b common.RawBytes, iOff, hOff uint8) {
 	b[6] = c.CurrHopF
 }
 
+func (c *CmnHdr) HdrLenBytes() int {
+	return int(c.HdrLen) * common.LineLen
+}
+
+func (c *CmnHdr) InfoFOffBytes() int {
+	return int(c.CurrInfoF) * common.LineLen
+}
+
+func (c *CmnHdr) HopFOffBytes() int {
+	return int(c.CurrHopF) * common.LineLen
+}
+
 func (c CmnHdr) String() string {
 	return fmt.Sprintf(
 		"Ver:%d Dst:%s Src:%s TotalLen:%dB HdrLen: %dB CurrInfoF:%dB CurrHopF:%dB NextHdr:%s",

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -90,16 +90,16 @@ func (s *ScnPkt) HdrLen() int {
 	if s.Path != nil {
 		l += len(s.Path.Raw)
 	}
-	return l
+	return l / common.LineLen
 }
 
 func (s *ScnPkt) TotalLen() int {
-	l := s.HdrLen()
+	l := s.HdrLen() * common.LineLen
 	for _, h := range s.HBHExt {
-		l += h.Len()
+		l += h.Len() + common.ExtnSubHdrLen
 	}
 	for _, e := range s.E2EExt {
-		l += e.Len()
+		l += e.Len() + common.ExtnSubHdrLen
 	}
 	if s.L4 != nil {
 		l += s.L4.L4Len()

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -90,11 +90,11 @@ func (s *ScnPkt) HdrLen() int {
 	if s.Path != nil {
 		l += len(s.Path.Raw)
 	}
-	return l / common.LineLen
+	return l
 }
 
 func (s *ScnPkt) TotalLen() int {
-	l := s.HdrLen() * common.LineLen
+	l := s.HdrLen()
 	for _, h := range s.HBHExt {
 		l += h.Len() + common.ExtnSubHdrLen
 	}

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -85,6 +85,7 @@ func (s *ScnPkt) AddrLen() int {
 	return addrLen + util.CalcPadding(addrLen, common.LineLen)
 }
 
+// HdrLen returns the length of the header, in bytes.
 func (s *ScnPkt) HdrLen() int {
 	l := CmnHdrLen + s.AddrLen()
 	if s.Path != nil {

--- a/python/integration/end2end_test.py
+++ b/python/integration/end2end_test.py
@@ -42,7 +42,7 @@ class E2EClient(TestClientBase):
     """
     def _create_payload(self, spkt):
         data = b"ping " + self.data
-        pld_len = self.path_meta.p.mtu - spkt.cmn_hdr.hdr_len - len(spkt.l4_hdr)
+        pld_len = self.path_meta.p.mtu - spkt.cmn_hdr.hdr_len_bytes() - len(spkt.l4_hdr)
         return self._gen_max_pld(data, pld_len)
 
     def _gen_max_pld(self, data, pld_len):

--- a/python/integration/scmp_error_test.py
+++ b/python/integration/scmp_error_test.py
@@ -185,7 +185,7 @@ class ErrorGenBadIOFOffsetShort(ErrorGenBase):
     def _send_pkt(self, spkt, first_hop):
         next_hop, port = self._get_next_hop(spkt)
         barr = bytearray(spkt.pack())
-        barr[5] -= 8
+        barr[5] -= 1
         self._send_raw_pkt(barr, next_hop, port)
 
 
@@ -329,7 +329,7 @@ class ErrorGenBadHopByHop(ErrorGenBase):
         next_hop, port = self._get_next_hop(spkt)
         spkt.update()
         barr = bytearray(spkt.pack())
-        idx = spkt.cmn_hdr.hdr_len + 2
+        idx = spkt.cmn_hdr.hdr_len_bytes() + 2
         barr[idx] = 255
         self._send_raw_pkt(barr, next_hop, port)
 

--- a/python/lib/packet/ext/traceroute.py
+++ b/python/lib/packet/ext/traceroute.py
@@ -77,7 +77,7 @@ class TracerouteExt(HopByHopExtension):
             packed.append(isd_as.pack())
             packed.append(struct.pack("!HH", if_id, timestamp))
         # Compute and set padding for the rest of the payload.
-        pad_hops = self._hdr_len - len(self.hops)
+        pad_hops = self._hdr_len - len(self.hops) - 1
         packed.append(bytes(pad_hops * self.HOP_LEN))
         raw = b"".join(packed)
         self._check_len(raw)
@@ -88,7 +88,7 @@ class TracerouteExt(HopByHopExtension):
         Append hop's information as a new field in the extension.
         """
         # Check whether
-        assert len(self.hops) < self._hdr_len
+        assert len(self.hops) < self._hdr_len - 1
         if timestamp is None:
             # Truncate milliseconds to 2B
             timestamp = int(SCIONTime.get_time() * 1000) % 2**16

--- a/python/lib/packet/ext_hdr.py
+++ b/python/lib/packet/ext_hdr.py
@@ -35,7 +35,7 @@ class ExtensionHeader(Serializable):
     MIN_PAYLOAD_LEN = MIN_LEN - SUBHDR_LEN
 
     def __init__(self, raw=None):  # pragma: no cover
-        self._hdr_len = 0
+        self._hdr_len = 1
         super().__init__(raw)
 
     def _parse(self, raw):  # pragma: no cover
@@ -46,7 +46,7 @@ class ExtensionHeader(Serializable):
         Initialize `additional_lines` of payload.
         All extensions have to have constant size.
         """
-        self._hdr_len = additional_lines
+        self._hdr_len = additional_lines + 1
 
     def _check_len(self, payload):  # pragma: no cover
         """
@@ -68,11 +68,11 @@ class ExtensionHeader(Serializable):
     def bytes_to_hdr_len(cls, bytes_):
         total_len = (bytes_ + cls.SUBHDR_LEN)
         assert total_len % cls.LINE_LEN == 0
-        return (total_len // cls.LINE_LEN) - 1
+        return total_len // cls.LINE_LEN
 
     @classmethod
     def hdr_len_to_bytes(cls, hdr_len):  # pragma: no cover
-        return (hdr_len + 1) * cls.LINE_LEN
+        return hdr_len * cls.LINE_LEN
 
     def reverse(self):  # pragma: no cover
         pass

--- a/python/lib/packet/ext_util.py
+++ b/python/lib/packet/ext_util.py
@@ -57,7 +57,7 @@ def parse_extensions(data, next_hdr):
         next_hdr_type, hdr_len, ext_no = struct.unpack(
             "!BBB", data.pop(ExtensionHeader.SUBHDR_LEN))
         # Calculate correct hdr_len in bytes
-        hdr_len = (hdr_len + 1) * ExtensionHeader.LINE_LEN
+        hdr_len *= ExtensionHeader.LINE_LEN
         logging.debug("Found extension hdr of type (%d, %d) with len %dB",
                       cur_hdr_type, ext_no, hdr_len)
         ext_class = EXTENSION_MAP.get((cur_hdr_type, ext_no))

--- a/python/lib/packet/scion.py
+++ b/python/lib/packet/scion.py
@@ -109,7 +109,7 @@ class SCIONCommonHdr(Serializable):
             raise SCIONParseError(
                 "hdr_len (%sB) < common header len (%sB) + addrs len (%sB) " %
                 (self.hdr_len_bytes(), self.LEN, self.addrs_len))
-        if iof_off == hof_off:
+        if iof_off == hof_off == 0:
             self._iof_idx = self._hof_idx = 0
             return
         first_of_offset = self.LEN + self.addrs_len
@@ -191,10 +191,10 @@ class SCIONCommonHdr(Serializable):
         values = {
             "dst_addr_type": haddr_get_type(self.dst_addr_type).name(),
             "src_addr_type": haddr_get_type(self.src_addr_type).name(),
+            "hdr_len": self.hdr_len_bytes(),
         }
         for i in ("version", "total_len", "_iof_idx", "_hof_idx", "next_hdr"):
             values[i] = getattr(self, i)
-        values["hdr_len"] = self.hdr_len_bytes()
         return (
             "CH ver: %(version)s, dst type: %(dst_addr_type)s, src type: %(src_addr_type)s, "
             "total len: %(total_len)sB, hdr len: %(hdr_len)sB, "

--- a/python/lib/packet/scion.py
+++ b/python/lib/packet/scion.py
@@ -146,7 +146,7 @@ class SCIONCommonHdr(Serializable):
         packed.append(struct.pack("!HHB", types, self.total_len, self.hdr_len))
         curr_iof_p = curr_hof_p = 0
         # FIXME(kormat): NB this assumes that all OFs have the same length.
-        if self._iof_idx:
+        if self._iof_idx or self._hof_idx:
             curr_iof_p = self.LEN + self.addrs_len + self._iof_idx * OpaqueField.LEN
         if self._hof_idx:
             curr_hof_p = self.LEN + self.addrs_len + self._hof_idx * OpaqueField.LEN

--- a/python/lib/packet/scion.py
+++ b/python/lib/packet/scion.py
@@ -112,7 +112,7 @@ class SCIONCommonHdr(Serializable):
         if iof_off == hof_off == 0:
             self._iof_idx = self._hof_idx = 0
             return
-        if iof_off == hof_off or (iof_off == 0 or hof_off == 0) and iof_off != hof_off:
+        if iof_off == 0 or hof_off <= iof_off:
             raise SCIONParseError(
                 "invalid CurrINF, CurrHF combination: (%s, %s) " % (iof_off, hof_off))
         first_of_offset = self.LEN + self.addrs_len
@@ -144,17 +144,14 @@ class SCIONCommonHdr(Serializable):
         types = ((self.version << 12) | (self.dst_addr_type << 6) |
                  self.src_addr_type)
         packed.append(struct.pack("!HHB", types, self.total_len, self.hdr_len))
-        curr_iof_p = curr_hof_p = offset = self.LEN + self.addrs_len
+        curr_iof_p = curr_hof_p = 0
         # FIXME(kormat): NB this assumes that all OFs have the same length.
         if self._iof_idx:
-            curr_iof_p += self._iof_idx * OpaqueField.LEN
+            curr_iof_p = self.LEN + self.addrs_len + self._iof_idx * OpaqueField.LEN
         if self._hof_idx:
-            curr_hof_p += self._hof_idx * OpaqueField.LEN
-        if curr_hof_p == offset and curr_iof_p == offset:
-            curr_hof_p = curr_iof_p = 0
-
-        packed.append(struct.pack("!BBB",
-                                  curr_iof_p//LINE_LEN, curr_hof_p//LINE_LEN, self.next_hdr))
+            curr_hof_p = self.LEN + self.addrs_len + self._hof_idx * OpaqueField.LEN
+        packed.append(struct.pack("!BBB", curr_iof_p//LINE_LEN,
+                                  curr_hof_p//LINE_LEN, self.next_hdr))
         raw = b"".join(packed)
         assert len(raw) == self.LEN
         return raw

--- a/python/test/lib/packet/ext/traceroute_test.py
+++ b/python/test/lib/packet/ext/traceroute_test.py
@@ -67,7 +67,7 @@ class TestTracerouteExtPack(object):
     def test(self):
         inst = TracerouteExt()
         inst._check_len = create_mock()
-        inst._hdr_len = 2
+        inst._hdr_len = 3
         isd_as_1_2 = create_mock(["pack"])
         isd_as_1_2.pack.return_value = b"1-2"
         isd_as_5_6 = create_mock(["pack"])
@@ -90,7 +90,7 @@ class TestTracerouteExtAppendHop(object):
     def test(self):
         inst = TracerouteExt()
         inst.hops = [1]
-        inst._hdr_len = 2
+        inst._hdr_len = 3
         # Call
         inst.append_hop("3-4", 5, 6)
         # Tests

--- a/python/test/lib/packet/ext_hdr_test.py
+++ b/python/test/lib/packet/ext_hdr_test.py
@@ -47,9 +47,9 @@ class TestExtensionHeaderBytesToHdrLen(object):
 
     def test_valid(self):
         for count, expected in (
-            (5, 0),
-            (13, 1),
-            (21, 2),
+            (5, 1),
+            (13, 2),
+            (21, 3),
         ):
             yield self._check_valid, count, expected
 

--- a/python/test/lib/packet/ext_util_test.py
+++ b/python/test/lib/packet/ext_util_test.py
@@ -39,9 +39,9 @@ class TestParseExtensions(object):
     def test(self, l4_protos, ext_map):
         data = create_mock(["pop"])
         data.pop.side_effect = (
-            bytes.fromhex("881003"), "ext0 data",
-            bytes.fromhex("011599"), "ext1 data",
-            bytes.fromhex("FF0706"), "ext1 data",
+            bytes.fromhex("881103"), "ext0 data",
+            bytes.fromhex("011699"), "ext1 data",
+            bytes.fromhex("FF0806"), "ext1 data",
         )
         l4_protos.append(0xFF)
         ext0 = create_mock()

--- a/python/test/lib/packet/scion_test.py
+++ b/python/test/lib/packet/scion_test.py
@@ -144,13 +144,13 @@ class TestSCIONCommonHdrPack(object):
         inst.src_addr_type = 0b111111
         inst.addrs_len = 24
         inst.total_len = 0x0304
-        inst.hdr_len = 0x04
+        inst.hdr_len = 0x05
         inst._iof_idx = 0x03
         inst._hof_idx = 0x04
         inst.next_hdr = 0x09
         expected = b"".join([
             bytes([0b11110000, 0b00111111]),
-            bytes.fromhex('0304 04 07 08 09'),
+            bytes.fromhex('0304 05 07 08 09'),
         ])
         # Call
         ntools.eq_(inst.pack(), expected)

--- a/python/test/lib/packet/scion_test.py
+++ b/python/test/lib/packet/scion_test.py
@@ -67,7 +67,7 @@ class TestSCIONCommonHdrParse(object):
         inst = SCIONCommonHdr()
         data = create_mock(["pop"])
         data.pop.return_value = bytes([first_b, 0b00111111]) + \
-            bytes.fromhex('0304 04 07 08 07')
+            bytes.fromhex('0304 04 07 08 09')
         return inst, data
 
     @patch("lib.packet.scion.Raw", autospec=True)
@@ -90,7 +90,7 @@ class TestSCIONCommonHdrParse(object):
         ntools.eq_(inst.total_len, 0x0304)
         ntools.eq_(inst.hdr_len, 0x04)
         ntools.eq_(inst.hdr_len_bytes(), 0x20)
-        ntools.eq_(inst.next_hdr, 0x07)
+        ntools.eq_(inst.next_hdr, 0x09)
         ntools.eq_(inst.version, 0b0)
         ntools.eq_(inst.dst_addr_type, 0b111100)
         ntools.eq_(inst.src_addr_type, 0b111111)

--- a/python/test/lib/packet/scion_test.py
+++ b/python/test/lib/packet/scion_test.py
@@ -144,13 +144,13 @@ class TestSCIONCommonHdrPack(object):
         inst.src_addr_type = 0b111111
         inst.addrs_len = 24
         inst.total_len = 0x0304
-        inst.hdr_len = 0x08
+        inst.hdr_len = 0x04
         inst._iof_idx = 0x03
         inst._hof_idx = 0x04
-        inst.next_hdr = 0x07
+        inst.next_hdr = 0x09
         expected = b"".join([
             bytes([0b11110000, 0b00111111]),
-            bytes.fromhex('0304 08 07 08 07'),
+            bytes.fromhex('0304 04 07 08 09'),
         ])
         # Call
         ntools.eq_(inst.pack(), expected)


### PR DESCRIPTION
Refactor Lengths/offsets: (addresses issue #981)
CurrINF, CurrHF, HdrLen, ExtHdrLen are all computed as value * 8.
set CurrINF,CurrHF = 0 if no path.
fix TotalLength computation for spkt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1136)
<!-- Reviewable:end -->
