### PR TITLE
Added timeout support to reliable sock and sciond

### DIFF
--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -23,9 +23,7 @@ import (
 
 type ErrCtx fmt15.FCtx
 
-type ErrorData interface {
-	fmt.Stringer
-}
+type ErrorData interface{}
 
 var _ error = (*CError)(nil)
 

--- a/go/lib/sciond/infra_test.go
+++ b/go/lib/sciond/infra_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build infrarunning
+
+package sciond
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/netsec-ethz/scion/go/lib/util"
+)
+
+func TestRevNotification(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	Convey("Old revocations should return correct status code", t, func() {
+		asStruct, err := util.LoadASList("../../../gen/as_list.yml")
+		SoMsg("AS selection error", err, ShouldBeNil)
+
+		asList := append(asStruct.NonCore, asStruct.Core...)
+		SoMsg("AS selection len", len(asList), ShouldBeGreaterThan, 0)
+		localIA := asList[rand.Intn(len(asList))]
+
+		conn, err := Connect(fmt.Sprintf("/run/shm/sciond/sd%v.sock", localIA))
+		SoMsg("Connect error", err, ShouldBeNil)
+
+		reply, err := conn.RevNotificationFromRaw([]byte(token))
+		SoMsg("RevNotification error", err, ShouldBeNil)
+		SoMsg("Result", reply.Result, ShouldEqual, RevInvalid)
+	})
+}

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -36,6 +36,7 @@ import (
 	"github.com/patrickmn/go-cache"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/ctrl/path_mgmt"
 	"github.com/netsec-ethz/scion/go/lib/sock/reliable"
 	"github.com/netsec-ethz/scion/go/proto"
@@ -66,7 +67,17 @@ type Connector struct {
 // guaranteed to be fresh, as the returned connector caches ASInfo replies for ASInfoTTL time,
 // IFInfo replies for IFInfoTTL time and SVCInfo for SVCInfoTTL time.
 func Connect(socketName string) (*Connector, error) {
-	conn, err := reliable.Dial(socketName)
+	return ConnectTimeout(socketName, time.Duration(0))
+}
+
+// ConnectTimeout acts like Connect but takes a timeout.
+//
+// A timeout of 0 means infinite timeout.
+//
+// To check for timeout errors, type assert the returned error to *net.OpError and
+// call method Timeout().
+func ConnectTimeout(socketName string, timeout time.Duration) (*Connector, error) {
+	conn, err := reliable.DialTimeout(socketName, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +99,7 @@ func (c *Connector) nextID() uint64 {
 func (c *Connector) send(p *Pld) error {
 	raw, err := proto.PackRoot(p)
 	if err != nil {
-		return err
+		return tryExtractNetError(err)
 	}
 	_, err = c.conn.Write(raw)
 	return err
@@ -98,7 +109,7 @@ func (c *Connector) receive() (*Pld, error) {
 	p := &Pld{}
 	err := proto.ParseFromReader(p, proto.SCIONDMsg_TypeID, c.conn)
 	if err != nil {
-		return nil, err
+		return nil, tryExtractNetError(err)
 	}
 	return p, nil
 }
@@ -281,4 +292,31 @@ func (c *Connector) RevNotification(revInfo *path_mgmt.RevInfo) (*RevReply, erro
 // Close shuts down the connection to a SCIOND server.
 func (c *Connector) Close() error {
 	return c.conn.Close()
+}
+
+// SetDeadline sets a deadline associated with any SCIOND query. If underlying
+// protocol operations exceed the deadline, the queries return immediately with
+// an error.
+//
+// A zero value for t means queries will not time out.
+//
+// To check for exceeded deadlines, type assert the returned error to *net.OpError and
+// call method Timeout().
+//
+// Following a timeout error the underlying protocol to SCIOND is probably
+// desynchronized. Establishing a fresh connection to SCIOND is recommended.
+func (c *Connector) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+// If err embeds a net.Error, return only the embedded error
+func tryExtractNetError(err error) error {
+	cErr, ok := err.(*common.CError)
+	if ok {
+		netErr, ok := cErr.Data.(net.Error)
+		if ok {
+			return netErr
+		}
+	}
+	return err
 }

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -67,12 +67,12 @@ type Connector struct {
 // guaranteed to be fresh, as the returned connector caches ASInfo replies for ASInfoTTL time,
 // IFInfo replies for IFInfoTTL time and SVCInfo for SVCInfoTTL time.
 func Connect(socketName string) (*Connector, error) {
-	return ConnectTimeout(socketName, time.Duration(0))
+	return ConnectTimeout(socketName, time.Duration(-1))
 }
 
 // ConnectTimeout acts like Connect but takes a timeout.
 //
-// A timeout of 0 means infinite timeout.
+// A negative timeout means infinite timeout.
 //
 // To check for timeout errors, type assert the returned error to *net.OpError and
 // call method Timeout().

--- a/go/lib/sciond/sciond.goconvey
+++ b/go/lib/sciond/sciond.goconvey
@@ -1,0 +1,2 @@
+# Make tests panic if timeout exceeded
+-timeout=10s

--- a/go/lib/sciond/sciond_test.go
+++ b/go/lib/sciond/sciond_test.go
@@ -87,7 +87,8 @@ func TestAPITimeout(t *testing.T) {
 				before := time.Now()
 				reply, err := conn.Paths(dst, src, 5, PathReqFlags{})
 				after := time.Now()
-				SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second), before.Add(4*time.Second))
+				SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second),
+					before.Add(4*time.Second))
 
 				SoMsg("reply", reply, ShouldBeNil)
 				SoMsg("err underlying type", err, ShouldHaveSameTypeAs, expectedT)
@@ -102,7 +103,8 @@ func TestAPITimeout(t *testing.T) {
 				before := time.Now()
 				reply, err := conn.RevNotificationFromRaw([]byte(token))
 				after := time.Now()
-				SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second), before.Add(4*time.Second))
+				SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second),
+					before.Add(4*time.Second))
 
 				SoMsg("reply", reply, ShouldBeNil)
 				SoMsg("err underlying type", err, ShouldHaveSameTypeAs, expectedT)

--- a/go/lib/sciond/sciond_test.go
+++ b/go/lib/sciond/sciond_test.go
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build infrarunning
-
 package sciond
 
 import (
-	"fmt"
-	"math/rand"
+	"net"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/netsec-ethz/scion/go/lib/util"
+	"github.com/netsec-ethz/scion/go/lib/addr"
 )
 
 var (
@@ -63,21 +62,64 @@ var (
 		"\x88\x70\x27\x3a\x27\xef\xf7\x28\x51\xb3\x24\x04\x00\x00\x00\x00"
 )
 
-func TestRevNotification(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	Convey("Old revocations should return correct status code", t, func() {
-		asStruct, err := util.LoadASList("../../../gen/as_list.yml")
-		SoMsg("AS selection error", err, ShouldBeNil)
+func TestAPITimeout(t *testing.T) {
+	name := getRandFile()
+	Convey("Start dummy server", t, func() {
+		sock, err := net.Listen("unix", name)
+		SoMsg("err", err, ShouldBeNil)
+		Reset(func() {
+			sock.Close()
+		})
 
-		asList := append(asStruct.NonCore, asStruct.Core...)
-		SoMsg("AS selection len", len(asList), ShouldBeGreaterThan, 0)
-		localIA := asList[rand.Intn(len(asList))]
+		Convey("Connect to server", func() {
+			conn, err := ConnectTimeout(name, 0)
+			SoMsg("err", err, ShouldBeNil)
+			Reset(func() {
+				conn.Close()
+			})
 
-		conn, err := Connect(fmt.Sprintf("/run/shm/sciond/sd%v.sock", localIA))
-		SoMsg("Connect error", err, ShouldBeNil)
+			Convey("Path request should timeout", func() {
+				var expectedT *net.OpError
+				src, _ := addr.IAFromString("1-1")
+				dst, _ := addr.IAFromString("2-2")
+				conn.SetDeadline(time.Now().Add(3 * time.Second))
 
-		reply, err := conn.RevNotificationFromRaw([]byte(token))
-		SoMsg("RevNotification error", err, ShouldBeNil)
-		SoMsg("Result", reply.Result, ShouldEqual, RevInvalid)
+				before := time.Now()
+				reply, err := conn.Paths(dst, src, 5, PathReqFlags{})
+				after := time.Now()
+				SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second), before.Add(4*time.Second))
+
+				SoMsg("reply", reply, ShouldBeNil)
+				SoMsg("err underlying type", err, ShouldHaveSameTypeAs, expectedT)
+				opErr := err.(*net.OpError)
+				SoMsg("timeout", opErr.Timeout(), ShouldBeTrue)
+			})
+
+			Convey("Revocation notification should timeout", func() {
+				var expectedT *net.OpError
+				conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+				before := time.Now()
+				reply, err := conn.RevNotificationFromRaw([]byte(token))
+				after := time.Now()
+				SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second), before.Add(4*time.Second))
+
+				SoMsg("reply", reply, ShouldBeNil)
+				SoMsg("err underlying type", err, ShouldHaveSameTypeAs, expectedT)
+				opErr := err.(*net.OpError)
+				SoMsg("timeout", opErr.Timeout(), ShouldBeTrue)
+			})
+		})
 	})
+}
+
+func getRandFile() string {
+	testDir := "/tmp/reliable"
+	if _, err := os.Stat(testDir); os.IsNotExist(err) {
+		os.Mkdir(testDir, 0700)
+	}
+
+	r := uint32(time.Now().UnixNano() + int64(os.Getpid()))
+	suffix := strconv.Itoa(int(1e9 + r%1e9))[1:]
+	return testDir + "/unix." + suffix
 }

--- a/go/lib/sock/reliable/bench_test.go
+++ b/go/lib/sock/reliable/bench_test.go
@@ -1,0 +1,169 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reliable
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type SetupFunc func() interface{}
+type EndpointFunc func(*Conn, interface{})
+type TestFunc func(t *testing.T, expected interface{}, have interface{}) bool
+
+func setupFunc() interface{} {
+	return make([]byte, 1280)
+}
+
+func readFunc(conn *Conn, data interface{}) {
+	buffer := data.([]byte)
+	for j := 0; j < 1000; j++ {
+		_, err := conn.Read(buffer)
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			fmt.Printf("Error reading: %v\n", err)
+		}
+	}
+}
+
+func writeFunc(conn *Conn, data interface{}) {
+	buffer := data.([]byte)
+	for j := 0; j < 1000; j++ {
+		_, err := conn.Write(buffer)
+		if err != nil {
+			fmt.Printf("Error writing: %v\n", err)
+		}
+	}
+}
+
+func setupNFunc() interface{} {
+	msgs := make([]Msg, 1000)
+	for i := 0; i < 1000; i++ {
+		msgs[i].Buffer = make([]byte, 1280)
+	}
+	return msgs
+}
+
+func readNFunc(conn *Conn, data interface{}) {
+	msgs := data.([]Msg)
+	for readMsgs := 0; readMsgs < len(msgs); {
+		n, err := conn.ReadN(msgs[readMsgs:])
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			fmt.Printf("Error reading: %v\n", err)
+		}
+		readMsgs += n
+	}
+}
+
+func writeNFunc(conn *Conn, data interface{}) {
+	msgs := data.([]Msg)
+	for writtenMsgs := 0; writtenMsgs < len(msgs); {
+		n, err := conn.WriteN(msgs[writtenMsgs:])
+		if err != nil {
+			fmt.Printf("Error writing: %v\n", err)
+		}
+		writtenMsgs += n
+	}
+}
+
+// Run 1000 writes individually
+func BenchmarkReadWrite(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmark(b, setupFunc, readFunc, writeFunc)
+	}
+}
+
+func BenchmarkWriteRead(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmark(b, setupFunc, writeFunc, readFunc)
+	}
+}
+
+// Run 1000 writes as a single batch operation
+func BenchmarkReadNWriteN(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmark(b, setupNFunc, readNFunc, writeNFunc)
+	}
+}
+
+func BenchmarkWriteNReadN(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmark(b, setupNFunc, writeNFunc, readNFunc)
+	}
+}
+
+func benchmark(b *testing.B, setup SetupFunc, client EndpointFunc, server EndpointFunc) {
+	uAddr := make(chan string, 1)
+	// Launch server
+	go func() {
+		file := getRandFile()
+		lconn, err := Listen(file)
+		if err != nil {
+			b.Fatalf("Unable to listen err=%v", err)
+		}
+		uAddr <- file
+		conn, err := lconn.Accept()
+		if err != nil {
+			b.Fatalf("Unable to accept err=%v", err)
+		}
+		data := setup()
+		server(conn, data)
+		conn.Close()
+		lconn.Close()
+	}()
+
+	// Dial after we have the socket address
+	conn, err := DialTimeout(<-uAddr, time.Second)
+	if err != nil {
+		b.Fatalf("Unable to connect err=%v", err)
+	}
+	data := setup()
+	client(conn, data)
+	conn.Close()
+}
+
+func setupTestNFunc() interface{} {
+	rand.Seed(time.Now().UnixNano())
+	msgs := make([]Msg, 1000)
+	for i := 0; i < len(msgs); i++ {
+		msgs[i].Buffer = make([]byte, rand.Intn(1280))
+		for j := 0; j < len(msgs[i].Buffer); j++ {
+			msgs[i].Buffer[j] = byte(rand.Intn(256))
+		}
+	}
+	return msgs
+}
+
+func testNFunc(t *testing.T, expected interface{}, have interface{}) {
+	msgsX := expected.([]Msg)
+	msgsY := have.([]Msg)
+
+	Convey("Sent messages should match received messages", t, func() {
+		SoMsg("Messages slice length", len(msgsY), ShouldEqual, len(msgsX))
+		for i := 0; i < len(msgsX); i++ {
+			SoMsg(fmt.Sprintf("MSG%d", i)+" buffers",
+				msgsY[i].Buffer[:msgsY[i].Copied], ShouldResemble, msgsX[i].Buffer)
+		}
+	})
+}

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -95,22 +95,29 @@ type Conn struct {
 	recvWriteHead int
 }
 
