### PR TITLE
Correctly reset rpkt buffer

### DIFF
--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -107,7 +107,7 @@ func (rp *RtrPkt) addL4(l4h l4.L4Header) *common.Error {
 	rp.L4Type = l4h.L4Type()
 	rp.l4 = l4h
 	// Reset buffer to full size
-	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+	rp.Raw = rp.Raw[:cap(rp.Raw)]
 	// Write L4 header into buffer
 	if err := rp.l4.Write(rp.Raw[rp.idxs.l4:]); err != nil {
 		return err
@@ -142,7 +142,7 @@ func (rp *RtrPkt) SetPld(pld common.Payload) *common.Error {
 	var plen int
 	if rp.pld != nil {
 		// Reset buffer to full size
-		rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+		rp.Raw = rp.Raw[:cap(rp.Raw)]
 		// Write payload into buffer
 		var err *common.Error
 		plen, err = rp.pld.Write(rp.Raw[rp.idxs.pld:])

--- a/go/border/rpkt/payload_ctrl.go
+++ b/go/border/rpkt/payload_ctrl.go
@@ -37,7 +37,7 @@ func (rp *RtrPkt) parseCtrlPayload() (HookResult, common.Payload, *common.Error)
 // updates the layer 4 and common headers accordingly.
 func (rp *RtrPkt) updateCtrlPld() *common.Error {
 	// Reset buffer to full size
-	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+	rp.Raw = rp.Raw[:cap(rp.Raw)]
 	// Write payload to buffer
 	plen, err := rp.pld.Write(rp.Raw[rp.idxs.pld:])
 	if err != nil {

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -207,7 +207,7 @@ type extnIdx struct {
 func (rp *RtrPkt) Reset() {
 	rp.Id = ""
 	// Reset the length of the buffer to the max size.
-	rp.Raw = rp.Raw[:cap(rp.Raw)-1]
+	rp.Raw = rp.Raw[:cap(rp.Raw)]
 	rp.TimeIn = 0
 	rp.DirFrom = rcmn.DirUnset
 	rp.DirTo = rcmn.DirUnset


### PR DESCRIPTION
The packet buffer in the a `RtrPkt` was not reset correctly after use. It didn't bite us, because we were doing it wrong consistently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1226)
<!-- Reviewable:end -->
