### PR TITLE
Increase Certificate validity to 1 year

### DIFF
--- a/python/lib/crypto/certificate.py
+++ b/python/lib/crypto/certificate.py
@@ -67,8 +67,8 @@ class Certificate(object):
     :cvar str sign_algortihm: default algorithm used to sign a certificate.
     :cvar str enc_alorithm: default algorithm used to encrypt messages.
     """
-    AS_VALIDITY_PERIOD = 3 * 24 * 60 * 60
-    CORE_AS_VALIDITY_PERIOD = 7 * 24 * 60 * 60
+    AS_VALIDITY_PERIOD = 365 * 24 * 60 * 60
+    CORE_AS_VALIDITY_PERIOD = 365 * 24 * 60 * 60
     SIGN_ALGORTIHM = 'ed25519'
     ENC_ALGORITHM = 'curve25519xsalsa20poly1305'
     FIELDS_MAP = {


### PR DESCRIPTION
Increase Certificate validity to 1 year, since we currently have no system in place to replace old certs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1142)
<!-- Reviewable:end -->
