### PR TITLE
Fix a memory leak in br/ringbuf.

### DIFF
--- a/go/border/io.go
+++ b/go/border/io.go
@@ -86,6 +86,8 @@ Top:
 			bytesRecv.Add(float64(length))
 			pktRecvSizes.Observe(float64(length))
 			s.Ring.Write(ringbuf.EntryList{pkts[i]}, true)
+			// Clear RtrPkt reference
+			pkts[i] = nil
 		}
 	}
 }
@@ -128,6 +130,8 @@ func (r *Router) posixOutput(s *rctx.Sock, _, stopped chan struct{}) {
 		End:
 			// Release inner RtrPkt entry
 			rp.Release()
+			// Clear EgressRtrPkt reference
+			epkts[i] = nil
 		}
 	}
 }

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -113,6 +113,7 @@ func (r *Router) handleSock(s *rctx.Sock, stop, stopped chan struct{}) {
 			r.processPacket(rp)
 			metrics.PktProcessTime.Add(monotime.Since(rp.TimeIn).Seconds())
 			rp.Release()
+			pkts[i] = nil
 		}
 	}
 }

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -39,7 +39,7 @@ import (
 
 // pktBufSize is the maxiumum size of a packet buffer.
 // FIXME(kormat): this should be reduced as soon as we respect the actual link MTU.
-const pktBufSize = 1 << 16
+const pktBufSize = 9 * 1024
 
 // callbacks is an anonymous struct used for functions supplied by the router
 // for various processing tasks.
@@ -205,8 +205,10 @@ type extnIdx struct {
 // Fields that are assumed to be overwritten (and hence aren't reset):
 // Id, TimeIn, CmnHdr, Logger
 func (rp *RtrPkt) Reset() {
+	rp.Id = ""
 	// Reset the length of the buffer to the max size.
 	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+	rp.TimeIn = 0
 	rp.DirFrom = rcmn.DirUnset
 	rp.DirTo = rcmn.DirUnset
 	rp.Ingress.Dst = nil
@@ -214,6 +216,7 @@ func (rp *RtrPkt) Reset() {
 	rp.Ingress.IfIDs = nil
 	rp.Ingress.LocIdx = -1
 	rp.Egress = rp.Egress[:0]
+	// CmnHdr doesn't contain any references.
 	rp.IncrementedPath = false
 	rp.idxs = packetIdxs{}
 	rp.dstIA = nil
@@ -232,6 +235,7 @@ func (rp *RtrPkt) Reset() {
 	rp.pld = nil
 	rp.hooks = hooks{}
 	rp.SCMPError = false
+	rp.Logger = nil
 	rp.Ctx = nil
 	rp.refCnt = 1
 	rp.Free = nil

--- a/go/lib/ringbuf/ringbuf.go
+++ b/go/lib/ringbuf/ringbuf.go
@@ -17,6 +17,8 @@ package ringbuf
 import (
 	"sync"
 
+	//log "github.com/inconshreveable/log15"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -140,10 +142,18 @@ func (r *Ring) write(entries EntryList) {
 
 func (r *Ring) read(entries EntryList) {
 	n := copy(entries, r.entries[r.readIndex:])
+	// Remove references that were just read.
+	for i := r.readIndex; i < r.readIndex+n; i++ {
+		r.entries[i] = nil
+	}
 	r.readIndex += n
 	// Wraparound if we need to read more slice references
 	if n < len(entries) {
 		n = copy(entries[n:], r.entries)
+		// Remove references that were just read.
+		for i := 0; i < n; i++ {
+			r.entries[i] = nil
+		}
 		// Reset read index
 		r.readIndex = n
 	}


### PR DESCRIPTION
When a packet was created by the BR (e.g. via `genPkt()`), references to
this packet would be retained in the egress ringbuf's until overwritten,
preventing it from being GC'd. Over time, this would lead to 1024 64KiB
packet references been kept, causing the RSS to balloon up to a maximum
size of ~200MiB.

This change:
- Clears references from a ringbuf on `Read()`
- Clears references from read/write slices passed to a ringbuf.

Also:
- Reduce the packet buffer size to handle jumbo frames (a 7x reduction),
  as there is currently no reason to support packet sizes beyond that.
- Make RtrPkt.Reset() slightly more comprehensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1224)
<!-- Reviewable:end -->
