### PR TITLE
Increase overlay.conn receive buffer sizes.

### DIFF
--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -123,7 +123,7 @@ func newConnUDPIPv4(c *net.UDPConn, listen, remote *topology.AddrInfo,
 			"remote", remote, "err", err)
 	}
 	if after/2 != recvBufSize {
-		msg := "Recieve buffer size smaller than requested"
+		msg := "Receive buffer size smaller than requested"
 		ctx := []interface{}{"expected", recvBufSize, "actual", after / 2, "before", before / 2}
 		if !*sizeIgnore {
 			return nil, common.NewError(msg, ctx...)


### PR DESCRIPTION
When a udp socket is created, conn will now try to set a 1MiB receive
buffer size. If the resulting size is less than requested, a warning is
logged. This change also adds a command-line flag to turn this warning
into a socket error, for use in production environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1218)
<!-- Reviewable:end -->
