### PR TITLE
Refactor prometheus metrics configuration.

### DIFF
--- a/go/border/router.go
+++ b/go/border/router.go
@@ -58,6 +58,7 @@ type Router struct {
 }
 
 func NewRouter(id, confDir string) (*Router, *common.Error) {
+	metrics.Init(id)
 	r := &Router{Id: id, confDir: confDir}
 	if err := r.setup(); err != nil {
 		return nil, err

--- a/go/lib/overlay/conn/metrics.go
+++ b/go/lib/overlay/conn/metrics.go
@@ -16,28 +16,20 @@ package conn
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/netsec-ethz/scion/go/lib/prom"
 )
 
 var RecvOverflow *prometheus.CounterVec
 var RecvDelay *prometheus.CounterVec
 
-func InitMetrics(namespace string) {
-	RecvOverflow = newCounterVec(namespace, "recv_ovfl_count",
-		"Number of packets dropped due to kernel receive buffer overflow.")
-	RecvDelay = newCounterVec(namespace, "recv_delay_seconds",
-		"How long packets spend in the kernel receive buffer.")
-}
-
-func newCounterVec(namespace, name, help string) *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: "over_conn",
-			Name:      name,
-			Help:      help,
-		},
-		[]string{"id"},
-	)
+func InitMetrics(namespace string, constLabels prometheus.Labels, labelNames []string) {
+	subsys := "over_conn"
+	RecvOverflow = prom.NewCounterVec(namespace, subsys, "recv_ovfl_count",
+		"Number of packets dropped due to kernel receive buffer overflow.", constLabels, labelNames)
+	RecvDelay = prom.NewCounterVec(namespace, subsys, "recv_delay_seconds",
+		"How long packets spend in the kernel receive buffer.", constLabels, labelNames)
+	prometheus.MustRegister(RecvOverflow, RecvDelay)
 }
 
 type metrics struct {

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -1,0 +1,85 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prom contains some utility functions for dealing with prometheus
+// metrics.
+package prom
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func CopyLabels(labels prometheus.Labels) prometheus.Labels {
+	l := make(prometheus.Labels)
+	for k, v := range labels {
+		l[k] = v
+	}
+	return l
+}
+
+func NewCounter(namespace, subsystem, name, help string,
+	constLabels prometheus.Labels) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        name,
+			Help:        help,
+			ConstLabels: constLabels,
+		},
+	)
+}
+
+func NewCounterVec(namespace, subsystem, name, help string,
+	constLabels prometheus.Labels, labelNames []string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        name,
+			Help:        help,
+			ConstLabels: constLabels,
+		},
+		labelNames,
+	)
+}
+
+func NewGaugeVec(namespace, subsystem, name, help string,
+	constLabels prometheus.Labels, labelNames []string) *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        name,
+			Help:        help,
+			ConstLabels: constLabels,
+		},
+		labelNames,
+	)
+}
+
+func NewHistogramVec(namespace, subsystem, name, help string, constLabels prometheus.Labels,
+	labelNames []string, buckets []float64) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        name,
+			Help:        help,
+			ConstLabels: constLabels,
+			Buckets:     buckets,
+		},
+		labelNames,
+	)
+}

--- a/go/sig/metrics/metrics.go
+++ b/go/sig/metrics/metrics.go
@@ -28,116 +28,58 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/prom"
 )
 
 var promAddr = flag.String("prom", "127.0.0.1:1281", "Address to export prometheus metrics on")
 
 // Declare prometheus metrics to export.
 var (
-	PktsRecv = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "pkts_recv_total",
-			Help:      "Number of packets received.",
-		},
-		[]string{"intf"},
-	)
-	PktsSent = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "pkts_sent_total",
-			Help:      "Number of packets sent.",
-		},
-		[]string{"intf"},
-	)
-	PktBytesRecv = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "pkt_bytes_recv_total",
-			Help:      "Number of packet bytes received.",
-		},
-		[]string{"intf"},
-	)
-	PktBytesSent = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "pkt_bytes_sent_total",
-			Help:      "Number of packets bytes sent.",
-		},
-		[]string{"intf"},
-	)
-	FramesRecv = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frames_recv_total",
-			Help:      "Number of frames received.",
-		},
-		[]string{"IA"},
-	)
-	FramesSent = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frames_sent_total",
-			Help:      "Number of frames sent.",
-		},
-		[]string{"IA"},
-	)
-	FrameBytesRecv = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frame_bytes_recv_total",
-			Help:      "Number of frame bytes received.",
-		},
-		[]string{"IA"},
-	)
-	FrameBytesSent = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frame_bytes_sent_total",
-			Help:      "Number of frame bytes sent.",
-		},
-		[]string{"IA"},
-	)
-	FrameDiscardEvents = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frame_discard_events_total",
-			Help:      "Number of frame-discard events.",
-		})
-	FramesDiscarded = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frames_discarded_total",
-			Help:      "Number of frames discarded",
-		})
-	FramesTooOld = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frames_too_old_total",
-			Help:      "Number of frames that are too old",
-		})
-	FramesDuplicated = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "sig",
-			Name:      "frames_duplicated_total",
-			Help:      "Number of duplicate frames",
-		})
+	PktsRecv           *prometheus.CounterVec
+	PktsSent           *prometheus.CounterVec
+	PktBytesRecv       *prometheus.CounterVec
+	PktBytesSent       *prometheus.CounterVec
+	FramesRecv         *prometheus.CounterVec
+	FramesSent         *prometheus.CounterVec
+	FrameBytesRecv     *prometheus.CounterVec
+	FrameBytesSent     *prometheus.CounterVec
+	FrameDiscardEvents prometheus.Counter
+	FramesDiscarded    prometheus.Counter
+	FramesTooOld       prometheus.Counter
+	FramesDuplicated   prometheus.Counter
 )
 
 // Ensure all metrics are registered.
