### PR TITLE
Fix scmp memory leak in dispatcher

### DIFF
--- a/c/dispatcher/Makefile
+++ b/c/dispatcher/Makefile
@@ -27,7 +27,7 @@ dispatcher: dispatcher.c
 install: $(INSTALL)
 
 $(INSTALL): dispatcher
-	cp dispatcher $@
+	cp -f dispatcher $@
 
 uninstall:
 	rm -f $(INSTALL)


### PR DESCRIPTION
Everytime scmp_parse_payload is called, it mallocs a new SCMPPayload
struct, which was never being freed.

Also:
- Force copy dispatcher to bin/, fixing the error that happens if the
  dispatcher is already running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1184)
<!-- Reviewable:end -->
