### PR TITLE
Add demo/connetivity tool for SCION in Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ bin/dispatcher
 bin/logdog
 bin/sig
 bin/topopruner
+bin/echo
 c/dispatcher/dispatcher
 c/lib/scion/checksum_bench
 c/ssp/test/*client

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -77,9 +77,6 @@ func AddrFromString(s string) (*Addr, error) {
 	if err != nil {
 		return nil, common.NewError("Invalid port string", "port", parts["port"], "err", err)
 	}
-	if port == 0 {
-		return nil, common.NewError("Invalid port number", "port", parts["port"])
-	}
 	return &Addr{IA: ia, Host: addr.HostFromIP(ip), L4Port: uint16(port)}, nil
 }
 

--- a/go/lib/snet/addr_test.go
+++ b/go/lib/snet/addr_test.go
@@ -64,7 +64,6 @@ func Test_AddrFromString(t *testing.T) {
 		{address: "1-20,[abc]:12", isError: true},
 		{address: "1-2]:14,[1.2.3.4]", isError: true},
 		{address: "1-1,[1.2.3.4]:70000", isError: true},
-		{address: "1-1,[1.2.3.4]:0", isError: true},
 		{address: "", isError: true},
 		{address: "1-1,[1.2.3.4]:80",
 			ia:   "1-1",

--- a/go/tools/echo/Readme.md
+++ b/go/tools/echo/Readme.md
@@ -1,0 +1,15 @@
+To run an echo connectivity test on the default topology from AS1-19 to AS2-25,
+first make sure the infrastructure is running.
+
+Then, start the server using:
+```
+go run echo.go -mode server -local 2-25,[127.0.0.1]:40002 -sciond /run/shm/sciond/sd2-25.sock \
+	-dispatcher /run/shm/dispatcher/default.sock -count 10
+```
+
+Finally, start the client using:
+```
+go run echo.go -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:40001 \
+	-sciond /run/shm/sciond/sd1-19.sock -dispatcher /run/shm/dispatcher/default.sock \
+	-count 10
+```

--- a/go/tools/echo/Readme.md
+++ b/go/tools/echo/Readme.md
@@ -9,7 +9,7 @@ go run echo.go -mode server -local 2-25,[127.0.0.1]:40002 -sciond /run/shm/scion
 
 Finally, start the client using:
 ```
-go run echo.go -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:40001 \
+go run echo.go -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:0 \
 	-sciond /run/shm/sciond/sd1-19.sock -dispatcher /run/shm/dispatcher/default.sock \
 	-count 10
 ```

--- a/go/tools/echo/Readme.md
+++ b/go/tools/echo/Readme.md
@@ -3,13 +3,10 @@ first make sure the infrastructure is running.
 
 Then, start the server using:
 ```
-go run echo.go -mode server -local 2-25,[127.0.0.1]:40002 -sciond /run/shm/sciond/sd2-25.sock \
-	-dispatcher /run/shm/dispatcher/default.sock -count 10
+go run echo.go -mode server -local 2-25,[127.0.0.1]:40002 -count 10
 ```
 
 Finally, start the client using:
 ```
-go run echo.go -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:0 \
-	-sciond /run/shm/sciond/sd1-19.sock -dispatcher /run/shm/dispatcher/default.sock \
-	-count 10
+go run echo.go -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:0 -count 10
 ```

--- a/go/tools/echo/echo.go
+++ b/go/tools/echo/echo.go
@@ -61,7 +61,7 @@ func init() {
 func main() {
 	validateFlags()
 	liblog.Setup(*id)
-	defer liblog.PanicLog()
+	defer liblog.LogPanicAndExit()
 	switch *mode {
 	case "client":
 		Client()

--- a/go/tools/echo/echo.go
+++ b/go/tools/echo/echo.go
@@ -37,7 +37,7 @@ const (
 )
 
 func GetDefaultSCIONDPath(ia *addr.ISD_AS) string {
-	return fmt.Sprintf("/run/shm/sd%v.sock", ia)
+	return fmt.Sprintf("/run/shm/sciond/sd%v.sock", ia)
 }
 
 var (
@@ -112,11 +112,13 @@ func Client() {
 		before := time.Now()
 		written, err := conn.Write([]byte(ReqMsg))
 		if err != nil {
-			LogFatal("Unable to write", "err", err)
+			log.Error("Unable to write", "err", err)
+			continue
 		}
 		if written != len(ReqMsg) {
-			LogFatal("Wrote incomplete message", "expected", len(ReqMsg),
+			log.Error("Wrote incomplete message", "expected", len(ReqMsg),
 				"actual", written)
+			continue
 		}
 
 		// Receive echo reply with timeout
@@ -125,6 +127,7 @@ func Client() {
 		conn.SetDeadline(time.Time{})
 		if err != nil {
 			log.Error("Unable to read", "err", err)
+			continue
 		}
 		if string(b[:read]) != ReplyMsg {
 			fmt.Println("Received bad message", "expected", ReplyMsg,
@@ -133,7 +136,7 @@ func Client() {
 		after := time.Now()
 		elapsed := after.Sub(before)
 		fmt.Printf("%d bytes from %v: seq=%d time=%s\n", read, &remote, i, elapsed)
-		time.Sleep((*interval) - elapsed)
+		time.Sleep(*interval)
 	}
 }
 

--- a/go/tools/echo/echo.go
+++ b/go/tools/echo/echo.go
@@ -29,12 +29,11 @@ import (
 )
 
 const (
-	DefaultDispatcherPath = "/run/shm/dispatcher/default.sock"
-	DefaultInterval       = 2 * time.Second
-	DefaultTimeout        = 2 * time.Second
-	MaxEchoes             = 1 << 16
-	ReqMsg                = "ping!"
-	ReplyMsg              = "pong!"
+	DefaultInterval = 2 * time.Second
+	DefaultTimeout  = 2 * time.Second
+	MaxEchoes       = 1 << 16
+	ReqMsg          = "ping!"
+	ReplyMsg        = "pong!"
 )
 
 func GetDefaultSCIONDPath(ia *addr.ISD_AS) string {
@@ -47,10 +46,10 @@ var (
 	id         = flag.String("id", "echo", "Element ID")
 	mode       = flag.String("mode", "client", "Run in client or server mode")
 	sciond     = flag.String("sciond", "", "Path to sciond socket")
-	dispatcher = flag.String("dispatcher", "", "Path to dispatcher socket")
-	count      = flag.Int("count", 0,
-		fmt.Sprintf("Number of echoes, between 0 and %d; "+
-			"a count of 0 means infinity", MaxEchoes))
+	dispatcher = flag.String("dispatcher", "/run/shm/dispatcher/default.sock",
+		"Path to dispatcher socket")
+	count = flag.Int("count", 0,
+		fmt.Sprintf("Number of echoes, between 0 and %d; a count of 0 means infinity", MaxEchoes))
 	interval = flag.Duration("interval", DefaultInterval, "time between echoes")
 )
 

--- a/go/tools/echo/echo.go
+++ b/go/tools/echo/echo.go
@@ -1,0 +1,204 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Simple echo application for SCION connectivity tests.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"time"
+
+	log15 "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/scion/go/lib/snet"
+)
+
+const (
+	DefaultInterval = 2 * time.Second
+	DefaultTimeout  = 2 * time.Second
+	MaxEchoes       = 1 << 16
+	ReqMsg          = "ping!"
+	ReplyMsg        = "pong!"
+)
+
+var (
+	local      snet.Addr
+	remote     snet.Addr
+	mode       = flag.String("mode", "client", "Run in client or server mode")
+	sciond     = flag.String("sciond", "", "(Mandatory) path to sciond socket")
+	dispatcher = flag.String("dispatcher", "", "(Mandatory) path to dispatcher socket")
+	count      = flag.Int("count", 0,
+		fmt.Sprintf("Number of echoes, between 0 and %d; "+
+			"a count of 0 means infinity", MaxEchoes))
+	interval = flag.Duration("interval", DefaultInterval, "time between echoes")
+)
+
+func init() {
+	flag.Var((*Address)(&local), "local", "(Mandatory) address to listen on")
+	flag.Var((*Address)(&remote), "remote", "(Mandatory for clients) address to connect to")
+}
+
+func main() {
+	validateFlags()
+
+	// Disable logging
+	log15.Root().SetHandler(log15.StreamHandler(ioutil.Discard, log15.LogfmtFormat()))
+
+	switch *mode {
+	case "client":
+		Client()
+	case "server":
+		Server()
+	}
+}
+
+func validateFlags() {
+	flag.Parse()
+
+	if *mode != "client" && *mode != "server" {
+		log.Fatal("Unknown mode, must be either 'client' or 'server'")
+	}
+
+	if *mode == "client" && remote.Host == nil {
+		log.Fatal("Error: missing remote address")
+	}
+
+	if *mode == "server" && local.Host == nil {
+		log.Fatal("Error: missing local address")
+	}
+
+	if *sciond == "" {
+		log.Fatal("Error: missing path to sciond")
+	}
+
+	if *dispatcher == "" {
+		log.Fatal("Error: missing path to dispatcher")
+	}
+
+	if *count < 0 || *count > MaxEchoes {
+		log.Fatal(fmt.Sprintf("Error: invalid count, must be between 0 and %d", MaxEchoes))
+	}
+}
+
+// Client dials to a remote SCION address and repeatedly sends echo request
+// messages while receiving echo reply messages. For each successful echo, a
+// message with the round trip time is printed. On errors (including timeouts),
+// the Client exits.
+func Client() {
+	// Initialize default SCION networking context
+	err := snet.Init(local.IA, *sciond, *dispatcher)
+	if err != nil {
+		log.Fatal("Error: unable to initialize SCION network")
+	}
+	fmt.Println("SCION network successfully initialized.")
+
+	// Connect to remote address. Note that currently the SCION library
+	// does not support automatic binding to local addresses, so the
+	// local IP address and port need to be supplied explicitly
+	conn, err := snet.DialSCION("udp4", &local, &remote)
+	if err != nil {
+		log.Fatal("Error: unable to dial", err)
+	}
+	fmt.Printf("Connected to %v.\n", &remote)
+
+	b := make([]byte, 1<<12)
+	for i := 0; i < *count || *count == 0; i++ {
+		before := time.Now()
+
+		// Send echo request to destination
+		written, err := conn.Write([]byte(ReqMsg))
+		if err != nil {
+			log.Fatal("Error: unable to write", err)
+		}
+		if written != len(ReqMsg) {
+			log.Fatal("Error: wrote incomplete message")
+		}
+
+		// Receive echo reply with timeout
+		conn.SetDeadline(time.Now().Add(DefaultTimeout))
+		read, err := conn.Read(b)
+		conn.SetDeadline(time.Time{})
+		if err != nil {
+			log.Fatal("Error: unable to read", err)
+		}
+		if string(b[:read]) != ReplyMsg {
+			fmt.Println("Received bad message", "expected", ReplyMsg,
+				"actual", string(b[:read]))
+		}
+		after := time.Now()
+
+		elapsed := after.Sub(before)
+		fmt.Printf("%d bytes from %v: seq=%d time=%s\n", read, &remote, i, elapsed)
+
+		time.Sleep((*interval) - elapsed)
+	}
+}
+
+// Server listens on a SCION address and replies to any echo request messages.
+// On any error, the server exits.
+func Server() {
+	// Initialize default SCION networking context
+	err := snet.Init(local.IA, *sciond, *dispatcher)
+	if err != nil {
+		log.Fatal("Error: unable to initialize SCION network")
+	}
+	fmt.Println("SCION network successfully initialized.")
+
+	// Listen on SCION address
+	conn, err := snet.ListenSCION("udp4", &local)
+	if err != nil {
+		log.Fatal("Error: unable to listen", err)
+	}
+	fmt.Printf("Listening to %v.\n", &local)
+
+	b := make([]byte, 1<<12)
+	for i := 0; i < *count || *count == 0; i++ {
+		// Receive echo request
+		read, senderAddr, err := conn.ReadFrom(b)
+		if err != nil {
+			log.Fatal("Error: unable to read", err)
+		}
+		if string(b[:read]) != ReqMsg {
+			fmt.Println("Received bad message", "expected", ReqMsg,
+				"actual", string(b[:read]))
+		}
+
+		// Send echo reply
+		written, err := conn.WriteTo([]byte(ReplyMsg), senderAddr)
+		if err != nil {
+			log.Fatal("Error: unable to write", err)
+		}
+		if written != len(ReplyMsg) {
+			log.Fatal("Error: wrote incomplete message")
+		}
+	}
+}
+
+type Address snet.Addr
+
+func (a *Address) String() string {
+	return (*snet.Addr)(a).String()
+}
+
+func (a *Address) Set(s string) error {
+	other, err := snet.AddrFromString(s)
+	if err != nil {
+		return err
+	}
+	a.IA, a.Host, a.L4Port = other.IA, other.Host, other.L4Port
+	return nil
+}

--- a/go/tools/echo/echo.go
+++ b/go/tools/echo/echo.go
@@ -108,6 +108,10 @@ func Client() {
 
 	b := make([]byte, 1<<12)
 	for i := 0; i < *count || *count == 0; i++ {
+		if i != 0 {
+			time.Sleep(*interval)
+		}
+
 		// Send echo request to destination
 		before := time.Now()
 		written, err := conn.Write([]byte(ReqMsg))
@@ -136,7 +140,6 @@ func Client() {
 		after := time.Now()
 		elapsed := after.Sub(before)
 		fmt.Printf("%d bytes from %v: seq=%d time=%s\n", read, &remote, i, elapsed)
-		time.Sleep(*interval)
 	}
 }
 


### PR DESCRIPTION
This PR adds a simple tool, written in Go, for echo request/reply connectivity tests.

This tool:
- showcases a simple use of the new SCION connection library;
- serves as a starting point for SCION end to end integration tests;
- can be used to test connectivity between any pair of ASes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1233)
<!-- Reviewable:end -->
