### PR TITLE
Make PathSegmentTTL and RevocationTreeTTL configurable.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN cp sub/web/web_scion/settings/private.dist.py sub/web/web_scion/settings/pri
 RUN sub/web/manage.py makemigrations
 
 # Build topology files
-RUN ./scion.sh topology
+RUN ./scion.sh topology --circleci

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN cp sub/web/web_scion/settings/private.dist.py sub/web/web_scion/settings/pri
 RUN sub/web/manage.py makemigrations
 
 # Build topology files
-RUN ./scion.sh topology --circleci
+RUN ./scion.sh topology

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -53,7 +53,7 @@ func (r *RevInfo) ProtoId() proto.ProtoIdType {
 }
 
 func (r *RevInfo) String() string {
-	return fmt.Sprintf("IA: %v IfID: %v Epoch: %v TreeTTL: %v",
+	return fmt.Sprintf("IA: %s IfID: %d Epoch: %d TreeTTL: %d",
 		r.IA(), r.IfID, r.Epoch, r.TreeTTL)
 }
 

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -37,6 +37,7 @@ type RevInfo struct {
 	NextRoot common.RawBytes
 	RawIsdas uint32 `capnp:"isdas"`
 	HashType uint16
+	TreeTTL  uint32
 }
 
 func NewRevInfoFromRaw(b common.RawBytes) (*RevInfo, error) {
@@ -52,7 +53,8 @@ func (r *RevInfo) ProtoId() proto.ProtoIdType {
 }
 
 func (r *RevInfo) String() string {
-	return fmt.Sprintf("IA: %v IfID: %v Epoch: %v", r.IA(), r.IfID, r.Epoch)
+	return fmt.Sprintf("IA: %v IfID: %v Epoch: %v TreeTTL: %v",
+		r.IA(), r.IfID, r.Epoch, r.TreeTTL)
 }
 
 type SiblingHash struct {

--- a/proto/rev_info.capnp
+++ b/proto/rev_info.capnp
@@ -17,4 +17,5 @@ struct RevInfo {
 	nextRoot @5 :Data;  # Root of the hashtree of next time block (T+1)
 	isdas @6 :UInt32;  # ISD-AS of the revocation issuer.
 	hashType @7 :UInt16;  # The hash function type needed to verify the revocation.
+	treeTTL @8 :UInt32;  # The validity period of the revocation tree.
 }

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -35,6 +35,7 @@ from lib.crypto.hash_tree import ConnectedHashTree
 from lib.crypto.symcrypto import kdf
 from lib.defines import (
     BEACON_SERVICE,
+    EXP_TIME_UNIT,
     HASHTREE_EPOCH_TIME,
     HASHTREE_EPOCH_TOLERANCE,
     HASHTREE_TTL,
@@ -108,8 +109,6 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             hash-chain for each interface.
     """
     SERVICE_TYPE = BEACON_SERVICE
-    # Amount of time units a HOF is valid (time unit is EXP_TIME_UNIT).
-    HOF_EXP_TIME = 63
     # ZK path for incoming PCBs
     ZK_PCB_CACHE_PATH = "pcb_cache"
     # ZK path for revocations.
@@ -134,6 +133,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         self.hashtree_gen_key = kdf(
                             self.config.master_as_key, b"Derive hashtree Key")
         logging.info(self.config.__dict__)
+        # Amount of time units a HOF is valid (time unit is EXP_TIME_UNIT).
+        self.hof_exp_time = int(self.config.segment_ttl / EXP_TIME_UNIT)
         self._hash_tree = None
         self._hash_tree_lock = Lock()
         self._next_tree = None
@@ -225,7 +226,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     def _create_one_hop_path(self, egress_if):
         ts = int(SCIONTime.get_time())
         info = InfoOpaqueField.from_values(ts, self.addr.isd_as[0], hops=2)
-        hf1 = HopOpaqueField.from_values(self.HOF_EXP_TIME, 0, egress_if)
+        hf1 = HopOpaqueField.from_values(self.hof_exp_time, 0, egress_if)
         hf1.set_mac(self.of_gen_key, ts, None)
         # Return a path where second HF is empty.
         return SCIONPath.from_values(info, [hf1, HopOpaqueField()])
@@ -379,7 +380,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         if out_info["remote_ia"].int() and not out_info["remote_if"]:
             return None
         hof = HopOpaqueField.from_values(
-            self.HOF_EXP_TIME, in_if, out_if, xover=xover)
+            self.hof_exp_time, in_if, out_if, xover=xover)
         hof.set_mac(self.of_gen_key, ts, prev_hof)
         return PCBMarking.from_values(
             in_info["remote_ia"], in_info["remote_if"], in_info["mtu"],
@@ -452,13 +453,13 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
     def _create_next_tree(self):
         last_ttl_window = 0
+        ttl = self.config.revocation_tree_ttl
         while self.run_flag.is_set():
             start = time.time()
-            cur_ttl_window = ConnectedHashTree.get_ttl_window()
-            time_to_sleep = (ConnectedHashTree.get_time_till_next_ttl() -
-                             HASHTREE_UPDATE_WINDOW)
+            cur_ttl_window = ConnectedHashTree.get_ttl_window(ttl)
+            time_to_sleep = ConnectedHashTree.time_until_next_window(ttl) - HASHTREE_UPDATE_WINDOW
             if cur_ttl_window == last_ttl_window:
-                time_to_sleep += HASHTREE_TTL
+                time_to_sleep += ttl
             if time_to_sleep > 0:
                 sleep_interval(start, time_to_sleep, "BS._create_next_tree",
                                self._quiet_startup())

--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -82,7 +82,7 @@ class Config(object):
         self.registers_paths = config['RegisterPath']
         self.cert_ver = config['CertChainVersion']
         self.segment_ttl = config['PathSegmentTTL']
-        self.revocation_tree_ttl = config['RevocationTreeTTL']
+        self.revocation_tree_ttl = config.get('RevocationTreeTTL', self.segment_ttl)
         if self.revocation_tree_ttl < self.segment_ttl:
             logging.warning("RevocationTreeTTL shorter than PathSegmentTTL (%ds vs %ds). "
                             "Setting RevocationTreeTTL to %ds",

--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -17,6 +17,7 @@
 """
 # Stdlib
 import base64
+import logging
 
 # SCION
 from lib.util import load_yaml_file
@@ -32,6 +33,8 @@ class Config(object):
     :ivar int registration_time: the interval at which paths are registered.
     :ivar int registers_paths: whether or not the AS registers paths.
     :ivar int cert_ver: initial version of the certificate chain.
+    :ivar int segment_ttl: the TTL of path segments registered by this AS (in seconds).
+    :ivar int revocation_tree_ttl: the TTL of one revocation tree (in seconds).
     """
 
     def __init__(self):  # pragma: no cover
@@ -40,6 +43,8 @@ class Config(object):
         self.registration_time = 0
         self.registers_paths = 0
         self.cert_ver = 0
+        self.segment_ttl = 0
+        self.revocation_tree_ttl = 0
 
     @classmethod
     def from_file(cls, config_file):  # pragma: no cover
@@ -76,3 +81,10 @@ class Config(object):
         self.registration_time = config['RegisterTime']
         self.registers_paths = config['RegisterPath']
         self.cert_ver = config['CertChainVersion']
+        self.segment_ttl = config['PathSegmentTTL']
+        self.revocation_tree_ttl = config['RevocationTreeTTL']
+        if self.revocation_tree_ttl < self.segment_ttl:
+            logging.warning("RevocationTreeTTL shorter than PathSegmentTTL (%ds vs %ds). "
+                            "Setting RevocationTreeTTL to %ds",
+                            self.segment_ttl, self.revocation_tree_ttl, self.segment_ttl)
+            self.revocation_tree_ttl = self.segment_ttl

--- a/python/lib/crypto/hash_tree.py
+++ b/python/lib/crypto/hash_tree.py
@@ -161,15 +161,15 @@ class ConnectedHashTree(object):
         """
         assert len(if_ids), "Must have at least 1 leaf"
         assert hashtree_ttl > 0, "HashTree TTL cannot be <= 0"
-        ttl_window = self.get_ttl_window()
+        ttl_window = self.get_ttl_window(hashtree_ttl)
         seed1 = seed + (ttl_window - 1).to_bytes(8, 'big')
         seed2 = seed + (ttl_window + 0).to_bytes(8, 'big')
         seed3 = seed + (ttl_window + 1).to_bytes(8, 'big')
 
         self._hash_func = hash_func_for_type(hash_type)
         self._ht0_root = self._hash_func(str(seed1).encode('utf-8'))
-        self._ht1 = HashTree(isd_as, if_ids, seed2, ttl_window, hash_type)
-        self._ht2 = HashTree(isd_as, if_ids, seed3, ttl_window + 1, hash_type)
+        self._ht1 = HashTree(isd_as, if_ids, seed2, hashtree_ttl, hash_type)
+        self._ht2 = HashTree(isd_as, if_ids, seed3, hashtree_ttl, hash_type)
 
     @classmethod
     def get_ttl_window(cls, ttl):
@@ -188,10 +188,10 @@ class ConnectedHashTree(object):
         return ttl - (time.time() % ttl)
 
     @classmethod
-    def get_next_tree(cls, isd_as, if_ids, seed, hash_type):
-        ttl_window = cls.get_ttl_window() + 2
+    def get_next_tree(cls, isd_as, if_ids, seed, ttl, hash_type):
+        ttl_window = cls.get_ttl_window(ttl) + 2
         seed += ttl_window.to_bytes(8, 'big')
-        return HashTree(isd_as, if_ids, seed, ttl_window, hash_type)
+        return HashTree(isd_as, if_ids, seed, ttl, hash_type)
 
     def update(self, next_tree):
         self._ht0_root = self._ht1._nodes[0]

--- a/python/lib/crypto/hash_tree.py
+++ b/python/lib/crypto/hash_tree.py
@@ -43,6 +43,8 @@ class HashTree(object):
         :param int ttl: The TTL window for which this hash tree is valid (in seconds).
         :param hash_type: Hash function type.
         """
+        assert ttl % HASHTREE_EPOCH_TIME == 0,\
+            "HashTree TTL must be a multiple of %ds" % HASHTREE_EPOCH_TIME
         self._isd_as = isd_as
         self._seed = seed
         self._ttl = ttl

--- a/python/lib/defines.py
+++ b/python/lib/defines.py
@@ -23,12 +23,7 @@ import os
 SCION_PROTO_VERSION = 0
 
 #: Max TTL of a PathSegment in realtime seconds.
-# TODO(shitz): This value should be externally configurable. The problem is that
-# the revocation hash tree TTL needs to be at least as large as MAX_SEGMENT_TTL,
-# but having a TTL of 1 day makes the hash tree generation costly enough that it
-# times out on CircleCI. Thus, we should have one external config file for the
-# Docker/CircleCI environment and one for production.
-MAX_SEGMENT_TTL = 30 * 60
+MAX_SEGMENT_TTL = 12 * 60 * 60
 #: Time unit for HOF expiration.
 EXP_TIME_UNIT = MAX_SEGMENT_TTL / 2 ** 8
 #: Max number of supported HopByHop extensions (does not include SCMP)
@@ -137,8 +132,6 @@ MAX_HOST_ADDR_LEN = 16
 HASHTREE_EPOCH_TIME = 10
 # The tolerable error in epoch in seconds.
 HASHTREE_EPOCH_TOLERANCE = 2
-# Max time to live
-HASHTREE_TTL = MAX_SEGMENT_TTL
 # Number of epochs in one TTL per interface
 HASHTREE_N_EPOCHS = HASHTREE_TTL // HASHTREE_EPOCH_TIME
 # How much time in advance to compute the next hash tree

--- a/python/lib/defines.py
+++ b/python/lib/defines.py
@@ -132,10 +132,6 @@ MAX_HOST_ADDR_LEN = 16
 HASHTREE_EPOCH_TIME = 10
 # The tolerable error in epoch in seconds.
 HASHTREE_EPOCH_TOLERANCE = 2
-# Number of epochs in one TTL per interface
-HASHTREE_N_EPOCHS = HASHTREE_TTL // HASHTREE_EPOCH_TIME
-# How much time in advance to compute the next hash tree
-HASHTREE_UPDATE_WINDOW = HASHTREE_TTL / 3
 
 # TCP polling timeouts, used by accept() and recv().
 TCP_ACCEPT_POLLING_TOUT = 1.0

--- a/python/lib/packet/path_mgmt/rev_info.py
+++ b/python/lib/packet/path_mgmt/rev_info.py
@@ -82,5 +82,5 @@ class RevocationInfo(Cerealizable):
         return hash(self.cmp_str())
 
     def short_desc(self):
-        return "RevInfo: %s IF: %d EPOCH: %d" % (self.isd_as(), self.p.ifID,
-                                                 self.p.epoch)
+        return "RevInfo: %s IF: %d EPOCH: %d TreeTTL: %d" % (
+            self.isd_as(), self.p.ifID, self.p.epoch, self.p.treeTTL)

--- a/python/lib/packet/path_mgmt/rev_info.py
+++ b/python/lib/packet/path_mgmt/rev_info.py
@@ -35,7 +35,7 @@ class RevocationInfo(Cerealizable):
 
     @classmethod
     def from_values(cls, isd_as, if_id, epoch, nonce, siblings, prev_root,
-                    next_root, hash_type):
+                    next_root, hash_type, tree_ttl):
         """
         Returns a RevocationInfo object with the specified values.
 
@@ -46,11 +46,12 @@ class RevocationInfo(Cerealizable):
         :param list[(bool, bytes)] siblings: Positions and hashes of siblings
         :param bytes prev_root: Hash of the tree root at time T-1
         :param bytes next_root: Hash of the tree root at time T+1
-        :param hash_type: The hash function needed to verify the revocation.
+        :param int hash_type: The hash function needed to verify the revocation.
+        :param int tree_ttl: The validity period of the revocation tree.
         """
         # Put the isd_as, if_id, epoch and nonce of the leaf into the proof.
         p = cls.P_CLS.new_message(isdas=int(isd_as), ifID=if_id, epoch=epoch,
-                                  nonce=nonce, hashType=hash_type)
+                                  nonce=nonce, hashType=hash_type, treeTTL=tree_ttl)
         # Put the list of sibling hashes (along with l/r) into the proof.
         sibs = p.init('siblings', len(siblings))
         for i, sibling in enumerate(siblings):

--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -31,7 +31,6 @@ from lib.crypto.hash_tree import ConnectedHashTree
 from lib.crypto.symcrypto import crypto_hash
 from lib.defines import (
     HASHTREE_EPOCH_TIME,
-    HASHTREE_TTL,
     PATH_REQ_TOUT,
     PATH_SERVICE,
 )
@@ -110,7 +109,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         self.waiting_targets = defaultdict(list)
         self.revocations = RevCache(labels=self._labels)
         # A mapping from (hash tree root of AS, IFID) to segments
-        self.htroot_if2seg = ExpiringDict(1000, HASHTREE_TTL)
+        self.htroot_if2seg = ExpiringDict(1000, self.config.revocation_tree_ttl)
         self.htroot_if2seglock = Lock()
         self.CTRL_PLD_CLASS_MAP = {
             PayloadClass.PATH: {

--- a/python/test/lib/config_test.py
+++ b/python/test/lib/config_test.py
@@ -51,8 +51,8 @@ class TestConfigParseDict(BaseLibConfig):
         "PropagateTime": 5,
         "RegisterPath": 1,
         "RegisterTime": 5,
-        "PathSegmentTTL": 6 * 24 * 60 * 60,
-        "RevocationTreeTTL": 6 *24 * 60 * 60,
+        "PathSegmentTTL": 6 * 60 * 60,
+        "RevocationTreeTTL": 6 * 60 * 60,
     }
 
     def test_basic(self):

--- a/python/test/lib/config_test.py
+++ b/python/test/lib/config_test.py
@@ -36,6 +36,8 @@ class BaseLibConfig(object):
         'registration_time': 'RegisterTime',
         'registers_paths': 'RegisterPath',
         'cert_ver': 'CertChainVersion',
+        'segment_ttl': 'PathSegmentTTL',
+        'revocation_tree_ttl': 'RevocationTreeTTL'
     }
 
 
@@ -49,6 +51,8 @@ class TestConfigParseDict(BaseLibConfig):
         "PropagateTime": 5,
         "RegisterPath": 1,
         "RegisterTime": 5,
+        "PathSegmentTTL": 6 * 24 * 60 * 60,
+        "RevocationTreeTTL": 6 *24 * 60 * 60,
     }
 
     def test_basic(self):

--- a/python/test/lib/crypto/hash_tree_test.py
+++ b/python/test/lib/crypto/hash_tree_test.py
@@ -65,7 +65,6 @@ class TestHashTreeCreateTree(object):
     """
     Unit test for lib.crypto.hash_tree.HashTree.create_tree
     """
-    @patch("lib.crypto.hash_tree.HASHTREE_N_EPOCHS", 1)
     @patch("lib.crypto.hash_tree.HashTree._setup", autospec=True)
     @patch("lib.crypto.hash_tree.hash_func_for_type", autospec=True)
     def test(self, hash_func_for_type, _):
@@ -76,7 +75,7 @@ class TestHashTreeCreateTree(object):
                   b"0", b"30s300", b"10s1020s20", b"10s1020s2030s300"]
         hash_func = create_mock_full(side_effect=hashes)
         hash_func_for_type.return_value = hash_func
-        inst = HashTree(isd_as, if_ids, b"s", 1, HashType.SHA256)
+        inst = HashTree(isd_as, if_ids, b"s", 10, HashType.SHA256)
         inst._depth = 2
         # Call
         inst.create_tree(if_ids)
@@ -90,7 +89,6 @@ class TestHashTreeGetProof(object):
     """
     Unit test for lib.crypto.hash_tree.HashTree.get_proof
     """
-    @patch("lib.crypto.hash_tree.HASHTREE_N_EPOCHS", 1)
     @patch("lib.crypto.hash_tree.HashTree._setup", autospec=True)
     @patch("lib.crypto.hash_tree.hash_func_for_type", autospec=True)
     def test(self, hash_func_for_type, _):
@@ -101,7 +99,7 @@ class TestHashTreeGetProof(object):
                   b"0", b"30s300", b"10s1020s20", b"10s1020s2030s300", b"s20"]
         hash_func = create_mock_full(side_effect=hashes)
         hash_func_for_type.return_value = hash_func
-        inst = HashTree(isd_as, if_ids, b"s", 1, HashType.SHA256)
+        inst = HashTree(isd_as, if_ids, b"s", 10, HashType.SHA256)
         inst._depth = 2
         inst.create_tree(if_ids)
         # Call
@@ -115,7 +113,6 @@ class TestHashTreeGetProof(object):
         ntools.eq_(proof.p.siblings[1].hash, b"30s300")
 
 
-@patch("lib.crypto.hash_tree.HASHTREE_N_EPOCHS", 1)
 class TestConnectedHashTreeUpdate(object):
     """
     Unit test for lib.crypto.hash_tree.ConnectedHashTree.update
@@ -125,11 +122,11 @@ class TestConnectedHashTreeUpdate(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, 60, HashType.SHA256)
         root1_before_update = inst._ht1._nodes[0]
         root2_before_update = inst._ht2._nodes[0]
         # Call
-        new_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed", HashType.SHA256)
+        new_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed", 60, HashType.SHA256)
         inst.update(new_tree)
         # Tests
         root0_after_update = inst._ht0_root
@@ -150,7 +147,7 @@ class TestConnectedHashtreeGetPossibleHashes(object):
         siblings.append(create_mock_full({"isLeft": False, "hash": "30s300"}))
         p = create_mock_full(
             {"ifID": 2, "epoch": 0, "nonce": b"s20", "siblings": siblings,
-             "prevRoot": "p", "nextRoot": "n", "hashType": 0})
+             "prevRoot": "p", "nextRoot": "n", "hashType": 0, "treeTTL": 60})
         rev_info = create_mock_full({"p": p})
         hashes = ["20s20", "10s1020s20", "10s1020s2030s300",
                   "p10s1020s2030s300", "10s1020s2030s300n"]
@@ -173,7 +170,7 @@ class TestConnectedHashTreeUpdateAndVerify(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, 60, HashType.SHA256)
         root = inst.get_root()
         # Call
         proof = inst.get_proof(120)
@@ -186,10 +183,10 @@ class TestConnectedHashTreeUpdateAndVerify(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, 60, HashType.SHA256)
         root = inst.get_root()
         # Call
-        next_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed", HashType.SHA256)
+        next_tree = inst.get_next_tree(isd_as, if_ids, b"new!!seed", 60, HashType.SHA256)
         inst.update(next_tree)
         # Tests
         proof = inst.get_proof(35)  # if_id = 35.
@@ -201,12 +198,12 @@ class TestConnectedHashTreeUpdateAndVerify(object):
         isd_as = ISD_AS("1-11")
         if_ids = [23, 35, 120]
         initial_seed = b"qwerty"
-        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, HashType.SHA256)
+        inst = ConnectedHashTree(isd_as, if_ids, initial_seed, 60, HashType.SHA256)
         root = inst.get_root()
         # Call
-        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@1", HashType.SHA256)
+        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@1", 60, HashType.SHA256)
         inst.update(new_tree)
-        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@2", HashType.SHA256)
+        new_tree = inst.get_next_tree(isd_as, if_ids, b"newseed.@2", 60, HashType.SHA256)
         inst.update(new_tree)
         # Tests
         proof = inst.get_proof(35)  # if_id = 35.

--- a/python/test/lib/crypto/hash_tree_test.py
+++ b/python/test/lib/crypto/hash_tree_test.py
@@ -43,7 +43,7 @@ class TestHashTreeCalcTreeDepth(object):
     @patch("lib.crypto.hash_tree.HashTree._setup", autospec=True)
     def test_for_non2power(self, _):
         # Setup
-        inst = HashTree(ISD_AS("1-11"), "if_ids", "seed", 1, HashType.SHA256)
+        inst = HashTree(ISD_AS("1-11"), "if_ids", "seed", 10, HashType.SHA256)
         # Call
         inst.calc_tree_depth(6)
         # Tests
@@ -54,7 +54,7 @@ class TestHashTreeCalcTreeDepth(object):
         # Setup
         if_ids = [1, 2, 3, 4]
         seed = b"abc"
-        inst = HashTree(ISD_AS("1-11"), if_ids, seed, 1, HashType.SHA256)
+        inst = HashTree(ISD_AS("1-11"), if_ids, seed, 10, HashType.SHA256)
         # Call
         inst.calc_tree_depth(8)
         # Tests

--- a/tools/ci/build_prep
+++ b/tools/ci/build_prep
@@ -15,4 +15,4 @@ APTARGS=-y ./env/deps
 make -C go deps
 cp sub/web/web_scion/settings/private.dist.py sub/web/web_scion/settings/private.py
 ./sub/web/manage.py makemigrations
-./scion.sh topology
+./scion.sh topology --pseg-ttl 1800


### PR DESCRIPTION
This PR adds the ability for each AS to configure the TTL of both their path segments and the revocation tree. The revocation tree TTL has to be at least as large as the path segment TTL.

Since each AS now can have a different revocation tree TTL, each revocation needs to include the TTL of the corresponding tree. Fixes #1098.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1164)
<!-- Reviewable:end -->
