### PR TITLE
Reduce a race-condition window for SIGHUP on startup.

### DIFF
--- a/go/border/main.go
+++ b/go/border/main.go
@@ -71,7 +71,7 @@ func main() {
 }
 
 func setupSignals() {
-	sig := make(chan os.Signal)
+	sig := make(chan os.Signal, 2)
 	signal.Notify(sig, os.Interrupt)
 	signal.Notify(sig, syscall.SIGTERM)
 	go func() {


### PR DESCRIPTION
If the border router process receives a HUP signal on startup, there's a
short window in which this can cause the process to exit immediately.
This change moves catching SIGHUP to the very start of the process, to
make the window as small as possible.

Also:
- Use buffered channels for signals, as otherwise signals can be lost
  (https://golang.org/pkg/os/signal/#Notify)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1160)
<!-- Reviewable:end -->
