### PR TITLE
Link dispatcher statically against scion libs.

### DIFF
--- a/c/dispatcher/Makefile
+++ b/c/dispatcher/Makefile
@@ -2,7 +2,7 @@
 
 CC = clang
 CFLAGS ?= -Wall -Werror -g -O2
-LDFLAGS ?= -lscion -lfilter -lpthread -lzlog -ltcpmw -llwip
+LDFLAGS ?= -lpthread -lzlog -Wl,-Bstatic -ltcpmw -llwip -lfilter -lscion -Wl,-Bdynamic
 
 LIB_DIR = ../lib
 LWIPDIR = ../../sub/lwip/src/include
@@ -22,7 +22,7 @@ clean:
 # can be recompiled if any of the included header files changed.
 -include *.d
 dispatcher: dispatcher.c
-	$(CC) $(CFLAGS) $(INC) $(LDFLAGS) -MMD -o $@ $<
+	$(CC) $(CFLAGS) $(INC) -MMD -o $@ $< $(LDFLAGS)
 
 install: $(INSTALL)
 

--- a/c/lib/scion/Makefile
+++ b/c/lib/scion/Makefile
@@ -29,8 +29,8 @@ $(STATIC): $(OBJS)
 $(DYNAMIC): $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS)
 
-checksum_bench: checksum_bench.c libscion.a
-	$(CC) $(CFLAGS) -L. -lscion -MMD -o $@ $<
+checksum_bench: checksum_bench.c $(DYNAMIC)
+	$(CC) $(CFLAGS) -MMD -o $@ $< -L. -lscion
 
 install: .installstamp
 


### PR DESCRIPTION
This will prevent the dispatcher from segfaulting when libraries are
re-compiled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1202)
<!-- Reviewable:end -->
