### PR TITLE
Make assertions in the router Much less expensive.

### DIFF
--- a/go/border/main.go
+++ b/go/border/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"flag"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -151,9 +151,9 @@ func (rp *RtrPkt) parseHopExtns() *common.Error {
 // field accordingly.
 func (rp *RtrPkt) setDirTo() {
 	if assert.On {
-		assert.Must(rp.DirFrom != DirSelf, rp.ErrStr("DirFrom must not be DirSelf."))
-		assert.Must(rp.DirFrom != DirUnset, rp.ErrStr("DirFrom must not be DirUnset."))
-		assert.Must(rp.ifCurr != nil, rp.ErrStr("rp.ifCurr must not be nil."))
+		assert.Mustf(rp.DirFrom != DirSelf, rp.ErrStrf("DirFrom must not be DirSelf."))
+		assert.Mustf(rp.DirFrom != DirUnset, rp.ErrStrf("DirFrom must not be DirUnset."))
+		assert.Mustf(rp.ifCurr != nil, rp.ErrStrf("rp.ifCurr must not be nil."))
 	}
 	if *rp.dstIA != *rp.Ctx.Conf.IA {
 		// Packet is not destined to the local AS, so it can't be DirSelf.

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -32,7 +32,7 @@ import (
 // validatePath validates the path header.
 func (rp *RtrPkt) validatePath(dirFrom Dir) *common.Error {
 	if assert.On {
-		assert.Must(rp.ifCurr != nil, rp.ErrStr("rp.ifCurr must not be nil"))
+		assert.Mustf(rp.ifCurr != nil, rp.ErrStrf("rp.ifCurr must not be nil"))
 	}
 	// First check to make sure the current interface is known and not revoked.
 	if err := rp.validateLocalIF(rp.ifCurr); err != nil {
@@ -285,7 +285,7 @@ func (rp *RtrPkt) IncPath() (bool, *common.Error) {
 		return false, nil
 	}
 	if assert.On {
-		assert.Must(rp.upFlag != nil, rp.ErrStr("rp.upFlag must not be nil"))
+		assert.Mustf(rp.upFlag != nil, rp.ErrStrf("rp.upFlag must not be nil"))
 	}
 	var err *common.Error
 	var hopF *spath.HopField

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -232,6 +232,7 @@ func (rp *RtrPkt) processSCMPRevocation() {
 	pld := rp.pld.(*scmp.Payload)
 	args.RevInfo = pld.Info.(*scmp.InfoRevocation).RevToken
 	intf := rp.Ctx.Conf.Net.IFs[*rp.ifCurr]
+	rp.SrcIA() // Ensure that rp.srcIA has been set
 	if (rp.dstIA.I == rp.Ctx.Conf.Topo.ISD_AS.I && intf.Type == topology.CoreLink) ||
 		(rp.srcIA.I == rp.Ctx.Conf.Topo.ISD_AS.I && intf.Type == topology.ParentLink) {
 		// Case 1 & 2

--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -140,7 +140,7 @@ func (rp *RtrPkt) forward() (HookResult, *common.Error) {
 // neighbouring ISD-AS.
 func (rp *RtrPkt) forwardFromExternal() (HookResult, *common.Error) {
 	if assert.On {
-		assert.Must(rp.hopF != nil, rp.ErrStr("rp.hopF must not be nil"))
+		assert.Mustf(rp.hopF != nil, rp.ErrStrf("rp.hopF must not be nil"))
 	}
 	if rp.hopF.VerifyOnly { // Should have been caught by validatePath
 		return HookError, common.NewError(

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -345,3 +345,12 @@ func (rp *RtrPkt) String() string {
 func (rp *RtrPkt) ErrStr(desc string) string {
 	return fmt.Sprintf("Error: %v\n  RtrPkt: %v\n  Raw: %v", desc, rp, rp.Raw)
 }
+
+// ErrStrf is a wrapper for ErrStr, which returns a callback to allow lazy
+// evaluation of ErrStr. This is used for assert.Mustf in particular, so that
+// when the assertion passes, the expensive call to ErrStr is avoided.
+func (rp *RtrPkt) ErrStrf(desc string) func() string {
+	return func() string {
+		return rp.ErrStr(desc)
+	}
+}

--- a/go/lib/assert/assert.go
+++ b/go/lib/assert/assert.go
@@ -23,3 +23,9 @@ func Must(condition bool, s string, args ...interface{}) {
 		panic(fmt.Sprintf(s, args...))
 	}
 }
+
+func Mustf(condition bool, f func() string) {
+	if !condition {
+		panic(f())
+	}
+}


### PR DESCRIPTION
Currently `assert.Must` combined with `rp.ErrStr` causes very expensive
string formatting to be done, even with the assertion passes. This
overhead slows the router by a factor of ~10. This change allows ErrStr
to be lazily evaluated, and only in the case of an assertion failure.

Also:
- Enable pprof http support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1177)
<!-- Reviewable:end -->