-func init() {
-	prometheus.MustRegister(PktsRecv)
-	prometheus.MustRegister(PktsSent)
-	prometheus.MustRegister(PktBytesRecv)
-	prometheus.MustRegister(PktBytesSent)
-	prometheus.MustRegister(FramesRecv)
-	prometheus.MustRegister(FramesSent)
-	prometheus.MustRegister(FrameBytesRecv)
-	prometheus.MustRegister(FrameBytesSent)
-	prometheus.MustRegister(FrameDiscardEvents)
-	prometheus.MustRegister(FramesDiscarded)
-	prometheus.MustRegister(FramesTooOld)
-	prometheus.MustRegister(FramesDuplicated)
+func Init(elem string) {
+	namespace := "sig"
+	constLabels := prometheus.Labels{"elem": elem}
+	intfLabels := []string{"intf"}
+	iaLabels := []string{"IA"}
+
+	// Some closures to reduce boiler-plate.
+	newC := func(name, help string) prometheus.Counter {
+		v := prom.NewCounter(namespace, "", name, help, constLabels)
+		prometheus.MustRegister(v)
+		return v
+	}
+	newCVec := func(name, help string, lNames []string) *prometheus.CounterVec {
+		v := prom.NewCounterVec(namespace, "", name, help, constLabels, lNames)
+		prometheus.MustRegister(v)
+		return v
+	}
+	// FIXME(kormat): these metrics should probably have more informative labels
+	PktsRecv = newCVec("pkts_recv_total", "Number of packets received.", intfLabels)
+	PktsSent = newCVec("pkts_sent_total", "Number of packets sent.", intfLabels)
+	PktBytesRecv = newCVec("pkt_bytes_recv_total", "Number of packet bytes received.", intfLabels)
+	PktBytesSent = newCVec("pkt_bytes_sent_total", "Number of packet bytes sent.", intfLabels)
+	FramesRecv = newCVec("frames_recv_total", "Number of frames received.", iaLabels)
+	FramesSent = newCVec("frames_sent_total", "Number of frames sent.", iaLabels)
+	FrameBytesRecv = newCVec("frame_bytes_recv_total", "Number of frame bytes received.", iaLabels)
+	FrameBytesSent = newCVec("frame_bytes_sent_total", "Number of frame bytes sent.", iaLabels)
+	FrameDiscardEvents = newC("frame_discard_events_total", "Number of frame-discard events.")
+	FramesDiscarded = newC("frames_discarded_total", "Number of frames discarded.")
+	FramesTooOld = newC("frames_too_old_total", "Number of frames that are too old.")
+	FramesDuplicated = newC("frames_duplicated_total", "Number of duplicate frames.")
 }
 
 var servers map[string]io.Closer

--- a/go/sig/sig.go
+++ b/go/sig/sig.go
@@ -48,6 +48,7 @@ var (
 )
 
 var (
+	id             = flag.String("id", "", "Element ID (Required. E.g. 'sig4-21-9')")
 	config         = flag.String("config", "", "optional config file")
 	cli            = flag.Bool("cli", false, "enable interactive console")
 	port           = flag.Int("encapport", ExternalIngressPort, "encapsulation data port")
@@ -61,10 +62,15 @@ var (
 
 func main() {
 	flag.Parse()
-	liblog.Setup("sig")
+	if *id == "" {
+		log.Crit("No element ID specified")
+		os.Exit(1)
+	}
+	liblog.Setup(*id)
 	defer liblog.PanicLog()
 	setupSignals()
 
+	metrics.Init(*id)
 	// Export prometheus metrics.
 	if err := metrics.Start(); err != nil {
 		log.Error("Unable to export prometheus metrics", "err", err)

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -816,7 +816,8 @@ class SupervisorGenerator(object):
         entries = []
         for k, v in topo.get("BorderRouters", {}).items():
             conf_dir = os.path.join(base, k)
-            entries.append((k, [cmd, "-id", k, "-confd", conf_dir, "-prom", _prom_addr_br(v)]))
+            entries.append((k, [cmd, "-id=%s" % k, "-confd=%s" % conf_dir,
+                                "-prom=%s" % _prom_addr_br(v)]))
         return entries
 
     def _sciond_entry(self, name, conf_dir):


### PR DESCRIPTION
By making metrics be configured on start rather than at compile time, we
can easily include things like the element ID in all labels a process
exports. It also removes a lot of boiler-plate.

Note: this change adds a mandatory -id flag to the sig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1221)
<!-- Reviewable:end -->
