### PR TITLE
Make SIG use an alternate routing table.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ bin/border
 bin/discovery
 bin/dispatcher
 bin/logdog
+bin/sig
 c/dispatcher/dispatcher
 c/ssp/test/*client
 c/ssp/test/*server

--- a/go/sig/sig.go
+++ b/go/sig/sig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netsec-ethz/scion/go/sig/control"
 	"github.com/netsec-ethz/scion/go/sig/lib/scion"
 	"github.com/netsec-ethz/scion/go/sig/management"
+	"github.com/netsec-ethz/scion/go/sig/xnet"
 )
 
 const (
@@ -112,6 +113,7 @@ func parseEncapFlags() error {
 	if netip == nil {
 		return common.NewError("Unable to parse encapsulation IP address", "addr", *ip)
 	}
+	xnet.Setup(netip)
 	Addr = addr.HostFromIP(netip)
 	Port = uint16(*port)
 	if Port == 0 {


### PR DESCRIPTION
This allows the main forwarding traffic to be easily switched to/away
from the SIG (by changing an ip rule). This also allows SIG healthchecks
to always use the SIG, so it can be checked even when it's not
forwarding the main traffic.

Also:
- Add bin/sig to .gitignore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1168)
<!-- Reviewable:end -->