+// DialTimeout acts like Dial but takes a timeout.
+//
+// A timeout of 0 means infinite timeout.
+//
+// To check for timeout errors, type assert the returned error to *net.OpError and
+// call method Timeout().
 func DialTimeout(address string, timeout time.Duration) (*Conn, error) {
-	c, err := net.DialTimeout("unix", address, timeout)
+	var err error
+	var c net.Conn
+	if timeout == 0 {
+		c, err = net.DialTimeout("unix", address, timeout)
+	} else {
+		c, err = net.Dial("unix", address)
+	}
 	if err != nil {
-		return nil, common.NewCError("Unable to connect", "address", address,
-			"err", err)
+		return nil, err
 	}
 	return newConn(c), nil
 }
 
 // Dial connects to the UNIX socket specified by address.
 func Dial(address string) (*Conn, error) {
-	c, err := net.Dial("unix", address)
-	if err != nil {
-		return nil, common.NewCError("Unable to connect", "address", address)
-	}
-	return newConn(c), nil
+	return DialTimeout(address, time.Duration(0))
 }
 
 func newConn(c net.Conn) *Conn {
@@ -121,16 +128,27 @@ func newConn(c net.Conn) *Conn {
 	}
 }
 
-// Register connects to a SCION Dispatcher's UNIX socket.
-// Future messages for address a in AS ia which arrive at the dispatcher can be read by
-// calling Read on the returned Conn structure.
-func Register(dispatcher string, ia *addr.ISD_AS, a AppAddr) (*Conn, uint16, error) {
+// RegisterTimeout acts like Register but takes a timeout.
+//
+// A timeout of 0 means infinite timeout.
+//
+// To check for timeout errors, type assert the returned error to *net.OpError and
+// call method Timeout().
+func RegisterTimeout(dispatcher string, ia *addr.ISD_AS, a AppAddr,
+	timeout time.Duration) (*Conn, uint16, error) {
 	if a.Addr.Type() == addr.HostTypeNone {
 		return nil, 0, common.NewCError("Cannot register with NoneType address")
 	}
-	conn, err := Dial(dispatcher)
+
+	deadline := time.Now().Add(timeout)
+	conn, err := DialTimeout(dispatcher, timeout)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	// If a timeout was specified, make reads and writes return if deadline exceeded
+	if timeout != 0 {
+		conn.SetDeadline(deadline)
 	}
 	request := make([]byte, regBaseHeaderLen+a.Addr.Size())
 	offset := 0
@@ -169,7 +187,17 @@ func Register(dispatcher string, ia *addr.ISD_AS, a AppAddr) (*Conn, uint16, err
 		return nil, 0, common.NewCError("Port mismatch when registering with dispatcher",
 			"expected", a.Port, "actual", replyPort)
 	}
+
+	// Disable deadline to not affect calling code
+	conn.SetDeadline(time.Time{})
 	return conn, replyPort, nil
+}
+
+// Register connects to a SCION Dispatcher's UNIX socket.
+// Future messages for address a in AS ia which arrive at the dispatcher can be read by
+// calling Read on the returned Conn structure.
+func Register(dispatcher string, ia *addr.ISD_AS, a AppAddr) (*Conn, uint16, error) {
+	return RegisterTimeout(dispatcher, ia, a, time.Duration(0))
 }
 
 // Read blocks until it reads the next framed message payload from conn and stores it in buf.

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -467,7 +467,7 @@ func Listen(laddr string) (*Listener, error) {
 func (listener *Listener) Accept() (*Conn, error) {
 	c, err := listener.UnixListener.Accept()
 	if err != nil {
-		return nil, common.NewCError("Unable to accept", "listener", listener)
+		return nil, err
 	}
 	return newConn(c), nil
 }

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -97,17 +97,17 @@ type Conn struct {
 
 // DialTimeout acts like Dial but takes a timeout.
 //
-// A timeout of 0 means infinite timeout.
+// A negative timeout means infinite timeout.
 //
 // To check for timeout errors, type assert the returned error to *net.OpError and
 // call method Timeout().
 func DialTimeout(address string, timeout time.Duration) (*Conn, error) {
 	var err error
 	var c net.Conn
-	if timeout == 0 {
-		c, err = net.DialTimeout("unix", address, timeout)
-	} else {
+	if timeout < 0 {
 		c, err = net.Dial("unix", address)
+	} else {
+		c, err = net.DialTimeout("unix", address, timeout)
 	}
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func DialTimeout(address string, timeout time.Duration) (*Conn, error) {
 
 // Dial connects to the UNIX socket specified by address.
 func Dial(address string) (*Conn, error) {
-	return DialTimeout(address, time.Duration(0))
+	return DialTimeout(address, time.Duration(-1))
 }
 
 func newConn(c net.Conn) *Conn {
@@ -130,7 +130,7 @@ func newConn(c net.Conn) *Conn {
 
 // RegisterTimeout acts like Register but takes a timeout.
 //
-// A timeout of 0 means infinite timeout.
+// A negative timeout means infinite timeout.
 //
 // To check for timeout errors, type assert the returned error to *net.OpError and
 // call method Timeout().

--- a/go/lib/sock/reliable/reliable.goconvey
+++ b/go/lib/sock/reliable/reliable.goconvey
@@ -1,0 +1,2 @@
+# Make tests panic if timeout exceeded
+-timeout=10s

--- a/go/lib/sock/reliable/reliable_test.go
+++ b/go/lib/sock/reliable/reliable_test.go
@@ -17,7 +17,6 @@ package reliable
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -27,199 +26,199 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
-	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/xtest"
 )
 
-type ExitData struct {
-	value []byte
-	err   error
-}
-
-type TestCase struct {
-	msg       string
-	ia        addr.ISD_AS
-	dst       AppAddr
-	want      []byte
-	timeoutOK bool
-}
-
-func Server(x chan ExitData, tc TestCase, sockName string, client func()) {
-	os.Remove(sockName)
-	defer os.Remove(sockName)
-	listener, err := Listen(sockName)
-	if err != nil {
-		x <- ExitData{err: err}
-		return
-	}
-
-	client()
-
-	conn, err := listener.Accept()
-	if err != nil {
-		x <- ExitData{err: err}
-		return
-	}
-
-	buf := make([]byte, len(tc.want))
-	_, err = io.ReadFull(conn.UnixConn, buf)
-	if err != nil {
-		x <- ExitData{err: err}
-		return
-	}
-
-	err = conn.Close()
-	if err != nil {
-		x <- ExitData{err: err}
-		return
-	}
-	x <- ExitData{value: buf}
-}
-
-func Client(x chan ExitData, tc TestCase, sockName string) {
-	conn, err := Dial(sockName)
-	if err != nil {
-		x <- ExitData{err: err}
-		return
-	}
-
-	_, err = conn.WriteTo([]byte(tc.msg), tc.dst)
-	if err != nil {
-		x <- ExitData{err: err}
-		return
-	}
-
-	// Do not close the connection or the server might not have time
-	// to get the data out
-	x <- ExitData{}
-}
-
-func ClientRegister(x chan ExitData, tc TestCase, sockName string) {
-	// The below returns with error because the server never replies before
-	// closing the connection, but we're not interested in testing this
-	// behavior
-	Register(sockName, &tc.ia, tc.dst)
-	x <- ExitData{}
-}
-
-func TestWriteTo(t *testing.T) {
-	nilAddr := addr.HostNone{}
-	testCases := []TestCase{
-		{msg: "", dst: AppAddr{Addr: nilAddr, Port: 0},
-			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 0}},
-		{msg: "test", dst: AppAddr{Addr: nilAddr, Port: 0},
-			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 4, 't', 'e', 's', 't'}},
-		{msg: "foo", dst: AppAddr{Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)), Port: 80},
-			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 1, 0, 0, 0, 3,
-				127, 0, 0, 1, 0, 80, 'f', 'o', 'o'}},
-		{msg: "bar", dst: AppAddr{Addr: addr.HostFromIP(net.IPv6loopback), Port: 80},
-			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 2, 0, 0, 0, 3,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-				0, 80, 'b', 'a', 'r'}}}
-
-	Convey("Client sending message to Server using WriteTo", t, func() {
-		Convey("Server should receive correct raw messages", func() {
-			for i, tc := range testCases {
-				Convey(fmt.Sprintf("Client sent message \"%v\"", tc.msg), func() {
-					sockName := getRandFile()
-
-					sc := make(chan ExitData, 1)
-					cc := make(chan ExitData, 1)
-					go Server(sc, tc, sockName, func() {
-						go Client(cc, tc, sockName)
-					})
-
-					var sData ExitData
-					select {
-					case sData = <-sc:
-					case <-time.After(3 * time.Second):
-						sData = ExitData{nil, common.NewCError("Server timed out")}
-					}
-					var cData ExitData
-					select {
-					case cData = <-cc:
-					case <-time.After(3 * time.Second):
-						cData = ExitData{nil, common.NewCError("Client timed out")}
-					}
-
-					prefix := fmt.Sprintf("WriteTo %d", i)
-					SoMsg(prefix+" server error", sData.err, ShouldBeNil)
-					SoMsg(prefix+" client error", cData.err, ShouldBeNil)
-					SoMsg(prefix+" server data", sData.value, ShouldResemble, tc.want)
-				})
-			}
-		})
-	})
-}
-
 func TestRegister(t *testing.T) {
-	nilAddr := addr.HostNone{}
-
-	testCases := []TestCase{
-		{ia: addr.ISD_AS{I: 1, A: 10}, dst: AppAddr{Addr: nilAddr, Port: 0},
-			want: nil, timeoutOK: true},
-		{ia: addr.ISD_AS{I: 2, A: 21},
-			dst: AppAddr{Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)), Port: 80},
+	testCases := []struct {
+		msg       string
+		ia        *addr.ISD_AS
+		dst       AppAddr
+		want      []byte
+		timeoutOK bool
+	}{
+		{
+			ia: &addr.ISD_AS{I: 1, A: 10},
+			dst: AppAddr{
+				Addr: addr.HostNone{},
+				Port: 0,
+			},
+			want: nil, timeoutOK: true,
+		}, {
+			ia: &addr.ISD_AS{I: 2, A: 21},
+			dst: AppAddr{
+				Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
+				Port: 80,
+			},
 			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 13,
-				3, 17, 0, 32, 0, 21, 0, 80, 1, 127, 0, 0, 1}, timeoutOK: false},
-		{ia: addr.ISD_AS{I: 2, A: 21},
+				3, 17, 0, 32, 0, 21, 0, 80, 1, 127, 0, 0, 1},
+			timeoutOK: false,
+		}, {
+			ia:  &addr.ISD_AS{I: 2, A: 21},
 			dst: AppAddr{Addr: addr.HostFromIP(net.IPv6loopback), Port: 80},
 			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 25,
 				3, 17, 0, 32, 0, 21, 0, 80, 2,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, timeoutOK: false}}
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			timeoutOK: false,
+		},
+	}
 
