### PR TITLE
Enable concurrent read/writes in the end host sock

### DIFF
--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -16,7 +16,6 @@ package snet
 
 import (
 	"net"
-	"sync"
 	"time"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
@@ -40,8 +39,7 @@ var _ net.Conn = (*Conn)(nil)
 var _ net.PacketConn = (*Conn)(nil)
 
 type Conn struct {
-	dispMutex sync.Mutex
-	conn      *reliable.Conn
+	conn *reliable.Conn
 	// Local and remote SCION addresses (IA, L3, L4)
 	laddr *Addr
 	raddr *Addr
@@ -101,9 +99,7 @@ func (c *Conn) read(b []byte) (int, *Addr, error) {
 	var err error
 	var remote *Addr
 
-	c.dispMutex.Lock()
 	n, err := c.conn.Read(c.recvBuffer)
-	c.dispMutex.Unlock()
 	if err != nil {
 		return 0, nil, common.NewCError("Dispatcher read error", "err", err)
 	}
@@ -225,9 +221,7 @@ func (c *Conn) write(b []byte, raddr *Addr) (int, error) {
 	}
 
 	// Send message
-	c.dispMutex.Lock()
 	n, err = c.conn.WriteTo(c.sendBuffer[:n], appAddr)
-	c.dispMutex.Unlock()
 	if err != nil {
 		return 0, common.NewCError("Dispatcher write error", "err", err)
 	}

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -53,7 +53,7 @@
 // To send messages to remote SCION hosts, hosts fill in the common header
 // with the address type, the address and the layer 4 port of the remote host.
 //
-// The connections are not thread safe.
+// Reads and writes to the connection are thread safe.
 //
 package reliable
 
@@ -61,6 +61,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
@@ -93,6 +94,9 @@ type Conn struct {
 	recvBuf       []byte
 	recvReadHead  int
 	recvWriteHead int
+
+	readMutex  sync.Mutex
+	writeMutex sync.Mutex
 }
 
 func DialTimeout(address string, timeout time.Duration) (*Conn, error) {
@@ -203,6 +207,9 @@ func (conn *Conn) ReadFrom(buf []byte) (int, *AppAddr, error) {
 // copied field of the Msg struct contains the number of bytes in the read
 // packet.
 func (conn *Conn) ReadN(msgs []Msg) (int, error) {
+	conn.readMutex.Lock()
+	defer conn.readMutex.Unlock()
+
 	fillIndex := 0
 	// If we do not have enough data for a full packet, try a blocking read
 	for fillIndex < len(msgs) {
@@ -334,6 +341,9 @@ func (conn *Conn) WriteTo(buf []byte, dst AppAddr) (int, error) {
 // oriented protocols); the copied field of struct Msg is reset to 0 for
 // written packets.  WriteN returns the number of packets written.
 func (conn *Conn) WriteN(bufs []Msg) (int, error) {
+	conn.writeMutex.Lock()
+	defer conn.writeMutex.Unlock()
+
 	copiedMsgs := 0
 	index := 0
 	for i := range bufs {


### PR DESCRIPTION
This is an attempt to support concurrent reads & writes through the snet.Conn interface by splitting the associated mutex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1253)
<!-- Reviewable:end -->
