### PR TITLE
Fixed faulty checksum in SIG egress

### DIFF
--- a/go/sig/lib/scion/scion.go
+++ b/go/sig/lib/scion/scion.go
@@ -10,11 +10,11 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/l4"
-	"github.com/netsec-ethz/scion/go/lib/libscion"
 	"github.com/netsec-ethz/scion/go/lib/sciond"
 	"github.com/netsec-ethz/scion/go/lib/sock/reliable"
 	"github.com/netsec-ethz/scion/go/lib/spath"
 	"github.com/netsec-ethz/scion/go/lib/spkt"
+	"github.com/netsec-ethz/scion/go/lib/util"
 )
 
 const (
@@ -247,8 +247,8 @@ func (c *SCIONConn) createUDPPacket(b []byte, raddr *SCIONAppAddr, path sciond.P
 	// Compute the checksum for SCION L4
 	// NOTE(scrye): is the checksum supposed to be this way? it breaks stack encap/decap
 	// principles (encapsulated UDP protocol looks at bytes from upper layer SCION protocol)
-	binary.BigEndian.PutUint16(udpHeader[6:8], libscion.Checksum(addrHeader[0:16],
-		commonHeader[7:8], udpHeader, b))
+	binary.BigEndian.PutUint16(udpHeader[6:8], util.Checksum(addrHeader,
+		[]byte{0, commonHeader[7]}, udpHeader[:6], b))
 
 	packet := make([]byte, 0)
 	packet = append(packet, commonHeader...)

--- a/go/sig/lib/scion/scion.go
+++ b/go/sig/lib/scion/scion.go
@@ -245,8 +245,6 @@ func (c *SCIONConn) createUDPPacket(b []byte, raddr *SCIONAppAddr, path sciond.P
 	binary.BigEndian.PutUint16(udpHeader[4:6], uint16(len(b))+l4.UDPLen)
 
 	// Compute the checksum for SCION L4
-	// NOTE(scrye): is the checksum supposed to be this way? it breaks stack encap/decap
-	// principles (encapsulated UDP protocol looks at bytes from upper layer SCION protocol)
 	binary.BigEndian.PutUint16(udpHeader[6:8], util.Checksum(addrHeader,
 		[]byte{0, commonHeader[7]}, udpHeader[:6], b))
 


### PR DESCRIPTION
The egress checksum was incompatible with the new version on master (incorrect padding, wrong byte order).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1193)
<!-- Reviewable:end -->
