### PR TITLE
Increase go checksum performance 2x

### DIFF
--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"encoding/binary"
+	"unsafe"
 )
 
 const (
@@ -26,6 +27,19 @@ const (
 )
 
 var Order = binary.BigEndian
+var NativeOrder binary.ByteOrder
+var BigEndian bool
+
+func init() {
+	var v uint16 = 0x11FF
+	if (*[2]uint8)(unsafe.Pointer(&v))[0] == 0x11 {
+		BigEndian = true
+		NativeOrder = binary.BigEndian
+	} else {
+		BigEndian = false
+		NativeOrder = binary.LittleEndian
+	}
+}
 
 const (
 	BR = "br"

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -28,15 +28,15 @@ const (
 
 var Order = binary.BigEndian
 var NativeOrder binary.ByteOrder
-var BigEndian bool
+var IsBigEndian bool
 
 func init() {
 	var v uint16 = 0x11FF
 	if (*[2]uint8)(unsafe.Pointer(&v))[0] == 0x11 {
-		BigEndian = true
+		IsBigEndian = true
 		NativeOrder = binary.BigEndian
 	} else {
-		BigEndian = false
+		IsBigEndian = false
 		NativeOrder = binary.LittleEndian
 	}
 }

--- a/go/lib/util/checksum.go
+++ b/go/lib/util/checksum.go
@@ -53,10 +53,9 @@ func Checksum(srcs ...common.RawBytes) uint16 {
 	for sum > 0xffff {
 		sum = (sum >> 16) + (sum & 0xffff)
 	}
-	sum = (sum&0xFF)<<8 + (sum >> 8)
+	if !common.BigEndian {
+		// Native order is little-endian, so swap the bytes.
+		sum = (sum&0xFF)<<8 + (sum >> 8)
+	}
 	return ^uint16(sum)
-}
-
-func toUint32(x uint8, y uint8) uint32 {
-	return uint32(x)<<8 + uint32(y)
 }

--- a/go/lib/util/checksum.go
+++ b/go/lib/util/checksum.go
@@ -53,7 +53,7 @@ func Checksum(srcs ...common.RawBytes) uint16 {
 	for sum > 0xffff {
 		sum = (sum >> 16) + (sum & 0xffff)
 	}
-	if !common.BigEndian {
+	if !common.IsBigEndian {
 		// Native order is little-endian, so swap the bytes.
 		sum = (sum&0xFF)<<8 + (sum >> 8)
 	}

--- a/go/lib/util/checksum.go
+++ b/go/lib/util/checksum.go
@@ -35,7 +35,7 @@ func Checksum(srcs ...common.RawBytes) uint16 {
 		// XXX(kormat): this creates a uint16 slice pointing to the underlying
 		// data in src. This provides a 2x speed-up, at least on
 		// linux/{amd64,arm64}. How it works:
-		// 1. Get the get the address of the backing array in src.
+		// 1. Get the address of the backing array in src.
 		// 2. Cast the address to a uint16 _array_ (with a size guaranteed to
 		//    be large enough).
 		// 3. Convert the array to a []uint16 of the appropriate number of

--- a/go/lib/util/checksum.go
+++ b/go/lib/util/checksum.go
@@ -15,6 +15,10 @@
 package util
 
 import (
+	"unsafe"
+
+	//log "github.com/inconshreveable/log15"
+
 	"github.com/netsec-ethz/scion/go/lib/common"
 )
 
@@ -24,21 +28,32 @@ func Checksum(srcs ...common.RawBytes) uint16 {
 	var sum uint32
 	for _, src := range srcs {
 		length := len(src)
-		i := 0
-
 		if length == 0 {
 			continue
 		}
-		for ; i < length-1; i += 2 {
-			sum += toUint32(src[i], src[i+1])
+		length2 := length / 2
+		// XXX(kormat): this creates a uint16 slice pointing to the underlying
+		// data in src. This provides a 2x speed-up, at least on
+		// linux/{amd64,arm64}. How it works:
+		// 1. Get the get the address of the backing array in src.
+		// 2. Cast the address to a uint16 _array_ (with a size guaranteed to
+		//    be large enough).
+		// 3. Convert the array to a []uint16 of the appropriate number of
+		//    uint16 elements (setting both length and cap).
+		// This has to be converted via an array, so that new slice metadata is
+		// allocated. Referencing a []uint8 as []uint16 will cause a crash.
+		src16 := (*[1 << 16]uint16)(unsafe.Pointer(&src[0]))[:length2:length2]
+		for i := 0; i < length2; i++ {
+			sum += uint32(src16[i])
 		}
-		if i != length {
-			sum += toUint32(src[i], 0)
+		if length%2 != 0 {
+			sum += uint32(src[length-1])
 		}
 	}
 	for sum > 0xffff {
 		sum = (sum >> 16) + (sum & 0xffff)
 	}
+	sum = (sum&0xFF)<<8 + (sum >> 8)
 	return ^uint16(sum)
 }
 

--- a/go/lib/util/checksum_test.go
+++ b/go/lib/util/checksum_test.go
@@ -38,3 +38,14 @@ func TestChecksum(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkChecksum(b *testing.B) {
+	data := make(common.RawBytes, 1500)
+	for i := 0; i < len(data); i++ {
+		data[i] = byte(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Checksum(data)
+	}
+}


### PR DESCRIPTION
Before: 948 ns/op
After: 455 ns/op

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1209)
<!-- Reviewable:end -->
