### PR TITLE
Clean up SIG ingress/egress logging

### DIFF
--- a/go/sig/base/framebuf.go
+++ b/go/sig/base/framebuf.go
@@ -72,8 +72,8 @@ func (fb *FrameBuf) ProcessCompletePkts() {
 			break
 		}
 		// We got everything for the packet. Write it out to the wire.
-		log.Debug("ProcessCompletePkts: directly write pkt", "seqNr", fb.seqNr,
-			"offset", offset, "len", pktLen)
+		//log.Debug("ProcessCompletePkts: directly write pkt", "seqNr", fb.seqNr,
+		//	"offset", offset, "len", pktLen)
 		if err := send(rawPkt[:pktLen]); err != nil {
 			log.Error("Unable to send packet", "err", err)
 		}
@@ -83,8 +83,6 @@ func (fb *FrameBuf) ProcessCompletePkts() {
 	}
 	if offset < fb.frameLen {
 		// There is an incomplete packet at the end of the frame.
-		log.Debug("Found packet fragment at the end of frame", "seqNr", fb.seqNr,
-			"start", offset, "pktLen", pktLen)
 		fb.frag0Start = offset
 		fb.pktLen = pktLen
 	}

--- a/go/sig/base/ingress.go
+++ b/go/sig/base/ingress.go
@@ -104,8 +104,8 @@ func (i *IngressWorker) ProcessFrame(frame *FrameBuf) {
 	epoch := int(common.Order.Uint16(frame.raw[6:8]))
 	frame.seqNr = seqNr
 	frame.index = index
-	log.Debug("Received Frame", "seqNr", seqNr, "index", index, "epoch", epoch,
-		"len", frame.frameLen)
+	//log.Debug("Received Frame", "seqNr", seqNr, "index", index, "epoch", epoch,
+	//	"len", frame.frameLen)
 	// If index == 1 then we can be sure that there is no fragment at the beginning
 	// of the frame.
 	frame.fragNProcessed = index == 1


### PR DESCRIPTION
Logging in the fast path severely impacts performance even if the logs aren't written to files. This PR deletes or comments out all per packet logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1208)
<!-- Reviewable:end -->
