### PR TITLE
Fix memory leak in PS and BS.

### DIFF
--- a/python/lib/msg_meta.py
+++ b/python/lib/msg_meta.py
@@ -50,10 +50,6 @@ class MetadataBase(object):
     def __str__(self):
         return "%s:%d" % (self.get_addr(), self.port)
 
-    def __eq__(self, other):
-        return self.host == other.host and self.port == other.port and (
-            (not self.ia and not other.ia) or (self.ia and other.ia and self.ia == other.ia))
-
 
 class UDPMetadata(MetadataBase):
     """

--- a/python/lib/msg_meta.py
+++ b/python/lib/msg_meta.py
@@ -51,7 +51,8 @@ class MetadataBase(object):
         return "%s:%d" % (self.get_addr(), self.port)
 
     def __eq__(self, other):
-        return self.ia == other.ia and self.host == other.host and self.port == other.port
+        return self.host == other.host and self.port == other.port and (
+            (not self.ia and not other.ia) or (self.ia and other.ia and self.ia == other.ia))
 
 
 class UDPMetadata(MetadataBase):

--- a/python/lib/msg_meta.py
+++ b/python/lib/msg_meta.py
@@ -50,6 +50,9 @@ class MetadataBase(object):
     def __str__(self):
         return "%s:%d" % (self.get_addr(), self.port)
 
+    def __eq__(self, other):
+        return self.ia == other.ia and self.host == other.host and self.port == other.port
+
 
 class UDPMetadata(MetadataBase):
     """

--- a/python/lib/path_seg_meta.py
+++ b/python/lib/path_seg_meta.py
@@ -19,7 +19,7 @@
 import threading
 
 
-class PathSegMeta(object):
+class PathSegMeta(object):  # pragma: no cover
     """
     The PathSegMeta class holds missing trcs and certificates and
     necessary metadata for a path segment.
@@ -36,6 +36,7 @@ class PathSegMeta(object):
         self.meta = meta
         self.type = type_
         self.params = params
+        self.id = seg.get_hops_hash()
 
     def verifiable(self):
         with self.miss_cert_lock and self.miss_trc_lock:

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -195,7 +195,7 @@ class SCIONElement(object):
             self._DefaultMeta = TCPMetadata
         else:
             self._DefaultMeta = UDPMetadata
-        self.unverified_segs = {}
+        self.unverified_segs = ExpiringDict(500, 60 * 60)
         self.unv_segs_lock = threading.RLock()
         self.requested_trcs = {}
         self.req_trcs_lock = threading.Lock()

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -430,8 +430,8 @@ class SCIONElement(object):
         for isd, ver in missing_trcs:
             with self.req_trcs_lock:
                 _, meta = self.requested_trcs.get((isd, ver), (None, None))
-                # There is already an outstanding request for the missing TRC.
                 if meta:
+                    # There is already an outstanding request for the missing TRC.
                     continue
             trc_req = TRCRequest.from_values(ISD_AS.from_values(isd, 0), ver, cache_only=True)
             meta = seg_meta.meta or self._get_cs()
@@ -462,8 +462,8 @@ class SCIONElement(object):
         for isd_as, ver in missing_certs:
             with self.req_certs_lock:
                 _, meta = self.requested_certs.get((isd_as, ver), (None, None))
-                # There is already an outstanding request for the missing TRC.
                 if meta:
+                    # There is already an outstanding request for the missing cert.
                     continue
             cert_req = CertChainRequest.from_values(isd_as, ver, cache_only=True)
             meta = seg_meta.meta or self._get_cs()

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -329,6 +329,7 @@ class SCIONElement(object):
                 if now - req_time >= self.TRC_CC_REQ_TIMEOUT:
                     trc_req = TRCRequest.from_values(ISD_AS.from_values(isd, 0), ver,
                                                      cache_only=True)
+                    meta = meta or self._get_cs()
                     logging.info("Re-Requesting TRC from %s: %s", meta, trc_req.short_desc())
                     self.send_meta(trc_req, meta)
                     self.requested_trcs[(isd, ver)] = (time.time(), meta)
@@ -344,6 +345,7 @@ class SCIONElement(object):
             for (isd_as, ver), (req_time, meta) in self.requested_certs.items():
                 if now - req_time >= self.TRC_CC_REQ_TIMEOUT:
                     cert_req = CertChainRequest.from_values(isd_as, ver, cache_only=True)
+                    meta = meta or self._get_cs()
                     logging.info("Re-Requesting CERTCHAIN from %s: %s", meta, cert_req.short_desc())
                     self.send_meta(cert_req, meta)
                     self.requested_certs[(isd_as, ver)] = (time.time(), meta)

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -426,7 +426,9 @@ class SCIONElement(object):
             return
         for isd, ver in missing_trcs:
             with self.req_trcs_lock:
-                if (isd, ver) in self.requested_trcs:
+                _, meta = self.requested_trcs.get((isd, ver), (None, None))
+                # Prefer requesting from remote BS.
+                if meta and (not seg_meta.meta or seg_meta.meta == self._get_cs()):
                     continue
             trc_req = TRCRequest.from_values(ISD_AS.from_values(isd, 0), ver, cache_only=True)
             meta = seg_meta.meta or self._get_cs()
@@ -456,7 +458,9 @@ class SCIONElement(object):
             return
         for isd_as, ver in missing_certs:
             with self.req_certs_lock:
-                if (isd_as, ver) in self.requested_certs:
+                _, meta = self.requested_certs.get((isd_as, ver), (None, None))
+                # Prefer requesting from remote BS.
+                if meta and (not seg_meta.meta or seg_meta.meta == self._get_cs()):
                     continue
             cert_req = CertChainRequest.from_values(isd_as, ver, cache_only=True)
             meta = seg_meta.meta or self._get_cs()


### PR DESCRIPTION
A flaw in how segment verification was handled when receiving path segments through Zookeeper lead to a memory leak.

On startup of a server it can happen that the first path segments come from Zookeeper. If not all certificates are available the server requests it from the local CS with the cache only flag set. However, the CS doesn't have this certificate yet, which lead to a rerequesting loop. This loop also prevented requesting the certs from the appropriate beacon servers when new path segments were arriving.

Fixed the issue by having newer path segments always overwrite older ones in the unverified segments map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1159)
<!-- Reviewable:end -->
