### PR TITLE
Fix stale dependency handling for govendor.

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -36,6 +36,12 @@ deps_proto: deps proto
 deps: vendor/.deps.stamp ../proto/go.capnp
 
 vendor/.deps.stamp: vendor/vendor.json
+	@echo "$$(date -Iseconds) Remove unused deps"; \
+	    govendor list -no-status +unused | while read pkg; do \
+	    grep -q '"path": "'$$pkg'"' vendor/vendor.json && continue; \
+	    echo "$$pkg"; \
+	    govendor remove "$$pkg"; \
+	done
 	@echo "$$(date -Iseconds) Syncing deps"; govendor sync -v
 	@echo "$$(date -Iseconds) Installing deps"; go install ./vendor/...
 	@if [ -n "$$(govendor list -no-status +outside | grep -v '^context$$')" ]; then \

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -64,13 +64,6 @@
 			"revisionTime": "2016-05-14T03:44:11Z"
 		},
 		{
-			"checksumSHA1": "HmbftipkadrLlCfzzVQ+iFHbl6g=",
-			"license": "APL 2.0",
-			"path": "github.com/golang/glog",
-			"revision": "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
-			"revisionTime": "2016-01-25T20:49:56Z"
-		},
-		{
 			"checksumSHA1": "SVXOQdpDBh0ihdZ5aIflgdA+Rpw=",
 			"license": "3-BSD",
 			"path": "github.com/golang/protobuf/proto",


### PR DESCRIPTION
If you're on a branch that requires go packages installed that aren't
required by master, when you switch back to master those packages aren't
removed, and can then cause build failures. This change will check for
this issue and work around it, but it's slightly brute-force: any
unneeded packages are also removed from govendor's cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1185)
<!-- Reviewable:end -->