-	Convey("Client registering to SCIOND", t, func() {
-		Convey("SCIOND should receive correct raw messages", func() {
-			for i, tc := range testCases {
-				Convey(fmt.Sprintf("Client registered to %v, %v", tc.ia, tc.dst), func() {
-					sockName := getRandFile()
+	sockName := getRandFile()
+	Convey("Start server", t, func() {
+		listener, err := Listen(sockName)
+		SoMsg("listen err", err, ShouldBeNil)
+		SoMsg("listener sock", listener, ShouldNotBeNil)
+		listener.SetUnlinkOnClose(true)
 
-					sc := make(chan ExitData, 1)
-					cc := make(chan ExitData, 1)
-					go Server(sc, tc, sockName, func() {
-						go ClientRegister(cc, tc, sockName)
-					})
-
-					var sData ExitData
-					select {
-					case sData = <-sc:
-					case <-time.After(3 * time.Second):
-						if !tc.timeoutOK {
-							sData = ExitData{nil, common.NewCError("Server timed out")}
-						}
-					}
-					var cData ExitData
-					select {
-					case cData = <-cc:
-					case <-time.After(3 * time.Second):
-						cData = ExitData{nil, common.NewCError("Client timed out")}
-					}
-
-					prefix := fmt.Sprintf("Register %d", i)
-					SoMsg(prefix+" server error", sData.err, ShouldBeNil)
-					SoMsg(prefix+" client error", cData.err, ShouldBeNil)
-					SoMsg(prefix+" server data", sData.value, ShouldResemble, tc.want)
-				})
-			}
+		Reset(func() {
+			err := listener.Close()
+			SoMsg("listener close error", err, ShouldBeNil)
 		})
+
+		for _, tc := range testCases {
+			Convey(fmt.Sprintf("Client registers %v, %v", tc.ia, tc.dst), xtest.Parallel(
+				func(sc *xtest.SC) {
+					err := listener.SetDeadline(time.Now().Add(time.Second))
+					sc.SoMsg("listener deadline err", err, ShouldBeNil)
+
+					sconn, err := listener.Accept()
+					if tc.timeoutOK {
+						sc.SoMsg("accept err", err, ShouldNotBeNil)
+						return
+					}
+					sc.SoMsg("accept err", err, ShouldBeNil)
+					sc.SoMsg("server conn", sconn, ShouldNotBeNil)
+
+					// Read raw protocol data from underlying UNIX conn
+					buf := make([]byte, len(tc.want))
+					_, err = io.ReadFull(sconn.UnixConn, buf)
+					sc.SoMsg("server read err", err, ShouldBeNil)
+					sc.SoMsg("server data", buf, ShouldResemble, tc.want)
+
+					err = sconn.Close()
+					sc.SoMsg("server close", err, ShouldBeNil)
+				}, func(sc *xtest.SC) {
+					_, _, err := RegisterTimeout(sockName, tc.ia, tc.dst, time.Second)
+					if tc.timeoutOK {
+						sc.SoMsg("register err", err, ShouldNotBeNil)
+						return
+					}
+					// Expect EOF error because the mocked dispatcher never replies
+					sc.SoMsg("register err", err, ShouldEqual, io.EOF)
+				}),
+			)
+		}
+	})
+}
+
+func TestWriteTo(t *testing.T) {
+	testCases := []struct {
+		msg       string
+		ia        addr.ISD_AS
+		dst       AppAddr
+		want      []byte
+		timeoutOK bool
+	}{
+		{
+			msg: "",
+			dst: AppAddr{
+				Addr: addr.HostNone{},
+				Port: 0,
+			},
+			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 0},
+		}, {
+			msg: "test",
+			dst: AppAddr{
+				Addr: addr.HostNone{},
+				Port: 0,
+			},
+			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 4, 't', 'e', 's', 't'},
+		}, {
+			msg: "foo",
+			dst: AppAddr{
+				Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
+				Port: 80,
+			},
+			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 1, 0, 0, 0, 3,
+				127, 0, 0, 1, 0, 80, 'f', 'o', 'o'},
+		}, {
+			msg: "bar",
+			dst: AppAddr{
+				Addr: addr.HostFromIP(net.IPv6loopback),
+				Port: 80,
+			},
+			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 2, 0, 0, 0, 3,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+				0, 80, 'b', 'a', 'r'},
+		},
+	}
+
+	sockName := getRandFile()
+	Convey("Start server", t, func() {
+		listener, err := Listen(sockName)
+		SoMsg("listen err", err, ShouldBeNil)
+		SoMsg("listener sock", listener, ShouldNotBeNil)
+		listener.SetUnlinkOnClose(true)
+
+		Reset(func() {
+			err := listener.Close()
+			SoMsg("listener close error", err, ShouldBeNil)
+		})
+		for _, tc := range testCases {
+			Convey(fmt.Sprintf("Clients sends message %v", tc.msg), xtest.Parallel(
+				func(sc *xtest.SC) {
+					err := listener.SetDeadline(time.Now().Add(time.Second))
+					sc.SoMsg("listener deadline err", err, ShouldBeNil)
+
+					sconn, err := listener.Accept()
+					if tc.timeoutOK {
+						sc.SoMsg("accept err", err, ShouldNotBeNil)
+						return
+					}
+					sc.SoMsg("accept err", err, ShouldBeNil)
+
+					b := make([]byte, len(tc.want))
+					_, err = io.ReadFull(sconn.UnixConn, b)
+					sc.SoMsg("server read err", err, ShouldBeNil)
+					sc.SoMsg("server read msg", b, ShouldResemble, tc.want)
+
+					err = sconn.Close()
+					sc.SoMsg("server close", err, ShouldBeNil)
+				}, func(sc *xtest.SC) {
+					cconn, err := DialTimeout(sockName, time.Second)
+					sc.SoMsg("dial err", err, ShouldBeNil)
+
+					n, err := cconn.WriteTo([]byte(tc.msg), tc.dst)
+					sc.SoMsg("client write err", err, ShouldBeNil)
+					sc.SoMsg("client written bytes", n, ShouldEqual, len(tc.msg))
+
+					err = cconn.Close()
+					sc.SoMsg("client close", err, ShouldBeNil)
+				}),
+			)
+		}
 	})
 }
 
 func TestRegisterTimeout(t *testing.T) {
-	name := getRandFile()
+	sockName := getRandFile()
 	Convey("Start dummy server", t, func() {
-		sock, err := net.Listen("unix", name)
-		SoMsg("err", err, ShouldBeNil)
-		Reset(func() {
-			sock.Close()
-		})
+		listener, err := Listen(sockName)
+		SoMsg("listen err", err, ShouldBeNil)
+		SoMsg("listener sock", listener, ShouldNotBeNil)
+		listener.SetUnlinkOnClose(true)
 
+		Reset(func() {
+			err := listener.Close()
+			SoMsg("listener close error", err, ShouldBeNil)
+		})
 		Convey("Register to \"dispatcher\" returns timeout error", func() {
 			var expectedT *net.OpError
-			ia, _ := addr.IAFromString("1-10")
+			ia := &addr.ISD_AS{I: 1, A: 10}
 			appAddr := AppAddr{Addr: addr.HostFromIP(net.IPv4(1, 2, 3, 4)), Port: 0}
 
 			before := time.Now()
-			conn, port, err := RegisterTimeout(name, ia, appAddr, 3*time.Second)
+			conn, port, err := RegisterTimeout(sockName, ia, appAddr, 3*time.Second)
 			after := time.Now()
 			SoMsg("timing", after, ShouldHappenBetween, before.Add(2*time.Second), before.Add(4*time.Second))
 
@@ -230,187 +229,6 @@ func TestRegisterTimeout(t *testing.T) {
 			SoMsg("timeout", opErr.Timeout(), ShouldBeTrue)
 		})
 	})
-}
-
-type SetupFunc func() interface{}
-type EndpointFunc func(*Conn, interface{})
-type TestFunc func(t *testing.T, expected interface{}, have interface{}) bool
-
-func setupFunc() interface{} {
-	return make([]byte, 1280)
-}
-
-func readFunc(conn *Conn, data interface{}) {
-	buffer := data.([]byte)
-	for j := 0; j < 1000; j++ {
-		_, err := conn.Read(buffer)
-		if err == io.EOF {
-			return
-		}
-		if err != nil {
-			fmt.Printf("Error reading: %v\n", err)
-		}
-	}
-}
-
-func writeFunc(conn *Conn, data interface{}) {
-	buffer := data.([]byte)
-	for j := 0; j < 1000; j++ {
-		_, err := conn.Write(buffer)
-		if err != nil {
-			fmt.Printf("Error writing: %v\n", err)
-		}
-	}
-}
-
-func setupNFunc() interface{} {
-	msgs := make([]Msg, 1000)
-	for i := 0; i < 1000; i++ {
-		msgs[i].Buffer = make([]byte, 1280)
-	}
-	return msgs
-}
-
-func readNFunc(conn *Conn, data interface{}) {
-	msgs := data.([]Msg)
-	for readMsgs := 0; readMsgs < len(msgs); {
-		n, err := conn.ReadN(msgs[readMsgs:])
-		if err == io.EOF {
-			return
-		}
-		if err != nil {
-			fmt.Printf("Error reading: %v\n", err)
-		}
-		readMsgs += n
-	}
-}
-
-func writeNFunc(conn *Conn, data interface{}) {
-	msgs := data.([]Msg)
-	for writtenMsgs := 0; writtenMsgs < len(msgs); {
-		n, err := conn.WriteN(msgs[writtenMsgs:])
-		if err != nil {
-			fmt.Printf("Error writing: %v\n", err)
-		}
-		writtenMsgs += n
-	}
-}
-
-// Run 1000 writes individually
-func BenchmarkReadWrite(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		benchmark(b, setupFunc, readFunc, writeFunc)
-	}
-}
-
-func BenchmarkWriteRead(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		benchmark(b, setupFunc, writeFunc, readFunc)
-	}
-}
-
-// Run 1000 writes as a single batch operation
-func BenchmarkReadNWriteN(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		benchmark(b, setupNFunc, readNFunc, writeNFunc)
-	}
-}
-
-func BenchmarkWriteNReadN(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		benchmark(b, setupNFunc, writeNFunc, readNFunc)
-	}
-}
-
-func benchmark(b *testing.B, setup SetupFunc, client EndpointFunc, server EndpointFunc) {
-	uAddr := make(chan string, 1)
-	// Launch server
-	go func() {
-		file := getRandFile()
-		lconn, err := Listen(file)
-		if err != nil {
-			b.Fatalf("Unable to listen err=%v", err)
-		}
-		uAddr <- file
-		conn, err := lconn.Accept()
-		if err != nil {
-			b.Fatalf("Unable to accept err=%v", err)
-		}
-		data := setup()
-		server(conn, data)
-		conn.Close()
-		lconn.Close()
-	}()
-
-	// Dial after we have the socket address
-	conn, err := DialTimeout(<-uAddr, time.Second)
-	if err != nil {
-		b.Fatalf("Unable to connect err=%v", err)
-	}
-	data := setup()
-	client(conn, data)
-	conn.Close()
-}
-
-func setupTestNFunc() interface{} {
-	rand.Seed(time.Now().UnixNano())
-	msgs := make([]Msg, 1000)
-	for i := 0; i < len(msgs); i++ {
-		msgs[i].Buffer = make([]byte, rand.Intn(1280))
-		for j := 0; j < len(msgs[i].Buffer); j++ {
-			msgs[i].Buffer[j] = byte(rand.Intn(256))
-		}
-	}
-	return msgs
-}
-
-func testNFunc(t *testing.T, expected interface{}, have interface{}) {
-	msgsX := expected.([]Msg)
-	msgsY := have.([]Msg)
-
-	Convey("Sent messages should match received messages", t, func() {
-		SoMsg("Messages slice length", len(msgsY), ShouldEqual, len(msgsX))
-		for i := 0; i < len(msgsX); i++ {
-			SoMsg(fmt.Sprintf("MSG%d", i)+" buffers",
-				msgsY[i].Buffer[:msgsY[i].Copied], ShouldResemble, msgsX[i].Buffer)
-		}
-	})
-}
-
-func TestReadNWriteN(t *testing.T) {
-	uAddr := make(chan string, 1)
-	readFinished := make(chan bool, 1)
-	serverData := setupNFunc()
-	clientData := setupTestNFunc()
-	// Launch server
-	go func() {
-		file := getRandFile()
-		lconn, err := Listen(file)
-		if err != nil {
-			t.Fatalf("Unable to listen err=%v", err)
-		}
-		uAddr <- file
-		conn, err := lconn.Accept()
-		if err != nil {
-			t.Fatalf("Unable to accept err=%v", err)
-		}
-		readNFunc(conn, serverData)
-		conn.Close()
-		lconn.Close()
-		readFinished <- true
-	}()
-
-	// Dial after we have the socket address
-	conn, err := DialTimeout(<-uAddr, time.Second)
-	if err != nil {
-		t.Fatalf("Unable to connect err=%v", err)
-	}
-	writeNFunc(conn, clientData)
-	conn.Close()
-
-	// Wait for server to finish reading before comparing results
-	<-readFinished
-	testNFunc(t, clientData, serverData)
 }
 
 func getRandFile() string {

--- a/go/lib/xtest/xtest.go
+++ b/go/lib/xtest/xtest.go
@@ -1,0 +1,73 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xtest adds support for assertions in multiple goroutines to Goconvey
+//
+// Parallel goconvey blocks cannot contain other goconvey blocks.
+//
+// For an example, check out the testing file in this package.
+package xtest
+
+import (
+	"sync"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type SC struct {
+	C
+	sync.WaitGroup
+	sync.Mutex
+}
+
+func (c *SC) Convey(items ...interface{}) {
+	panic("Convey in SyncConvey Context not supported")
+}
+
+func (c *SC) So(actual interface{}, assert func(actual interface{}, expected ...interface{}) string, expected ...interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	c.C.So(actual, assert, expected)
+}
+
+func (c *SC) SoMsg(msg string, actual interface{}, assert func(actual interface{}, expected ...interface{}) string, expected ...interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	c.C.SoMsg(msg, actual, assert, expected...)
+}
+
+func (c *SC) RecoverAndWait() {
+	c.Done()
+	defer c.Wait()
+	if r := recover(); r != nil {
+		// Silently discard failure halts
+		if rString, ok := r.(string); ok && rString == "___FAILURE_HALT___" {
+			return
+		}
+		panic(r)
+	}
+}
+
+func Parallel(f, g func(sc *SC)) func(c C) {
+	return func(c C) {
+		sc := &SC{C: c}
+		sc.Add(2)
+		go func() {
+			defer sc.RecoverAndWait()
+			g(sc)
+		}()
+		defer sc.RecoverAndWait()
+		f(sc)
+	}
+}

--- a/go/lib/xtest/xtest.go
+++ b/go/lib/xtest/xtest.go
@@ -71,8 +71,7 @@ func Parallel(f, g func(sc *SC)) func(c C) {
 			g(sc)
 		}()
 		// If f panics, first recover from the panic. Afterwards (or if f
-		// finishes normally), announce that f finished and wait for g to
-		// finish.
+		// finishes normally), wait for g to finish.
 		defer sc.Wait()
 		defer sc.Recover()
 		f(sc)

--- a/go/lib/xtest/xtest.go
+++ b/go/lib/xtest/xtest.go
@@ -62,7 +62,7 @@ func (c *SC) Recover() {
 func Parallel(f, g func(sc *SC)) func(c C) {
 	return func(c C) {
 		sc := &SC{C: c}
-		sc.Add(2)
+		sc.Add(1)
 		go func() {
 			// If g panics, first recover from the panic. Afterwards (or if g
 			// finishes normally), announce that g finished.
@@ -74,7 +74,6 @@ func Parallel(f, g func(sc *SC)) func(c C) {
 		// finishes normally), announce that f finished and wait for g to
 		// finish.
 		defer sc.Wait()
-		defer sc.Done()
 		defer sc.Recover()
 		f(sc)
 	}

--- a/go/lib/xtest/xtest_test.go
+++ b/go/lib/xtest/xtest_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xtest
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestParallel(t *testing.T) {
+	Convey("Test parallel goroutines", t, Parallel(func(sc *SC) {
+		x := 1
+		sc.SoMsg("x", x, ShouldEqual, 1)
+		x += 1
+		sc.SoMsg("new x", x, ShouldEqual, 2)
+	}, func(sc *SC) {
+		y := 1
+		sc.SoMsg("y", y, ShouldEqual, 1)
+		y += 1
+		sc.SoMsg("new y", y, ShouldEqual, 2)
+	}))
+}

--- a/go/proto/cereal.go
+++ b/go/proto/cereal.go
@@ -98,7 +98,7 @@ func ReadRootFromReader(r io.Reader) (capnp.Struct, error) {
 	var blank capnp.Struct
 	msg, err := capnp.NewPackedDecoder(r).Decode()
 	if err != nil {
-		return blank, common.NewCError("Failed to decode capnp message", "err", err)
+		return blank, common.NewCErrorData("Failed to decode capnp message", err, "err", err)
 	}
 	rootPtr, err := msg.RootPtr()
 	if err != nil {


### PR DESCRIPTION
Dispatcher registrations and SCIOND queries in Go can block indefinitely, leaking goroutines and making it difficult to implement timeouts in calling code (such as the SCION socket library).

This PR adds timeout and deadline support to SCIOND and dispatcher interactions.

Also:
  * CError Data field changed to interface{} to support embedded errors
  * Enabled goconvey global test timeouts in some tests which deal with timeouts
  * Moved infra tests to a different filename to clearly distinguish them from standard unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1250)
<!-- Reviewable:end -->
