### PR TITLE
Waiting time to be a float instead of int

### DIFF
--- a/tools/pktgen.py
+++ b/tools/pktgen.py
@@ -120,7 +120,7 @@ def main():
                         help='Number of packets to send. 0 means unlimited.')
     parser.add_argument('-s', '--size', default=0, type=int,
                         help='Size of packets to send. 0 means use the MTU of the path.')
-    parser.add_argument('-w', '--wait', default=0, type=int,
+    parser.add_argument('-w', '--wait', default=0, type=float,
                         help='Wait time in milliseconds after a packet has been sent.')
     parser.add_argument('-r', '--random', action='store_true',
                         help='Run with randomized wait time and packet size')


### PR DESCRIPTION
Increases the possibility to test for higher loads since the packet size is limited by the MTU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1225)
<!-- Reviewable:end -->
