### PR TITLE
Separate retrieved TRCs and certs in separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 /logs/*
 !/logs/.keepme
 /gen/
+/gen-cache/
 /traces/
 
 # Python generated files #

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -175,7 +175,7 @@ class SCIONElement(object):
             if bind is None:
                 self.bind = own_config.bind
         self.init_ifid2br()
-        self.trust_store = TrustStore(self.conf_dir, self._labels)
+        self.trust_store = TrustStore(self.conf_dir, "gen-cache", self.id, self._labels)
         self.total_dropped = 0
         self._core_ases = defaultdict(list)  # Mapping ISD_ID->list of core ASes
         self.init_core_ases()

--- a/python/test/lib/trust_store_test.py
+++ b/python/test/lib/trust_store_test.py
@@ -31,7 +31,7 @@ class TestTrustStoreGetTrc(object):
     Unit tests for lib.trust_store.TrustStore.get_trc
     """
     def _init(self):
-        inst = TrustStore("conf_dir")
+        inst = TrustStore("conf_dir", "cache_dir", "element_name")
         inst._trcs[1] = [(1, 'trc1'), (3, 'trc3'), (0, 'trc0')]
         return inst
 
@@ -61,7 +61,7 @@ class TestTrustStoreGetCert(object):
     Unit tests for lib.trust_store.TrustStore.get_cert
     """
     def _init(self):
-        inst = TrustStore("conf_dir")
+        inst = TrustStore("conf_dir", "cache_dir", "element_name")
         inst._certs["1-1"] = [(1, 'cert1'), (3, 'cert3'), (0, 'cert0')]
         return inst
 
@@ -92,7 +92,7 @@ class TestTrustStoreAddTrc(object):
     """
     @patch("lib.trust_store.write_file", autospec=True)
     def test_add_unique_version(self, write_file):
-        inst = TrustStore("conf_dir")
+        inst = TrustStore("conf_dir", "cache_dir", "element_name")
         inst._trcs[1] = [(0, 'trc0'), (1, 'trc1')]
         trcs_before = inst._trcs[1][:]
         trc = create_mock(['get_isd_ver'])
@@ -102,11 +102,11 @@ class TestTrustStoreAddTrc(object):
         # Tests
         ntools.eq_(inst._trcs[1], trcs_before + [(2, trc)])
         write_file.assert_called_once_with(
-            "conf_dir/certs/ISD1-V2.trc", str(trc))
+            "cache_dir/element_name-ISD1-V2.trc", str(trc))
 
     @patch("lib.trust_store.write_file", autospec=True)
     def test_add_non_unique_version(self, write_file):
-        inst = TrustStore("conf_dir")
+        inst = TrustStore("conf_dir", "cache_dir", "element_name")
         inst._trcs[1] = [(0, 'trc0'), (1, 'trc1')]
         trcs_before = inst._trcs[1][:]
         trc = create_mock(['get_isd_ver'])
@@ -124,7 +124,7 @@ class TestTrustStoreAddCert(object):
     """
     @patch("lib.trust_store.write_file", autospec=True)
     def test_add_unique_version(self, write_file):
-        inst = TrustStore("conf_dir")
+        inst = TrustStore("conf_dir", "cache_dir", "element_name")
         inst._certs[(1, 1)] = [(0, 'cert0'), (1, 'cert1')]
         certs_before = inst._certs[(1, 1)][:]
         cert = create_mock(['get_leaf_isd_as_ver'])
@@ -134,11 +134,11 @@ class TestTrustStoreAddCert(object):
         # Tests
         ntools.eq_(inst._certs[(1, 1)], certs_before + [(2, cert)])
         write_file.assert_called_once_with(
-            "conf_dir/certs/ISD1-AS1-V2.crt", str(cert))
+            "cache_dir/element_name-ISD1-AS1-V2.crt", str(cert))
 
     @patch("lib.trust_store.write_file", autospec=True)
     def test_add_non_unique_version(self, write_file):
-        inst = TrustStore("conf_dir")
+        inst = TrustStore("conf_dir", "cache_dir", "element_name")
         inst._certs[(1, 1)] = [(0, 'cert0'), (1, 'cert1')]
         certs_before = inst._certs[(1, 1)][:]
         cert = create_mock(['get_leaf_isd_as_ver'])

--- a/scion.sh
+++ b/scion.sh
@@ -11,6 +11,8 @@ cmd_topology() {
     echo "Shutting down supervisord: $(supervisor/supervisor.sh shutdown)"
     mkdir -p logs traces
     [ -e gen ] && rm -r gen
+    [ -e gen-cache ] && rm -r gen-cache
+    mkdir gen-cache
     if [ "$1" = "zkclean" ]; then
         shift
         zkclean="y"


### PR DESCRIPTION
To avoid deleting cached data from `gen/` and thus triggering restarts
via Ansible, move those files to a separate subdirectory, `gen-cache`.
Also fix `scion.sh` to nuke and (re)make the directory if the topology
is (re)generated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1161)
<!-- Reviewable:end -->
