### PR TITLE
Re-factor sring to a single ringbuffer

### DIFF
--- a/go/lib/ringbuf/metrics.go
+++ b/go/lib/ringbuf/metrics.go
@@ -1,0 +1,70 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ringbuf
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	writeCalls   prometheus.Counter
+	readCalls    prometheus.Counter
+	writeEntries prometheus.Counter
+	readEntries  prometheus.Counter
+}
+
+func newMetrics(desc string, labels prometheus.Labels) *metrics {
+	l := copyLabels(labels)
+	l["desc"] = desc
+	return &metrics{
+		writeCalls:   WriteCalls.With(l),
+		readCalls:    ReadCalls.With(l),
+		writeEntries: WriteEntries.With(l),
+		readEntries:  ReadEntries.With(l),
+	}
+}
+
+func copyLabels(labels prometheus.Labels) prometheus.Labels {
+	l := make(prometheus.Labels)
+	for k, v := range labels {
+		l[k] = v
+	}
+	return l
+}
+
+var WriteCalls *prometheus.CounterVec
+var ReadCalls *prometheus.CounterVec
+var WriteEntries *prometheus.CounterVec
+var ReadEntries *prometheus.CounterVec
+
+func InitMetrics(namespace string) {
+	WriteCalls = newCounterVec(namespace, "write_calls_total", "Number of calls to Write.")
+	ReadCalls = newCounterVec(namespace, "read_calls_total", "Number of calls to Read.")
+	WriteEntries = newCounterVec(namespace, "write_entries_total",
+		"Number of written entries.")
+	ReadEntries = newCounterVec(namespace, "read_entries_total",
+		"Number of read entries.")
+}
+
+func newCounterVec(namespace, name, help string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      name,
+			Help:      help,
+		},
+		[]string{"id", "desc"},
+	)
+}

--- a/go/lib/ringbuf/ringbuf.go
+++ b/go/lib/ringbuf/ringbuf.go
@@ -1,0 +1,146 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ringbuf
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Entry interface{}
+type EntryList []Entry
+type NewEntryF func() interface{}
+
+// Ring is a classic generic ring buffer on top of a fixed-sized slice.
+type Ring struct {
+	mutex      sync.Mutex
+	writableC  *sync.Cond
+	readableC  *sync.Cond
+	entries    EntryList
+	writeIndex int
+	readIndex  int
+	writable   int
+	readable   int
+	closed     bool
+	metrics    *metrics
+}
+
+func New(count int, newf NewEntryF, desc string, labels prometheus.Labels) *Ring {
+	r := &Ring{}
+	r.readableC = sync.NewCond(&r.mutex)
+	r.entries = make(EntryList, count)
+	// Only allocate memory if caller requested it
+	if newf != nil {
+		for i := 0; i < count; i++ {
+			r.entries[i] = newf()
+		}
+		// A ring buffer that allocates data starts off as full
+		r.readable = count
+	} else {
+		// A ring buffer that does not allocate starts off as empty
+		r.writable = count
+	}
+	r.closed = false
+	r.metrics = newMetrics(desc, labels)
+	return r
+}
+
+// Write copies entries to the internal ring buffer.
+// Returns the number of entries written, or -1 if the RingBuf is closed.
+func (r *Ring) Write(entries EntryList, block bool) int {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.metrics.writeCalls.Inc()
+	for r.writable == 0 && !r.closed {
+		if !block {
+			return 0
+		}
+		r.writableC.Wait()
+	}
+	if r.closed {
+		return -1
+	}
+	n := min(r.writable, len(entries))
+	r.write(entries[:n])
+	r.writable -= n
+	r.readable += n
+	r.readableC.Signal()
+	r.metrics.writeEntries.Add(float64(n))
+	return n
+}
+
+// Read copies entries from the internal ring buffer.
+// Returns the number of entries read, or -1 if the RingBuf is closed.
+func (r *Ring) Read(entries EntryList, block bool) int {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.metrics.readCalls.Inc()
+	for r.readable == 0 && !r.closed {
+		if !block {
+			return 0
+		}
+		r.readableC.Wait()
+	}
+	if r.closed {
+		return -1
+	}
+	n := min(r.readable, len(entries))
+	r.read(entries[:n])
+	r.readable -= n
+	r.writable += n
+	r.writableC.Signal()
+	r.metrics.readEntries.Add(float64(n))
+	return n
+}
+
+// Close closes the ring buffer, and causes all blocked readers/writers to be
+// notified.
+func (r *Ring) Close() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.closed = true
+	r.writableC.Signal()
+	r.readableC.Signal()
+}
+
+func (r *Ring) write(entries EntryList) {
+	n := copy(r.entries[r.writeIndex:], entries)
+	r.writeIndex += n
+	// Wraparound if we need to write more slice references
+	if n < len(entries) {
+		n = copy(r.entries, entries[n:])
+		// Reset write index
+		r.writeIndex = n
+	}
+}
+
+func (r *Ring) read(entries EntryList) {
+	n := copy(entries, r.entries[r.readIndex:])
+	r.readIndex += n
+	// Wraparound if we need to read more slice references
+	if n < len(entries) {
+		n = copy(entries[n:], r.entries)
+		// Reset read index
+		r.readIndex = n
+	}
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}


### PR DESCRIPTION
This simplifies its use in places where you are passing data through
multiple ring-buffers without copying. This also means it can just be
used as a free buffer pool regardless of how filled buffers are passed
around.

Also:
- Add a `Close()` method, to allow shutting down of go routines who are
  blocked reading/writing to the ring buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1214)
<!-- Reviewable:end -->
