### PR TITLE
Egress data now passes through the dispatcher

### DIFF
--- a/go/sig/lib/scion/scion.go
+++ b/go/sig/lib/scion/scion.go
@@ -45,24 +45,8 @@ func NewSCIONNet(ia *addr.ISD_AS, sciondPath string, dispatcherPath string) (*SC
 // pass through the dispatcher, which sends it to the local application via a
 // Reliable (UNIX) socket.
 func (c *SCIONNet) DialSCION(IA *addr.ISD_AS, local, remote addr.HostAddr, port uint16) (*SCIONConn, error) {
-	// We ask the OS for a free dynamic source port because the dispatcher
-	// cannot select a SCION/UDP one for us. A reference to this port is
-	// kept in the returned *SCIONConn object to prevent the GC from
-	// freeing the socket. This port is never used after reservation.
-	udpLocalIP := &net.UDPAddr{IP: local.IP()}
-	udpConn, err := net.ListenUDP("udp4", udpLocalIP)
-	if err != nil {
-		return nil, common.NewError("Unable to assign port", "err", err)
-	}
-
-	localSocket := udpConn.LocalAddr()
-	udpLocalAddr, err := net.ResolveUDPAddr(localSocket.Network(), localSocket.String())
-	if err != nil {
-		return nil, common.NewError("Unable to extract UDP address", "err", err)
-	}
-
 	// FIXME(scrye): add deadline so Register can time out if the dispatcher is not responding
-	regAddr := reliable.AppAddr{Addr: addr.HostFromIP(udpLocalAddr.IP), Port: uint16(udpLocalAddr.Port)}
+	regAddr := reliable.AppAddr{Addr: local, Port: 0}
 	conn, _, err := reliable.Register(c.dispatcherPath, c.IA, regAddr)
 	if err != nil {
 		return nil, common.NewError("Unable to register with dispatcher", "err", err)
@@ -75,7 +59,6 @@ func (c *SCIONNet) DialSCION(IA *addr.ISD_AS, local, remote addr.HostAddr, port 
 		Conn:       conn,
 		laddr:      laddr,
 		raddr:      raddr,
-		udpConn:    udpConn,
 		pm:         c.pm,
 		recvBuffer: make([]byte, RecvBufferSize)}
 	return sconn, nil
@@ -85,16 +68,6 @@ func (c *SCIONNet) DialSCION(IA *addr.ISD_AS, local, remote addr.HostAddr, port 
 // object capable of Read and WriteTo calls. ReadFrom and ReadFromSCION can be
 // used to get the SCION address which sent the packet.
 func (c *SCIONNet) ListenSCION(address addr.HostAddr, port uint16) (*SCIONConn, error) {
-	// Reserve a local port anyway so we do not get into a state where the
-	// dispatcher has a registration for one process on a SCION/UDP port,
-	// but a different process is listening on the actual UDP port.
-	udpAddr := &net.UDPAddr{IP: address.IP(), Port: int(port)}
-	udpConn, err := net.ListenUDP("udp4", udpAddr)
-	if err != nil {
-		return nil, common.NewError("Unable to reserve UDP port for SCION listen", "addr", address,
-			"port", port)
-	}
-
 	// FIXME(scrye): add deadline so Register can time out if the dispatcher is not responding
 	regAddr := reliable.AppAddr{Addr: address, Port: port}
 	conn, _, err := reliable.Register(c.dispatcherPath, c.IA, regAddr)
@@ -108,7 +81,6 @@ func (c *SCIONNet) ListenSCION(address addr.HostAddr, port uint16) (*SCIONConn, 
 	sconn := &SCIONConn{
 		Conn:       conn,
 		laddr:      laddr,
-		udpConn:    udpConn,
 		pm:         c.pm,
 		recvBuffer: make([]byte, RecvBufferSize)}
 	return sconn, nil
@@ -120,10 +92,6 @@ type SCIONConn struct {
 	raddr      *SCIONAppAddr
 	pm         *PathManager
 	recvBuffer []byte
-
-	// udpConn is used to reserve a local dynamic port during Dial and
-	// Listen; it is never used for reading or writing data
-	udpConn *net.UDPConn
 }
 
 func (c *SCIONConn) ReadFromSCION(b []byte) (int, *SCIONAppAddr, error) {
@@ -219,12 +187,6 @@ func (c *SCIONConn) Close() error {
 	err := c.Conn.Close()
 	if err != nil {
 		return common.NewError("Unable to close reliable socket", "err", err)
-	}
-	if c.udpConn != nil {
-		err := c.udpConn.Close()
-		if err != nil {
-			return common.NewError("Unable to close UDP socket", "err", err)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Also included some comments on why a UDP socket is allocated but never used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1176)
<!-- Reviewable:end -->
