### PR TITLE
New build flag to disable debug logging

### DIFF
--- a/go/lib/log/const_off.go
+++ b/go/lib/log/const_off.go
@@ -1,0 +1,19 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !debug
+
+package liblog
+
+const DebugOn = false

--- a/go/lib/log/const_on.go
+++ b/go/lib/log/const_on.go
@@ -1,4 +1,4 @@
-// Copyright 2016 ETH Zurich
+// Copyright 2017 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/lib/log/const_on.go
+++ b/go/lib/log/const_on.go
@@ -1,0 +1,19 @@
+// Copyright 2016 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build debug
+
+package liblog
+
+const DebugOn = true

--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -88,3 +88,25 @@ func PanicLog() {
 func Flush() {
 	logBuf.Flush()
 }
+
+func Debug(msg string, ctx ...interface{}) {
+	if DebugOn {
+		log.Debug(msg, ctx...)
+	}
+}
+
+func Info(msg string, ctx ...interface{}) {
+	log.Info(msg, ctx...)
+}
+
+func Warn(msg string, ctx ...interface{}) {
+	log.Warn(msg, ctx...)
+}
+
+func Error(msg string, ctx ...interface{}) {
+	log.Error(msg, ctx...)
+}
+
+func Crit(msg string, ctx ...interface{}) {
+	log.Crit(msg, ctx...)
+}

--- a/go/sig/base/forward.go
+++ b/go/sig/base/forward.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/sig/lib/scion"

--- a/go/sig/base/framebuf.go
+++ b/go/sig/base/framebuf.go
@@ -3,7 +3,7 @@ package base
 import (
 	"fmt"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 )

--- a/go/sig/base/ingress.go
+++ b/go/sig/base/ingress.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"

--- a/go/sig/base/rlist.go
+++ b/go/sig/base/rlist.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/sig/metrics"

--- a/go/sig/base/sdb.go
+++ b/go/sig/base/sdb.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/sig/lib/scion"

--- a/go/sig/lib/scion/paths.go
+++ b/go/sig/lib/scion/paths.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"

--- a/go/sig/lib/scion/scion.go
+++ b/go/sig/lib/scion/scion.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"net"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"

--- a/go/sig/management/console.go
+++ b/go/sig/management/console.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/abiosoft/ishell"
 	"github.com/chzyer/readline"
-	log "github.com/inconshreveable/log15"
+
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/sig/control"
 )

--- a/go/sig/metrics/metrics.go
+++ b/go/sig/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/go/sig/sig.go
+++ b/go/sig/sig.go
@@ -8,11 +8,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/netsec-ethz/scion/go/lib/log"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
-	liblog "github.com/netsec-ethz/scion/go/lib/log"
 	"github.com/netsec-ethz/scion/go/sig/base"
 	"github.com/netsec-ethz/scion/go/sig/control"
 	"github.com/netsec-ethz/scion/go/sig/lib/scion"
@@ -47,8 +46,8 @@ var (
 
 func main() {
 	flag.Parse()
-	liblog.Setup("sig")
-	defer liblog.PanicLog()
+	log.Setup("sig")
+	defer log.PanicLog()
 	setupSignals()
 
 	// Export prometheus metrics.
@@ -111,7 +110,7 @@ func setupSignals() {
 	go func() {
 		s := <-sig
 		log.Info("Received signal, exiting...", "signal", s)
-		liblog.Flush()
+		log.Flush()
 		os.Exit(1)
 	}()
 }

--- a/go/sig/xnet/xnet.go
+++ b/go/sig/xnet/xnet.go
@@ -6,9 +6,10 @@ import (
 	"net"
 	"os/exec"
 
-	log "github.com/inconshreveable/log15"
 	"github.com/songgao/water"
 	"github.com/vishvananda/netlink"
+
+	log "github.com/netsec-ethz/scion/go/lib/log"
 )
 
 const SIGRTable = 11


### PR DESCRIPTION
The command line logging level disables writing out to files but does not disable log processing. This severely impacts performance.

This PR adds a new build flag `debug`. If the flag is not specified, all calls to `log.Debug` are deleted by the compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1201)
<!-- Reviewable:end -->
