### PR TITLE
Add interface IDs to PCB short descriptions

### DIFF
--- a/python/lib/packet/pcb.py
+++ b/python/lib/packet/pcb.py
@@ -347,11 +347,18 @@ class PathSegment(SCIONPayloadBaseProto):
         desc.append("%s, %s, " % (self.short_id(), iso_timestamp(self.get_timestamp())))
         hops = []
         for asm in self.iter_asms():
-            hops.append(str(asm.isd_as()))
+            hop = []
+            hof = asm.pcbm(0).hof()
+            if hof.ingress_if:
+                hop.append("%d " % hof.ingress_if)
+            hop.append("%s" % asm.isd_as())
+            if hof.egress_if:
+                hop.append(" %d" % hof.egress_if)
+            hops.append("".join(hop))
         exts = []
         if self.is_sibra():
             exts.append("  %s" % self.sibra_ext.short_desc())
-        desc.append(" > ".join(hops))
+        desc.append(">".join(hops))
         if exts:
             return "%s\n%s" % ("".join(desc), "\n".join(exts))
         return "".join(desc)


### PR DESCRIPTION
Otherwise it is impossible to distinguish between PCBs that use
different interfaces between a pair of ASes.

Example:
`9922531e290e, 2017-07-05 14:34:12+00:00, 1-13 18>68 1-16 33>56 1-19`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1151)
<!-- Reviewable:end -->
