### PR TITLE
Added checksums in native Go

### DIFF
--- a/c/lib/scion/checksum.c
+++ b/c/lib/scion/checksum.c
@@ -14,7 +14,6 @@ void _add_sum(uint32_t *sum, uint16_t val);
 uint16_t checksum(chk_input *in) {
     int i;
     uint32_t sum = 0;
-    uint8_t *carry = NULL;
 
     // Iterate over the chunks
     for (i=0; i < in->total; i++){
@@ -24,23 +23,16 @@ uint16_t checksum(chk_input *in) {
         if (len == 0) {
             continue;
         }
-        // Handle a carry byte from the previous chunk.
-        if (carry) {
-            _add_sum(&sum, *carry << 8 | ptr[0]);
-            j = 1;
-        }
         for (; j < len - 1; j+=2) {
             _add_sum(&sum, ntohs(*((uint16_t *)(ptr + j))));
         }
-        // If there's an odd number of bytes, save last one.
-        carry = j == len ? NULL : ptr + j;
-    }
-    if (carry) {
-        // Total number of bytes is odd, so pad with trailing 0.
-        _add_sum(&sum, *carry << 8);
+        // If there's an odd number of bytes, pad chunk with a 0
+        if (j != len) {
+            _add_sum(&sum, ((uint16_t)ptr[j]) << 8);
+        }
     }
     // Return 16bit ones-complement.
-    return ~sum & 0xFFFF;
+    return htons(~sum & 0xFFFF);
 }
 
 /*

--- a/c/lib/scion/scmp.c
+++ b/c/lib/scion/scmp.c
@@ -11,17 +11,18 @@ uint16_t scmp_checksum(uint8_t *buf)
 {
     chk_input *input = mk_chk_input(6);
     SCMPL4Header *scmp_l4;
-    uint8_t l4_type;
+    uint16_t l4_type;
     uint16_t payload_len, ret, blank_sum = 0;
 
     // Address header (without padding)
     chk_add_chunk(input, buf + DST_IA_OFFSET, get_addrs_len(buf));
 
     uint8_t *ptr = buf;
-    l4_type = get_l4_proto(&ptr);
+    // Load LSB of l4_type with protocol number
+    l4_type = htons((uint16_t)get_l4_proto(&ptr));
     scmp_l4 = (SCMPL4Header *)ptr;
     // L4 protocol type
-    chk_add_chunk(input, &l4_type, 1);
+    chk_add_chunk(input, (uint8_t*)&l4_type, 2);
     // SCMP class, type & length
     ptr = chk_add_chunk(input, ptr, 6);
     // Use blank checksum field

--- a/c/lib/scion/udp.c
+++ b/c/lib/scion/udp.c
@@ -34,17 +34,18 @@ uint16_t scion_udp_checksum(uint8_t *buf)
 {
     chk_input *input = mk_chk_input(5);
     SCIONUDPHeader *udp_hdr;
-    uint8_t l4_type;
+    uint16_t l4_type;
     uint16_t payload_len, ret, blank_sum = 0;
 
     // Address header (without padding)
     chk_add_chunk(input, buf + DST_IA_OFFSET, get_addrs_len(buf));
 
     uint8_t *ptr = buf;
-    l4_type = get_l4_proto(&ptr);
+    // Load LSB of l4_type with protocol number, then put in network order
+    l4_type = htons((uint16_t)get_l4_proto(&ptr));
     udp_hdr = (SCIONUDPHeader *)ptr;
     // L4 protocol type
-    chk_add_chunk(input, &l4_type, 1);
+    chk_add_chunk(input, (uint8_t*)&l4_type, 2);
     // udp src+dst port and len fields.
     ptr = chk_add_chunk(input, ptr, 6);
     // Use blank checksum field

--- a/go/lib/l4/common.go
+++ b/go/lib/l4/common.go
@@ -21,7 +21,7 @@ import (
 	//log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/libscion"
+	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
 const ErrorInvalidChksum = "Invalid L4 checksum"
@@ -45,7 +45,7 @@ func CalcCSum(h L4Header, addr, pld common.RawBytes) (common.RawBytes, *common.E
 	if err != nil {
 		return nil, err
 	}
-	sum := libscion.Checksum(addr, []uint8{uint8(h.L4Type())}, rawh, pld)
+	sum := util.Checksum(addr, []uint8{0, uint8(h.L4Type())}, rawh, pld)
 	out := make(common.RawBytes, 2)
 	common.Order.PutUint16(out, sum)
 	return out, nil

--- a/go/lib/util/checksum.go
+++ b/go/lib/util/checksum.go
@@ -1,0 +1,47 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+// Calculate RFC1071 checksum of supplied data chunks. If a chunk has
+// an odd length, it is padded with a 0 during checksum computation.
+func Checksum(srcs ...common.RawBytes) uint16 {
+	var sum uint32
+	for _, src := range srcs {
+		length := len(src)
+		i := 0
+
+		if length == 0 {
+			continue
+		}
+		for ; i < length-1; i += 2 {
+			sum += toUint32(src[i], src[i+1])
+		}
+		if i != length {
+			sum += toUint32(src[i], 0)
+		}
+	}
+	for sum > 0xffff {
+		sum = (sum >> 16) + (sum & 0xffff)
+	}
+	return ^uint16(sum)
+}
+
+func toUint32(x uint8, y uint8) uint32 {
+	return uint32(x)<<8 + uint32(y)
+}

--- a/go/lib/util/checksum_test.go
+++ b/go/lib/util/checksum_test.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+func TestChecksum(t *testing.T) {
+	tests := []struct {
+		Input  []common.RawBytes
+		Output [2]byte
+	}{
+		{[]common.RawBytes{{0x00, 0x01}}, [2]byte{0xff, 0xfe}},
+		{[]common.RawBytes{{0x34, 0x88, 0x19, 0x55}}, [2]byte{0xb2, 0x22}},
+		{[]common.RawBytes{{0x17, 0x00}}, [2]byte{0xe8, 0xff}},
+		{[]common.RawBytes{{0x11, 0x11}}, [2]byte{0xee, 0xee}},
+		{[]common.RawBytes{{0xef}}, [2]byte{0x10, 0xff}},
+		{[]common.RawBytes{{0x11}, {0x80, 0x15, 0x13}},
+			[2]byte{0x5b, 0xea}},
+		{[]common.RawBytes{{0xa1, 0xa2, 0xa3, 0xa4},
+			{0xb1, 0xb2, 0xb3},
+			{0x10, 0x20}}, [2]byte{0x45, 0xe5}},
+	}
+
+	Convey("Test checksum", t, func() {
+		for _, test := range tests {
+			checksum := make([]byte, 2)
+			binary.BigEndian.PutUint16(checksum, Checksum(test.Input...))
+			Convey(fmt.Sprintf("Input %v", test.Input), func() {
+				So(checksum[0], ShouldEqual, test.Output[0])
+				So(checksum[1], ShouldEqual, test.Output[1])
+			})
+		}
+	})
+}

--- a/python/lib/packet/scion_udp.py
+++ b/python/lib/packet/scion_udp.py
@@ -114,12 +114,11 @@ class SCIONUDPHeader(L4HeaderBase):
         pseudo_header = b"".join([
             self._dst.isd_as.pack(), self._src.isd_as.pack(),
             self._dst.host.pack(), self._src.host.pack(),
-            struct.pack("!B", L4Proto.UDP),
+            b"\x00", struct.pack("!B", L4Proto.UDP),
             self.pack(payload, checksum=bytes(2)), payload,
         ])
         chk_int = scapy.utils.checksum(pseudo_header)
-        # scapy's checksum always outputs in network-byte-order.
-        return struct.pack("H", chk_int)
+        return struct.pack("!H", chk_int)
 
     def reverse(self):
         self._src, self._dst = self._dst, self._src

--- a/python/lib/packet/scmp/hdr.py
+++ b/python/lib/packet/scmp/hdr.py
@@ -126,12 +126,11 @@ class SCMPHeader(L4HeaderBase):
         pseudo_header = b"".join([
             self._dst.isd_as.pack(), self._src.isd_as.pack(),
             self._dst.host.pack(), self._src.host.pack(),
-            struct.pack("!B", L4Proto.SCMP),
+            b"\x00", struct.pack("!B", L4Proto.SCMP),
             self.pack(payload, checksum=bytes(2)), payload,
         ])
         chk_int = scapy.utils.checksum(pseudo_header)
-        # scapy's checksum always outputs in network-byte-order.
-        return struct.pack("H", chk_int)
+        return struct.pack("!H", chk_int)
 
     def __len__(self):  # pragma: no cover
         return self.LEN

--- a/python/test/lib/packet/scion_udp_test.py
+++ b/python/test/lib/packet/scion_udp_test.py
@@ -95,12 +95,12 @@ class TestSCIONUDPHeaderCalcChecksum(object):
         inst.pack = create_mock_full(return_value=b"packed with null checksum")
         payload = b"payload"
         expected_call = b"".join([
-            b"dsIA", b"srIA", b"dstH", b"srcH", bytes([L4Proto.UDP]),
+            b"dsIA", b"srIA", b"dstH", b"srcH", b"\x00", bytes([L4Proto.UDP]),
             b"packed with null checksum", payload,
         ])
         scapy_checksum.return_value = 0x3412
         # Call
-        ntools.eq_(inst._calc_checksum(payload), bytes.fromhex("1234"))
+        ntools.eq_(inst._calc_checksum(payload), bytes.fromhex("3412"))
         # Tests
         scapy_checksum.assert_called_once_with(expected_call)
 

--- a/python/test/lib/packet/scmp/hdr_test.py
+++ b/python/test/lib/packet/scmp/hdr_test.py
@@ -94,12 +94,12 @@ class TestSCMPHeaderCalcChecksum(object):
         inst.pack.return_value = b"packed with null checksum"
         payload = b"payload"
         expected_call = b"".join([
-            b"dsIA", b"srIA", b"dHst", b"sHst", bytes([L4Proto.SCMP]),
+            b"dsIA", b"srIA", b"dHst", b"sHst", b"\x00", bytes([L4Proto.SCMP]),
             b"packed with null checksum", payload,
         ])
         scapy_checksum.return_value = 0x3412
         # Call
-        ntools.eq_(inst._calc_checksum(payload), bytes.fromhex("1234"))
+        ntools.eq_(inst._calc_checksum(payload), bytes.fromhex("3412"))
         # Tests
         scapy_checksum.assert_called_once_with(expected_call)
 


### PR DESCRIPTION
IMPORTANT: This change is incompatible with previous versions of SCION services.

Also:
  * Checksum function is now commutative
  * Byte order is correct on wire
  * Odd-length chunks are individually padded with a 0 byte at the end
  * The SCION/UDP pseudoheader upper protocol type field is padded with a 0 to the left (same as IP)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1190)
<!-- Reviewable:end -->
