### PR TITLE
Added ring buffer for slice elements

### DIFF
--- a/go/lib/sring/rb.go
+++ b/go/lib/sring/rb.go
@@ -1,0 +1,93 @@
+package sring
+
+import "sync"
+
+// rb is a classical ring buffer for slices which throws errors
+// whenever a write is larger than the current available space
+type rb struct {
+	mutex      sync.Mutex
+	readableC  *sync.Cond
+	buffers    [][]byte
+	writeIndex int
+	readIndex  int
+	writable   int
+	readable   int
+}
+
+func newRB(count int, size int) *rb {
+	r := &rb{}
+	r.readableC = sync.NewCond(&r.mutex)
+	r.buffers = make([][]byte, count)
+	// Only allocate memory if caller requested it
+	if size != 0 {
+		for i := 0; i < count; i++ {
+			r.buffers[i] = make([]byte, size)
+		}
+		// A ring buffer that allocates data starts off as full
+		r.readable = count
+	} else {
+		// A ring buffer that does not allocate starts off as empty
+		r.writable = count
+	}
+	return r
+}
+
+func (r *rb) Write(buffers [][]byte) (int, int, bool) {
+	r.mutex.Lock()
+	// Attempting to free up more resources than we acquired points to a
+	// logic error in the calling code
+	if len(buffers) > r.writable {
+		writable := r.writable
+		r.mutex.Unlock()
+		return 0, writable, false
+	}
+	n := min(r.writable, len(buffers))
+	r.write(buffers[:n])
+	r.writable -= n
+	r.readable += n
+	r.readableC.Signal()
+	r.mutex.Unlock()
+	return n, 0, true
+}
+
+func (r *rb) Read(buffers [][]byte) int {
+	r.mutex.Lock()
+	for r.readable == 0 {
+		r.readableC.Wait()
+	}
+	n := min(r.readable, len(buffers))
+	r.read(buffers[:n])
+	r.readable -= n
+	r.writable += n
+	r.mutex.Unlock()
+	return n
+}
+
+func (r *rb) write(buffers [][]byte) {
+	n := copy(r.buffers[r.writeIndex:], buffers)
+	r.writeIndex += n
+	// Wraparound if we need to write more slice references
+	if n < len(buffers) {
+		n = copy(r.buffers, buffers[n:])
+		// Reset write index
+		r.writeIndex = n
+	}
+}
+
+func (r *rb) read(buffers [][]byte) {
+	n := copy(buffers, r.buffers[r.readIndex:])
+	r.readIndex += n
+	// Wraparound if we need to read more slice references
+	if n < len(buffers) {
+		n = copy(buffers[n:], r.buffers)
+		// Reset read index
+		r.readIndex = n
+	}
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/go/lib/sring/rb.go
+++ b/go/lib/sring/rb.go
@@ -32,6 +32,11 @@ func newRB(count int, size int) *rb {
 	return r
 }
 
+// Write copies the slices in buffers to the internal ring buffer. Attempting
+// to write more than the available space causes Write to fail.  Return
+// arguments contain the number of written slices (all on success, 0 on
+// failure), the number of available space (0 on success, actual space on
+// failure) and whether the operation succeeded.
 func (r *rb) Write(buffers [][]byte) (int, int, bool) {
 	r.mutex.Lock()
 	// Attempting to free up more resources than we acquired points to a

--- a/go/lib/sring/sring.go
+++ b/go/lib/sring/sring.go
@@ -1,5 +1,6 @@
 // Package sring (Slice Ring) implements a simple RingBuffer where the elements
-// are slice references.
+// are slice references. SRing is organized internally as two ring buffers,
+// one containing slices with free space and one containing slices with data.
 //
 // New allocates buffers internally.
 //
@@ -11,6 +12,8 @@
 // processing the buffers are marked as available again by calling Release. It
 // is also valid for a reader to give up ownership by calling Write, although
 // this is probably never useful.
+//
+// Slice capacity is never reset internally, this has to be done by the caller.
 //
 // If Write or Release ever attempts to relinquish more references than would
 // fit into the ring buffer, an error is returned and no operation is
@@ -32,18 +35,18 @@ func New(count int, size int) *SRing {
 	return r
 }
 
-// Reserve fills buffers with references to pre-allocated slices. The caller
-// is assumed to have exclusive access over the returned slices. If no
-// reference is available to reserve, the function blocks.
+// Reserve copies slice references from the free ring buffer to buffers.
+// The caller is assumed to have exclusive access over the returned slices. If
+// no slice is available to reserve, the function blocks.
 func (r *SRing) Reserve(buffers [][]byte) int {
 	return r.freeRefs.Read(buffers)
 }
 
-// Write copies the buffer references in buffers to the internal ring buffer.
+// Write copies the slice references in buffers to the data ring buffer.
 // Attempting to write back more references than can fit into the ring buffer
-// returns an error, and no operation is performed. On no error, all buffer
-// references are guaranteed to be copied. After writing back a buffer
-// reference, callers should no longer read or write to it. Write never blocks.
+// returns an error, and no operation is performed. On no error, all references
+// are guaranteed to be copied. After writing back a reference, callers should
+// no longer read or write to it. Write never blocks.
 func (r *SRing) Write(buffers [][]byte) (int, error) {
 	n, max, ok := r.dataRefs.Write(buffers)
 	if !ok {
@@ -53,14 +56,15 @@ func (r *SRing) Write(buffers [][]byte) (int, error) {
 	return n, nil
 }
 
-// Read copies to buffers up to len(buffers) references from the internal ring
-// buffer.  The number of copied references is returned. If no element is
-// available in the ring buffer, the function blocks.
+// Read copies slice references from the data ring buffer to buffers.  The
+// number of copied references is returned; this can be anywhere from 1 to
+// len(buffers), depending on available data. If no element is available in the
+// ring buffer, the function blocks.
 func (r *SRing) Read(buffers [][]byte) int {
 	return r.dataRefs.Read(buffers)
 }
 
-// Release returns the buffer references in buffers back to the ring buffer.
+// Release copies the slice references in buffers to the free ring buffer.
 // Attempting to Release more buffers than can fit into the ring buffer returns
 // an error, and no operation is performed. On no error, all buffer references
 // are guaranteed to be released. After releasing a buffer reference, callers

--- a/go/lib/sring/sring.go
+++ b/go/lib/sring/sring.go
@@ -17,7 +17,7 @@
 // performed. This is generally caused by a logic error in the caller.
 package pring
 
-import "fmt"
+import "github.com/netsec-ethz/scion/go/lib/common"
 
 type SRing struct {
 	freeRefs, dataRefs *rb
@@ -47,7 +47,7 @@ func (r *SRing) Reserve(buffers [][]byte) int {
 func (r *SRing) Write(buffers [][]byte) (int, error) {
 	n, max, ok := r.dataRefs.Write(buffers)
 	if !ok {
-		return 0, fmt.Errorf("Attempted to write more buffers than reserved",
+		return 0, common.NewError("Attempted to write more buffers than reserved",
 			"expect", max, "actual", len(buffers))
 	}
 	return n, nil
@@ -68,7 +68,7 @@ func (r *SRing) Read(buffers [][]byte) int {
 func (r *SRing) Release(buffers [][]byte) (int, error) {
 	n, max, ok := r.freeRefs.Write(buffers)
 	if !ok {
-		return 0, fmt.Errorf("Attempted to release more buffers than acquired",
+		return 0, common.NewError("Attempted to release more buffers than acquired",
 			"expect", max, "actual", len(buffers))
 	}
 	return n, nil

--- a/go/lib/sring/sring.go
+++ b/go/lib/sring/sring.go
@@ -15,7 +15,7 @@
 // If Write or Release ever attempts to relinquish more references than would
 // fit into the ring buffer, an error is returned and no operation is
 // performed. This is generally caused by a logic error in the caller.
-package pring
+package sring
 
 import "github.com/netsec-ethz/scion/go/lib/common"
 

--- a/go/lib/sring/sring.go
+++ b/go/lib/sring/sring.go
@@ -1,0 +1,170 @@
+// Package sring (Slice Ring) implements a simple RingBuffer where the elements
+// are slice references.
+//
+// New allocates buffers internally.
+//
+// Writers gain exclusive access to the buffers by calling Reserve, and send
+// out the buffers after processing by calling Write.
+//
+// Readers gain exclusive access to the buffers by calling Read.  After
+// processing the buffers are marked as available again by calling Release.
+package pring
+
+import (
+	"fmt"
+	"sync"
+)
+
+type SRing struct {
+	buffers      [][]byte
+	reserveIndex int
+	writeIndex   int
+	readIndex    int
+	releaseIndex int
+
+	mutex       sync.Mutex
+	readableC   *sync.Cond
+	reservableC *sync.Cond
+
+	reservable int
+	writable   int
+	readable   int
+	releasable int
+}
+
+// New creates a new SRing with count pre-allocated internal buffers of size
+// bytes.
+func New(count int, size int) *SRing {
+	r := &SRing{}
+	r.readableC = sync.NewCond(&r.mutex)
+	r.reservableC = sync.NewCond(&r.mutex)
+	r.buffers = make([][]byte, count)
+	for i := 0; i < count; i++ {
+		r.buffers[i] = make([]byte, size)
+	}
+	r.reservable = count
+	return r
+}
+
+// Reserve fills buffers with references to pre-allocated slices. The caller
+// is assumed to have exclusive access over the returned slices. If no
+// reference is available to reserve, the function blocks.
+func (r *SRing) Reserve(buffers [][]byte) (int, error) {
+	r.mutex.Lock()
+	for r.reservable == 0 {
+		r.reservableC.Wait()
+	}
+	// Only reserve what we have available
+	n := min(r.reservable, len(buffers))
+	r.reserve(buffers[:n])
+	r.reservable -= n
+	r.writable += n
+	r.mutex.Unlock()
+	return n, nil
+}
+
+// Write copies the buffer references in buffers to the internal ring buffer.
+// Writing back more references than are currently reserved returns an error,
+// and no operation is performed. On no error, all buffer references are
+// guaranteed to be copied. After writing back a buffer reference, callers
+// should no longer read or write to it. Write never blocks.
+func (r *SRing) Write(buffers [][]byte) (int, error) {
+	r.mutex.Lock()
+	if len(buffers) > r.writable {
+		return 0, fmt.Errorf("Corrupted SRing, insufficient space"+
+			"forever (max %d, have %d)", len(r.buffers), buffers)
+	}
+	r.write(buffers)
+	r.writable -= len(buffers)
+	r.readable += len(buffers)
+	r.readableC.Signal()
+	r.mutex.Unlock()
+	return len(buffers), nil
+}
+
+// Read copies to buffers up to len(buffers) references from the internal ring
+// buffer.  The number of copied references is returned. If no element is
+// available in the ring buffer, the function blocks.
+func (r *SRing) Read(buffers [][]byte) (int, error) {
+	r.mutex.Lock()
+	for r.readable == 0 {
+		r.readableC.Wait()
+	}
+	n := min(r.readable, len(buffers))
+	// Only read what we have available
+	r.read(buffers[:n])
+	r.readable -= n
+	r.releasable += n
+	r.mutex.Unlock()
+	return n, nil
+}
+
+// Release returns the buffer references in buffers back to the ring buffer.
+// Attempting to Release more buffers than were Read returns an error, and no
+// operation is performed. On no error, all buffer references are guaranteed to
+// be released. After releasing a buffer reference, callers should no longer
+// read or write to it. Release never blocks.
+func (r *SRing) Release(buffers [][]byte) (int, error) {
+	r.mutex.Lock()
+	if len(buffers) > r.releasable {
+		return 0, fmt.Errorf("Corrupted SRing, releasing more buffers"+
+			"than read (read %d, releasing %d)", r.releasable,
+			len(buffers))
+	}
+	r.release(buffers)
+	r.releasable -= len(buffers)
+	r.reservable += len(buffers)
+	r.reservableC.Signal()
+	r.mutex.Unlock()
+	return len(buffers), nil
+}
+
+func (r *SRing) reserve(buffers [][]byte) {
+	n := copy(buffers, r.buffers[r.reserveIndex:])
+	r.reserveIndex += n
+	// Wraparound if we need to return more slice references
+	if n < len(buffers) {
+		// Reset reserve index
+		n = copy(buffers[n:], r.buffers)
+		r.reserveIndex = n
+	}
+}
+
+func (r *SRing) write(buffers [][]byte) {
+	n := copy(r.buffers[r.writeIndex:], buffers)
+	r.writeIndex += n
+	// Wraparound if we need to write more slice references
+	if n < len(buffers) {
+		n = copy(r.buffers, buffers[n:])
+		// Reset write index
+		r.writeIndex = n
+	}
+}
+
+func (r *SRing) read(buffers [][]byte) {
+	n := copy(buffers, r.buffers[r.readIndex:])
+	r.readIndex += n
+	// Wraparound if we need to read more slice references
+	if n < len(buffers) {
+		n = copy(buffers[n:], r.buffers)
+		// Reset read index
+		r.readIndex = n
+	}
+}
+
+func (r *SRing) release(buffers [][]byte) {
+	n := copy(r.buffers[r.releaseIndex:], buffers)
+	r.reserveIndex += n
+	// Wraparound if we need to release more slice references
+	if n < len(buffers) {
+		n = copy(r.buffers, buffers[n:])
+		r.releaseIndex = n
+	}
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/go/lib/sring/sring.go
+++ b/go/lib/sring/sring.go
@@ -4,167 +4,72 @@
 // New allocates buffers internally.
 //
 // Writers gain exclusive access to the buffers by calling Reserve, and send
-// out the buffers after processing by calling Write.
+// out the buffers after processing by calling Write. Writers can also choose
+// to free the buffers directly by calling Release.
 //
-// Readers gain exclusive access to the buffers by calling Read.  After
-// processing the buffers are marked as available again by calling Release.
+// Readers gain exclusive access to the buffers by calling Read. After
+// processing the buffers are marked as available again by calling Release. It
+// is also valid for a reader to give up ownership by calling Write, although
+// this is probably never useful.
+//
+// If Write or Release ever attempts to relinquish more references than would
+// fit into the ring buffer, an error is returned and no operation is
+// performed. This is generally caused by a logic error in the caller.
 package pring
 
-import (
-	"fmt"
-	"sync"
-)
+import "fmt"
 
 type SRing struct {
-	buffers      [][]byte
-	reserveIndex int
-	writeIndex   int
-	readIndex    int
-	releaseIndex int
-
-	mutex       sync.Mutex
-	readableC   *sync.Cond
-	reservableC *sync.Cond
-
-	reservable int
-	writable   int
-	readable   int
-	releasable int
+	freeRefs, dataRefs *rb
 }
 
 // New creates a new SRing with count pre-allocated internal buffers of size
 // bytes.
 func New(count int, size int) *SRing {
 	r := &SRing{}
-	r.readableC = sync.NewCond(&r.mutex)
-	r.reservableC = sync.NewCond(&r.mutex)
-	r.buffers = make([][]byte, count)
-	for i := 0; i < count; i++ {
-		r.buffers[i] = make([]byte, size)
-	}
-	r.reservable = count
+	r.freeRefs = newRB(count, size)
+	r.dataRefs = newRB(count, 0)
 	return r
 }
 
 // Reserve fills buffers with references to pre-allocated slices. The caller
 // is assumed to have exclusive access over the returned slices. If no
 // reference is available to reserve, the function blocks.
-func (r *SRing) Reserve(buffers [][]byte) (int, error) {
-	r.mutex.Lock()
-	for r.reservable == 0 {
-		r.reservableC.Wait()
-	}
-	// Only reserve what we have available
-	n := min(r.reservable, len(buffers))
-	r.reserve(buffers[:n])
-	r.reservable -= n
-	r.writable += n
-	r.mutex.Unlock()
-	return n, nil
+func (r *SRing) Reserve(buffers [][]byte) int {
+	return r.freeRefs.Read(buffers)
 }
 
 // Write copies the buffer references in buffers to the internal ring buffer.
-// Writing back more references than are currently reserved returns an error,
-// and no operation is performed. On no error, all buffer references are
-// guaranteed to be copied. After writing back a buffer reference, callers
-// should no longer read or write to it. Write never blocks.
+// Attempting to write back more references than can fit into the ring buffer
+// returns an error, and no operation is performed. On no error, all buffer
+// references are guaranteed to be copied. After writing back a buffer
+// reference, callers should no longer read or write to it. Write never blocks.
 func (r *SRing) Write(buffers [][]byte) (int, error) {
-	r.mutex.Lock()
-	if len(buffers) > r.writable {
-		return 0, fmt.Errorf("Corrupted SRing, insufficient space"+
-			"forever (max %d, have %d)", len(r.buffers), buffers)
+	n, max, ok := r.dataRefs.Write(buffers)
+	if !ok {
+		return 0, fmt.Errorf("Attempted to write more buffers than reserved",
+			"expect", max, "actual", len(buffers))
 	}
-	r.write(buffers)
-	r.writable -= len(buffers)
-	r.readable += len(buffers)
-	r.readableC.Signal()
-	r.mutex.Unlock()
-	return len(buffers), nil
+	return n, nil
 }
 
 // Read copies to buffers up to len(buffers) references from the internal ring
 // buffer.  The number of copied references is returned. If no element is
 // available in the ring buffer, the function blocks.
-func (r *SRing) Read(buffers [][]byte) (int, error) {
-	r.mutex.Lock()
-	for r.readable == 0 {
-		r.readableC.Wait()
-	}
-	n := min(r.readable, len(buffers))
-	// Only read what we have available
-	r.read(buffers[:n])
-	r.readable -= n
-	r.releasable += n
-	r.mutex.Unlock()
-	return n, nil
+func (r *SRing) Read(buffers [][]byte) int {
+	return r.dataRefs.Read(buffers)
 }
 
 // Release returns the buffer references in buffers back to the ring buffer.
-// Attempting to Release more buffers than were Read returns an error, and no
-// operation is performed. On no error, all buffer references are guaranteed to
-// be released. After releasing a buffer reference, callers should no longer
-// read or write to it. Release never blocks.
+// Attempting to Release more buffers than can fit into the ring buffer returns
+// an error, and no operation is performed. On no error, all buffer references
+// are guaranteed to be released. After releasing a buffer reference, callers
+// should no longer read or write to it. Release never blocks.
 func (r *SRing) Release(buffers [][]byte) (int, error) {
-	r.mutex.Lock()
-	if len(buffers) > r.releasable {
-		return 0, fmt.Errorf("Corrupted SRing, releasing more buffers"+
-			"than read (read %d, releasing %d)", r.releasable,
-			len(buffers))
+	n, max, ok := r.freeRefs.Write(buffers)
+	if !ok {
+		return 0, fmt.Errorf("Attempted to release more buffers than acquired",
+			"expect", max, "actual", len(buffers))
 	}
-	r.release(buffers)
-	r.releasable -= len(buffers)
-	r.reservable += len(buffers)
-	r.reservableC.Signal()
-	r.mutex.Unlock()
-	return len(buffers), nil
-}
-
-func (r *SRing) reserve(buffers [][]byte) {
-	n := copy(buffers, r.buffers[r.reserveIndex:])
-	r.reserveIndex += n
-	// Wraparound if we need to return more slice references
-	if n < len(buffers) {
-		// Reset reserve index
-		n = copy(buffers[n:], r.buffers)
-		r.reserveIndex = n
-	}
-}
-
-func (r *SRing) write(buffers [][]byte) {
-	n := copy(r.buffers[r.writeIndex:], buffers)
-	r.writeIndex += n
-	// Wraparound if we need to write more slice references
-	if n < len(buffers) {
-		n = copy(r.buffers, buffers[n:])
-		// Reset write index
-		r.writeIndex = n
-	}
-}
-
-func (r *SRing) read(buffers [][]byte) {
-	n := copy(buffers, r.buffers[r.readIndex:])
-	r.readIndex += n
-	// Wraparound if we need to read more slice references
-	if n < len(buffers) {
-		n = copy(buffers[n:], r.buffers)
-		// Reset read index
-		r.readIndex = n
-	}
-}
-
-func (r *SRing) release(buffers [][]byte) {
-	n := copy(r.buffers[r.releaseIndex:], buffers)
-	r.reserveIndex += n
-	// Wraparound if we need to release more slice references
-	if n < len(buffers) {
-		n = copy(r.buffers, buffers[n:])
-		r.releaseIndex = n
-	}
-}
-
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
+	return n, nil
 }

--- a/go/lib/sring/sring_test.go
+++ b/go/lib/sring/sring_test.go
@@ -1,0 +1,124 @@
+package pring
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type Op uint8
+
+const (
+	RES Op = iota
+	WR
+	RD
+	REL
+)
+
+func (o Op) String() string {
+	switch o {
+	case RES:
+		return "RES"
+	case WR:
+		return "WR"
+	case RD:
+		return "RD"
+	case REL:
+		return "REL"
+	}
+	return "???"
+}
+
+type Command struct {
+	op  Op
+	arg int
+}
+
+func (c Command) String() string {
+	return fmt.Sprintf("%v:%d", c.op, c.arg)
+}
+
+func runOps(script []Command) *SRing {
+	var err error
+	r := New(8, 128)
+	buffers := make([][]byte, 16)
+	for _, cmd := range script {
+		switch cmd.op {
+		case RES:
+			_, err = r.Reserve(buffers[:cmd.arg])
+		case WR:
+			_, err = r.Write(buffers[:cmd.arg])
+		case RD:
+			_, err = r.Read(buffers[:cmd.arg])
+		case REL:
+			_, err = r.Release(buffers[:cmd.arg])
+		}
+	}
+	if err != nil {
+		return nil
+	}
+	return r
+}
+
+func TestOperations(t *testing.T) {
+	tests := []struct {
+		script []Command
+		expect [4]int
+		fail   bool
+	}{
+		{[]Command{},
+			[4]int{8, 0, 0, 0}, false},
+		{[]Command{{RES, 6}},
+			[4]int{2, 6, 0, 0}, false},
+		{[]Command{{RES, 6}, {RES, 2}},
+			[4]int{0, 8, 0, 0}, false},
+		{[]Command{{RES, 6}, {WR, 2}, {RES, 2}, {WR, 4}},
+			[4]int{0, 2, 6, 0}, false},
+		{[]Command{{RES, 4}, {WR, 4}, {RD, 4}, {REL, 4}},
+			[4]int{8, 0, 0, 0}, false},
+		{[]Command{{RES, 4}, {WR, 1}, {WR, 1}, {RD, 2}, {WR, 2}, {REL, 2}, {RES, 6}},
+			[4]int{0, 6, 2, 0}, false},
+		{[]Command{{RES, 10}},
+			[4]int{0, 8, 0, 0}, false},
+		{[]Command{{WR, 2}},
+			[4]int{0, 0, 0, 0}, true},
+		{[]Command{{REL, 2}},
+			[4]int{0, 0, 0, 0}, true},
+	}
+
+	Convey("Test ops", t, func() {
+		for _, test := range tests {
+			Convey(fmt.Sprintf("%v", test.script), func() {
+				r := runOps(test.script)
+				if test.fail == false {
+					SoMsg("Reservable", r.reservable, ShouldEqual, test.expect[0])
+					SoMsg("Writable", r.writable, ShouldEqual, test.expect[1])
+					SoMsg("Readable", r.readable, ShouldEqual, test.expect[2])
+					SoMsg("Releasable", r.releasable, ShouldEqual, test.expect[3])
+				} else {
+					SoMsg("Error", r, ShouldBeNil)
+				}
+			})
+		}
+	})
+}
+
+func TestContents(t *testing.T) {
+	r := New(8, 128)
+	data := []byte{1, 2, 3, 4, 5}
+	buffersWriter := make([][]byte, 1)
+	buffersReader := make([][]byte, 1)
+
+	Convey("Test data transfer", t, func() {
+		r.Reserve(buffersWriter)
+		copy(buffersWriter[0], data)
+		buffersWriter[0] = buffersWriter[0][:len(data)]
+		r.Write(buffersWriter)
+
+		r.Read(buffersReader)
+		buffersReader[0] = buffersReader[0][:cap(data)]
+		SoMsg("Buffer contents", buffersReader[0], ShouldResemble, data)
+		r.Release(buffersReader)
+	})
+}

--- a/go/lib/sring/sring_test.go
+++ b/go/lib/sring/sring_test.go
@@ -1,4 +1,4 @@
-package pring
+package sring
 
 import (
 	"fmt"


### PR DESCRIPTION
On creation, the ring buffer populates itself with buffers. Writers reserve buffers, process them and then write the references back. Readers read buffers, process them and then release the references back to the ring buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1196)
<!-- Reviewable:end -->
