### PR TITLE
Add simple path queries to path resolver

### DIFF
--- a/go/lib/pathmgr/defines.go
+++ b/go/lib/pathmgr/defines.go
@@ -31,6 +31,8 @@ const (
 	reconnectInterval = 3 * time.Second
 )
 
+type PathList []*sciond.PathReplyEntry
+
 // query contains the context needed to issue and update a query
 type query struct {
 	src, dst *addr.ISD_AS
@@ -47,8 +49,8 @@ type SyncPaths struct {
 }
 
 // Overwrite Load to avoid external type assertions
-func (sp *SyncPaths) Load() []*sciond.PathReplyEntry {
-	return sp.Value.Load().([]*sciond.PathReplyEntry)
+func (sp *SyncPaths) Load() PathList {
+	return sp.Value.Load().(PathList)
 }
 
 // sciondState is used to track the health of the connection to SCIOND
@@ -70,4 +72,8 @@ func (state sciondState) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+func IAKey(src, dst *addr.ISD_AS) string {
+	return src.String() + "." + dst.String()
 }

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -51,7 +51,7 @@ import (
 var (
 	// Time between checks for stale path references
 	pathCleanupInterval = time.Minute
-	// TTL for pointers to Path Resolver managed paths
+	// TTL for pointers to Path Resolver cached paths
 	pathTTL = 30 * time.Minute
 )
 
@@ -120,7 +120,7 @@ func (r *PR) Query(src, dst *addr.ISD_AS) PathList {
 	q := query{src: src, dst: dst}
 	pathList := r.lookup(q)
 	if pathList == nil {
-		// We didn't find any paths due to an error
+		// We didn't find any paths
 		return nil
 	}
 	// We found paths, so we cache them
@@ -214,7 +214,7 @@ func (r *PR) lookup(q query) PathList {
 		log.Error("Unable to find path", "src", q.src, "dst", q.dst,
 			"code", reply.ErrorCode)
 
-		// NB: keep the old path if lookup failed
+		// On error we return immediately, without changing any paths
 		return nil
 	}
 

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -213,8 +213,6 @@ func (r *PR) lookup(q query) PathList {
 		// SCIOND internal error
 		log.Error("Unable to find path", "src", q.src, "dst", q.dst,
 			"code", reply.ErrorCode)
-
-		// On error we return immediately, without changing any paths
 		return nil
 	}
 

--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -34,7 +34,7 @@ var (
 
 // SCION test infrastructure needs to be running for this example.
 func ExamplePR() {
-	// Run with "go test -tags=infrarunning -args -srcIA 1-11 -dstIA 1-13".
+	// Run with "go test -tags=infrarunning -args -srcIA 1-14 -dstIA 2-21".
 	var cerr *common.Error
 	src, cerr := addr.IAFromString(*srcStr)
 	if cerr != nil {

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -178,15 +178,11 @@ func (c *Conn) Write(b []byte) (int, error) {
 func (c *Conn) write(b []byte, raddr *Addr) (int, error) {
 	var path *spath.Path
 	var err error
-
 	pathEntry, err := c.selectPathEntry(raddr)
 	if err != nil {
-		return 0, common.NewError("Path error", "err", err)
+		return 0, err
 	}
-	if pathEntry == nil {
-		// No path information should be added to the packet
-		path = nil
-	} else {
+	if pathEntry != nil {
 		path = spath.New(pathEntry.Path.FwdPath)
 		// Create the path using initial IF/HF pointers
 		err = path.InitOffsets()
@@ -242,7 +238,6 @@ func (c *Conn) write(b []byte, raddr *Addr) (int, error) {
 func (c *Conn) selectPathEntry(raddr *Addr) (*sciond.PathReplyEntry, error) {
 	var err error
 	var pathList pathmgr.PathList
-
 	if c.laddr.IA.Eq(raddr.IA) {
 		// If src and dst are in the same AS, the path will be empty
 		return nil, nil
@@ -265,7 +260,7 @@ func (c *Conn) selectPathEntry(raddr *Addr) (*sciond.PathReplyEntry, error) {
 	}
 
 	if len(pathList) == 0 {
-		return nil, common.NewError("Path not found")
+		return nil, common.NewError("Path not found", "srcIA", c.laddr.IA, "dstIA", raddr.IA)
 	}
 	return pathList[0], nil
 }

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -46,7 +46,6 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
-	cache "github.com/patrickmn/go-cache"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
@@ -118,9 +117,9 @@ func (n *Network) DialSCION(network string, laddr, raddr *Addr) (*Conn, error) {
 		return nil, err
 	}
 	conn.raddr = raddr.Copy()
-	_, err = conn.getPaths(raddr)
+	conn.sp, err = n.pathResolver.Register(conn.laddr.IA, conn.raddr.IA)
 	if err != nil {
-		return nil, common.NewError("Path error", "err", err)
+		return nil, common.NewError("Unable to establish path", "err", err)
 	}
 	return conn, nil
 }
@@ -153,7 +152,6 @@ func (n *Network) ListenSCION(network string, laddr *Addr) (*Conn, error) {
 	conn := &Conn{
 		net:        network,
 		scionNet:   n,
-		pathMap:    cache.New(pathTTL, pathCleanupInterval),
 		recvBuffer: make(common.RawBytes, BufSize),
 		sendBuffer: make(common.RawBytes, BufSize)}
 


### PR DESCRIPTION
The SCION connection library can only get paths from the resolver by registering source and destination IAs for continuous monitoring. This is expensive, and should only be used for performance critical paths.

This extends the path resolver API with a new function for simple queries. It also moves all path information to the path resolver; this will allow us to put all revocation logic in the path resolver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1237)
<!-- Reviewable:end -->
