### PR TITLE
Improve checksum performance for dispatcher.

### DIFF
--- a/c/dispatcher/Makefile
+++ b/c/dispatcher/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean install uninstall
 
 CC = clang
-CFLAGS ?= -Wall -Werror -g
+CFLAGS ?= -Wall -Werror -g -O2
 LDFLAGS ?= -lscion -lfilter -lpthread -lzlog -ltcpmw -llwip
 
 LIB_DIR = ../lib

--- a/c/lib/scion/Makefile
+++ b/c/lib/scion/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean install uninstall
 
 CC = clang
-CFLAGS ?= -Wall -Werror -g -fPIC
+CFLAGS ?= -Wall -Werror -g -fPIC -O2
 LDFLAGS ?= -shared -Wl,-z,defs
 
 SRCS = $(wildcard *.c)

--- a/c/lib/scion/checksum.c
+++ b/c/lib/scion/checksum.c
@@ -18,16 +18,17 @@ uint16_t checksum(chk_input *in) {
     for (i=0; i < in->total; i++){
         int j = 0;
         int len = in->len[i];
-        uint8_t *ptr = in->ptr[i];
+        int len2 = len/2;
+        uint16_t *ptr = (uint16_t *)(in->ptr[i]);
         if (len == 0) {
             continue;
         }
-        for (; j < len - 1; j+=2) {
-            sum += *((uint16_t *)(ptr + j));
+        for (; j < len2; j++) {
+            sum += ptr[j];
         }
         // Add left-over byte, if any
-        if (j != len) {
-            sum += ptr[j];
+        if (len % 2 != 0) {
+            sum += in->ptr[i][len-1];
         }
     }
     // Fold 32-bit sum to 16 bits

--- a/c/lib/scion/checksum.c
+++ b/c/lib/scion/checksum.c
@@ -3,8 +3,6 @@
 #include <stdlib.h>
 #include "checksum.h"
 
-void _add_sum(uint32_t *sum, uint16_t val);
-
 /*
  * Calculate RFC1071 checksum of supplied data chunks. The use of a gather
  * mechanism means there's 0 copies required to calculate the checksum.
@@ -13,6 +11,7 @@ void _add_sum(uint32_t *sum, uint16_t val);
  */
 uint16_t checksum(chk_input *in) {
     int i;
+    /* As the maximum packet size is 65535B, the 32-bit accumulator cannot overflow. */
     uint32_t sum = 0;
 
     // Iterate over the chunks
@@ -24,24 +23,20 @@ uint16_t checksum(chk_input *in) {
             continue;
         }
         for (; j < len - 1; j+=2) {
-            _add_sum(&sum, ntohs(*((uint16_t *)(ptr + j))));
+            sum += *((uint16_t *)(ptr + j));
         }
-        // If there's an odd number of bytes, pad chunk with a 0
+        // Add left-over byte, if any
         if (j != len) {
-            _add_sum(&sum, ((uint16_t)ptr[j]) << 8);
+            sum += ptr[j];
         }
     }
-    // Return 16bit ones-complement.
-    return htons(~sum & 0xFFFF);
-}
+    // Fold 32-bit sum to 16 bits
+    while (sum > 0xFFFF) {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
 
-/*
- * Handle bit-carry operation during addition.
- */
-void _add_sum(uint32_t *sum, uint16_t val) {
-    *sum += val;
-    if (*sum > 0xFFFF)
-        *sum -= 0xFFFF;
+    // Return ones-complement.
+    return ~sum;
 }
 
 /*

--- a/c/lib/scion/checksum.c
+++ b/c/lib/scion/checksum.c
@@ -37,6 +37,7 @@ uint16_t checksum(chk_input *in) {
     }
 
     // Return ones-complement.
+    // XXX(kormat): this value is in network-byte order.
     return ~sum;
 }
 

--- a/c/lib/scion/udp.h
+++ b/c/lib/scion/udp.h
@@ -13,9 +13,10 @@ typedef struct {
 
 #pragma pack(pop)
 
+#define UDP_CHK_INPUT_SIZE 5
+
 void build_scion_udp(uint8_t *buf, uint16_t src_port, uint16_t dst_port, uint16_t payload_len);
-uint16_t scion_udp_checksum(uint8_t *buf);
-void update_scion_udp_checksum(uint8_t *buf);
+uint16_t scion_udp_checksum(uint8_t *buf, chk_input *input);
 void reverse_udp_header(uint8_t *l4ptr);
 void print_udp_header(uint8_t *buf);
 


### PR DESCRIPTION
- Instead of allocating a new chk_input struct for each packet inside
  `scion_udp_checksum()`, have the caller allocate one and pass it in
  repeatedly. This saves a Large number of mallocs/frees.
- Simplify `checksum()`:
  - The checksum algorithm is already endian-agnostic, so remove all
    byte-swapping.
  - With a 32-bit accumulator, overflow is avoided, removing the need
    for checks.

Some simple benchmarks of `checksum()` put this at >2x faster than
the existing implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1198)
<!-- Reviewable:end -->
