### PR TITLE
WiP SIG hello protocol (unfinished)

### DIFF
--- a/go/sig/hello/hello.go
+++ b/go/sig/hello/hello.go
@@ -1,0 +1,79 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hello
+
+import (
+	"time"
+
+	"github.com/prometheus/common/log"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/snet"
+)
+
+const (
+	DefaultTimeout = 500 * time.Millisecond
+	// After this many consecutive hello failures run Down() event
+	DownFailureCount = 3
+)
+
+type Callback func()
+
+func EchoClient(m *Mux, raddr *snet.Addr, onDown, onUp Callback) {
+	isUp := true
+	failures := 0
+	channels := m.AddRemote(raddr.IA)
+
+	timer := time.NewTimer(DefaultTimeout)
+	// Drain channel to safely Reset timer on start of loop
+	<-timer.C
+	for {
+		if failures == DownFailureCount {
+			log.Error("Ctrl module marked remote as down", "remote", ia)
+			onDown()
+			isUp = false
+		}
+
+		// timer.C is always drained before getting here, so Reset is race free
+		timer.Reset(DefaultTimeout)
+		msg := Msg{
+			Raddr:   raddr,
+			Payload: make(common.RawBytes, 0),
+		}
+		select {
+		case channels.Out <- msg:
+		case <-timer.C:
+			failures++
+			log.Warn("Ctrl timed out waiting to send echo", "remote", ia)
+			continue
+		}
+		select {
+		case <-channels.In:
+			// Don't care if we receive older reply, as long as we receive something
+		case <-timer.C:
+			failures++
+			log.Warn("Ctrl timed out waiting to receive echo reply", "remote", ia)
+			continue
+		}
+
+		failures = 0
+		if isUp == false {
+			log.Info("Ctrl module marked remote as up", "remote", ia)
+			onUp()
+			isUp = true
+		}
+		<-timer.C
+	}
+}

--- a/go/sig/hello/hello.go
+++ b/go/sig/hello/hello.go
@@ -17,7 +17,7 @@ package hello
 import (
 	"time"
 
-	"github.com/prometheus/common/log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/snet"

--- a/go/sig/hello/mux.go
+++ b/go/sig/hello/mux.go
@@ -1,0 +1,98 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hello
+
+import (
+	"sync"
+
+	"github.com/prometheus/common/log"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/snet"
+)
+
+type Msg struct {
+	Raddr   *snet.Addr
+	Payload common.RawBytes
+}
+
+type Channels struct {
+	Out chan Msg
+	In  chan Msg
+}
+
+// Mux multiplexes/demultiplexes data traffic from multiple goroutines on a
+// single SCION connection. The remote IA of received traffic is used to
+// identify the goroutine to which to send.
+type Mux struct {
+	sync.Mutex
+	m map[string]*Channels
+	// The outgoing channel is shared
+	out chan Msg
+	// Connection for sends/receives
+	conn *snet.Conn
+}
+
+func NewMux(conn *snet.Conn) *Mux {
+	m := &Mux{
+		m:    make(map[string]*Channels),
+		out:  make(chan Msg, 10),
+		conn: conn,
+	}
+
+	go runOutgoing()
+	go runIngoing()
+}
+
+func (m *Mux) runOutgoing() {
+	for {
+		msg <- m.out
+		n, err := conn.WriteToSCION(msg.Payload, msg.Raddr)
+		if err != nil {
+			log.Error("Unable to write")
+		}
+	}
+}
+
+func (m *Mux) runIngoing() {
+	b := make([]byte, 1<<12)
+	for {
+		n, raddr, err := conn.ReadFromSCION(b)
+		if err != nil {
+			log.Error("Unable to read")
+		}
+
+		msg := Msg{raddr.Copy(), Payload: Copy(b[:n])}
+		m[raddr.IA.String()].In <- msg
+	}
+}
+
+func (m *Mux) AddRemote(ia *addr.ISD_AS) (*Channels, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	c := &Channels{
+		Out: m.Out,
+		In:  make(chan Msg, 10),
+	}
+
+	iaStr := ia.String()
+	if _, ok := m.m[iaStr]; ok {
+		return nil, common.NewError("duplicate entry", "remote", ia)
+	}
+	m.m[iaStr] = c
+	return c, nil
+}

--- a/go/sig/hello/mux.go
+++ b/go/sig/hello/mux.go
@@ -17,7 +17,7 @@ package hello
 import (
 	"sync"
 
-	"github.com/prometheus/common/log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"


### PR DESCRIPTION
  - Directly sends data to the remote SIG's control address; no discovery is performed
  - Only checks that the remote SIG is somehow reachable over the control port; individual paths cannot be checked
  - Uses a mux/demux to send data from multiple sources (one source for each remote AS) over a single SCION connection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1256)
<!-- Reviewable:end -->
