### PR TITLE
Add SO_TIMESTAMP support.

### DIFF
--- a/go/border/main.go
+++ b/go/border/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/assert"
 	liblog "github.com/netsec-ethz/scion/go/lib/log"
 	"github.com/netsec-ethz/scion/go/lib/profile"
-	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 )
 
 var (
@@ -83,8 +82,4 @@ func setupSignals() {
 		liblog.Flush()
 		os.Exit(1)
 	}()
-}
-
-func init() {
-	ringbuf.InitMetrics("border")
 }

--- a/go/border/metrics/metrics.go
+++ b/go/border/metrics/metrics.go
@@ -27,6 +27,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/overlay/conn"
+	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 )
 
 var promAddr = flag.String("prom", "127.0.0.1:1280", "Address to export prometheus metrics on")
@@ -46,14 +48,6 @@ var (
 			Namespace: "border",
 			Name:      "pkts_sent_total",
 			Help:      "Number of packets sent.",
-		},
-		[]string{"id"},
-	)
-	PktsRecvOvfl = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "border",
-			Name:      "pkts_recv_ovfl_total",
-			Help:      "Number of packets dropped due to receive buffer overflow.",
 		},
 		[]string{"id"},
 	)
@@ -140,7 +134,6 @@ var (
 func init() {
 	prometheus.MustRegister(PktsRecv)
 	prometheus.MustRegister(PktsSent)
-	prometheus.MustRegister(PktsRecvOvfl)
 	prometheus.MustRegister(PktsRecvSize)
 	prometheus.MustRegister(BytesRecv)
 	prometheus.MustRegister(BytesSent)
@@ -152,6 +145,16 @@ func init() {
 	prometheus.MustRegister(InputLoops)
 	prometheus.MustRegister(InputProcessTime)
 	prometheus.MustRegister(OutputProcessTime)
+
+	ringbuf.InitMetrics("border")
+	prometheus.MustRegister(ringbuf.WriteCalls)
+	prometheus.MustRegister(ringbuf.ReadCalls)
+	prometheus.MustRegister(ringbuf.WriteEntries)
+	prometheus.MustRegister(ringbuf.ReadEntries)
+
+	conn.InitMetrics("border")
+	prometheus.MustRegister(conn.RecvOverflow)
+	prometheus.MustRegister(conn.RecvDelay)
 }
 
 var servers map[string]io.Closer

--- a/go/lib/overlay/conn/c.go
+++ b/go/lib/overlay/conn/c.go
@@ -22,21 +22,9 @@ int sizeof_struct_timeval = sizeof(struct timeval);
 */
 import "C"
 
-import (
-	"time"
-	"unsafe"
-
-	"github.com/netsec-ethz/scion/go/lib/common"
-)
-
 const (
-	SizeOfInt     = C.sizeof_int
-	SizeOfTimeVal = C.sizeof_struct_timeval
+	SizeOfInt      = C.sizeof_int
+	SizeOfTimespec = C.sizeof_struct_timespec
 )
 
-type Timeval C.struct_timeval
-
-func ParseTimeVal(b common.RawBytes) time.Time {
-	tv := *(*Timeval)(unsafe.Pointer(&b[0]))
-	return time.Unix(int64(tv.tv_sec), int64(tv.tv_usec)*1000)
-}
+type Timespec C.struct_timespec

--- a/go/lib/overlay/conn/c.go
+++ b/go/lib/overlay/conn/c.go
@@ -1,0 +1,42 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conn
+
+/*
+#include <sys/time.h>
+
+int sizeof_int = sizeof(int);
+int sizeof_struct_timeval = sizeof(struct timeval);
+*/
+import "C"
+
+import (
+	"time"
+	"unsafe"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+)
+
+const (
+	SizeOfInt     = C.sizeof_int
+	SizeOfTimeVal = C.sizeof_struct_timeval
+)
+
+type Timeval C.struct_timeval
+
+func ParseTimeVal(b common.RawBytes) time.Time {
+	tv := *(*Timeval)(unsafe.Pointer(&b[0]))
+	return time.Unix(int64(tv.tv_sec), int64(tv.tv_usec)*1000)
+}

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -18,23 +18,18 @@ import (
 	"fmt"
 	"net"
 	"syscall"
+	"time"
 	"unsafe"
 
 	log "github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/netsec-ethz/scion/go/border/metrics"
 	"github.com/netsec-ethz/scion/go/lib/assert"
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/nethack"
 	"github.com/netsec-ethz/scion/go/lib/overlay"
 	"github.com/netsec-ethz/scion/go/lib/topology"
 )
-
-// There isn't a way to calculate the size of a syscall integer, so use the
-// value that the stdlib hard-codes instead.
-// E.g. https://golang.org/pkg/syscall/#SetsockoptInt
-const syscallIntSize = 4
 
 type Conn interface {
 	Read(common.RawBytes) (int, *topology.AddrInfo, error)
@@ -81,12 +76,12 @@ func New(listen, remote *topology.AddrInfo, labels prometheus.Labels) (Conn, *co
 }
 
 type connUDPIPv4 struct {
-	conn         *net.UDPConn
-	Listen       *topology.AddrInfo
-	Remote       *topology.AddrInfo
-	oob          common.RawBytes
-	pktsRecvOvfl prometheus.Counter
-	closed       bool
+	conn    *net.UDPConn
+	Listen  *topology.AddrInfo
+	Remote  *topology.AddrInfo
+	oob     common.RawBytes
+	metrics *metrics
+	closed  bool
 }
 
 func newConnUDPIPv4(c *net.UDPConn, listen, remote *topology.AddrInfo,
@@ -100,13 +95,18 @@ func newConnUDPIPv4(c *net.UDPConn, listen, remote *topology.AddrInfo,
 		return nil, common.NewError("Error setting SO_RXQ_OVFL socket option", "listen", listen,
 			"remote", remote, "err", err)
 	}
+	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
+		return nil, common.NewError("Error setting SO_TIMESTAMP socket option", "listen", listen,
+			"remote", remote, "err", err)
+	}
+	oob := make(common.RawBytes, syscall.CmsgSpace(SizeOfInt)+syscall.CmsgSpace(SizeOfTimeVal))
 	return &connUDPIPv4{
-		conn:         c,
-		Listen:       listen,
-		Remote:       remote,
-		oob:          make(common.RawBytes, syscall.CmsgSpace(syscallIntSize)),
-		pktsRecvOvfl: metrics.PktsRecvOvfl.With(labels),
-		closed:       false,
+		conn:    c,
+		Listen:  listen,
+		Remote:  remote,
+		oob:     oob,
+		metrics: newMetrics(labels),
+		closed:  false,
 	}, nil
 }
 
@@ -124,6 +124,9 @@ func (c *connUDPIPv4) Read(b common.RawBytes) (int, *topology.AddrInfo, error) {
 }
 
 func (c *connUDPIPv4) handleCmsg(oob common.RawBytes) {
+	// TODO(kormat): instead of updating metrics here, stop conforming to
+	// net.Conn and pass metadata directly back to the caller of Read(). E.g.,
+	// this allows the caller to use the received timestamp.
 	cmsgs, err := syscall.ParseSocketControlMessage(oob)
 	if err != nil {
 		log.Debug("Error decoding cmsg data from ReadMsgUdp", "listen", c.Listen,
@@ -135,7 +138,13 @@ func (c *connUDPIPv4) handleCmsg(oob common.RawBytes) {
 		switch {
 		case hdr.Level == syscall.SOL_SOCKET && hdr.Type == syscall.SO_RXQ_OVFL:
 			val := *(*int)(unsafe.Pointer(&cmsg.Data[0]))
-			c.pktsRecvOvfl.Set(float64(val))
+			c.metrics.recvOvfl.Set(float64(val))
+		case hdr.Level == syscall.SOL_SOCKET && hdr.Type == syscall.SO_TIMESTAMP:
+			since := time.Since(ParseTimeVal(cmsg.Data))
+			// Guard against leap-seconds.
+			if since > 0 {
+				c.metrics.recvDelay.Add(since.Seconds())
+			}
 		}
 	}
 }

--- a/go/lib/overlay/conn/metrics.go
+++ b/go/lib/overlay/conn/metrics.go
@@ -24,7 +24,7 @@ var RecvDelay *prometheus.CounterVec
 func InitMetrics(namespace string) {
 	RecvOverflow = newCounterVec(namespace, "recv_ovfl_count",
 		"Number of packets dropped due to kernel receive buffer overflow.")
-	RecvDelay = newCounterVec(namespace, "recv_delay_secounds",
+	RecvDelay = newCounterVec(namespace, "recv_delay_seconds",
 		"How long packets spend in the kernel receive buffer.")
 }
 

--- a/go/lib/overlay/conn/metrics.go
+++ b/go/lib/overlay/conn/metrics.go
@@ -1,0 +1,53 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conn
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var RecvOverflow *prometheus.CounterVec
+var RecvDelay *prometheus.CounterVec
+
+func InitMetrics(namespace string) {
+	RecvOverflow = newCounterVec(namespace, "recv_ovfl_count",
+		"Number of packets dropped due to kernel receive buffer overflow.")
+	RecvDelay = newCounterVec(namespace, "recv_delay_secounds",
+		"How long packets spend in the kernel receive buffer.")
+}
+
+func newCounterVec(namespace, name, help string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "over_conn",
+			Name:      name,
+			Help:      help,
+		},
+		[]string{"id"},
+	)
+}
+
+type metrics struct {
+	recvOvfl  prometheus.Counter
+	recvDelay prometheus.Counter
+}
+
+func newMetrics(labels prometheus.Labels) *metrics {
+	return &metrics{
+		recvOvfl:  RecvOverflow.With(labels),
+		recvDelay: RecvDelay.With(labels),
+	}
+}

--- a/go/lib/ringbuf/metrics.go
+++ b/go/lib/ringbuf/metrics.go
@@ -62,6 +62,7 @@ func newCounterVec(namespace, name, help string) *prometheus.CounterVec {
 	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
+			Subsystem: "ringbuf",
 			Name:      name,
 			Help:      help,
 		},


### PR DESCRIPTION
With SO_TIMESTAMP on a socket, the kernel returns when a packet arrived
when readmsg is called.

As the size of `struct timeval` isn't available anywhere in the go std
lib, this change adds a very short cgo file to calculate the sizes, and
also handle conversion of `struct timeval` to `time.Time`.

Also:
- Clean up metrics on overlay/conn - it no longer imports the border
  metrics module.
- Add missing subsystem to ringbuf metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1217)
<!-- Reviewable:end -->
