### PR TITLE
Set tx qlen on tun devices.

### DIFF
--- a/c/dispatcher/Makefile
+++ b/c/dispatcher/Makefile
@@ -27,6 +27,7 @@ dispatcher: dispatcher.c
 install: $(INSTALL)
 
 $(INSTALL): dispatcher
+	@rm -f $@
 	cp dispatcher $@
 
 uninstall:

--- a/c/dispatcher/dispatcher.c
+++ b/c/dispatcher/dispatcher.c
@@ -42,6 +42,9 @@
 FilterSocket *filter_socket = NULL;
 #endif
 
+#undef zlog_debug
+#define zlog_debug(...)
+
 #define DSTADDR_DATASIZE (CMSG_SPACE(sizeof(struct in6_pktinfo)))
 #define DSTADDR(x) (((struct in_pktinfo *)CMSG_DATA(x))->ipi_addr)
 #define DSTV6ADDR(x) (((struct in6_pktinfo *)CMSG_DATA(x))->ipi6_addr)
@@ -937,8 +940,8 @@ void deliver_udp_svc(uint8_t *buf, int len, HostAddr *from, HostAddr *dst) {
             return;
         }
     }
-    char dststr[MAX_HOST_ADDR_STR];
-    char svcstr[MAX_HOST_ADDR_STR];
+    //char dststr[MAX_HOST_ADDR_STR];
+    //char svcstr[MAX_HOST_ADDR_STR];
     zlog_debug(zc, "deliver UDP packet to (%d-%d):%s SVC:%s",
             ISD(svc_key.isd_as), AS(svc_key.isd_as),
             addr_to_str(dst->addr, dst->addr_type, dststr),

--- a/go/sig/xnet/xnet.go
+++ b/go/sig/xnet/xnet.go
@@ -4,6 +4,7 @@ package xnet
 import (
 	"io"
 	"net"
+	"os/exec"
 
 	log "github.com/inconshreveable/log15"
 	"github.com/songgao/water"
@@ -37,7 +38,10 @@ func ConnectTun(name string) (io.ReadWriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	cmd := exec.Command("ip", "link", "set", name, "qlen", "1000")
+	if err = cmd.Run(); err != nil {
+		return nil, err
+	}
 	return iface, nil
 }
 


### PR DESCRIPTION
This is a bit of a hack, but our netlink library doesn't support setting
this.

Also:
- Fix error when compiling the dispatcher while it's running.
- Disable debug logging in the dispatcher (only really affects sending
  logs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1182)
<!-- Reviewable:end -->
