### PR TITLE
Small fixes to bind address support.

### DIFF
--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -198,7 +198,7 @@ class SCIONElement(object):
             host_addr, b_port = self.bind[0]
             b_addr = SCIONAddr.from_values(self.topology.isd_as, host_addr)
             self._udp_sock = ReliableSocket(
-                reg=(self.addr, self._port, init, svc), bind_addr=(b_addr, b_port))
+                reg=(self.addr, self._port, init, svc), bind_ip=(b_addr, b_port))
         else:
             self._udp_sock = ReliableSocket(
                 reg=(self.addr, self._port, init, svc))


### PR DESCRIPTION
The dispatcher was copying 0 bytes of the bind address into the bind SVC
entry, and scion_elem was using the wrong parameter name for
ReliableSocket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1137)
<!-- Reviewable:end -->
