### PR TITLE
Renamed SCION proto to CtrlPld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: clibs dispatcher go
 
 clean:
 	$(foreach var,$(SRC_DIRS),$(MAKE) -C $(var) clean || exit 1;)
-	if type -P go >/dev/null; then cd go && $(MAKE) clean; fi
+	cd go && $(MAKE) clean
 	rm -f tags
 
 go: libscion

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -140,17 +140,17 @@ func (rp *RtrPkt) processDestSelf() (HookResult, error) {
 			"pldType", fmt.Sprintf("%T", rp.pld), "pld", rp.pld)
 	}
 	// Determine the type of SCION control payload.
-	u0, err := cpld.Union0()
+	cts, err := cpld.Contents()
 	if err != nil {
 		return HookError, err
 	}
-	switch u0 := u0.(type) {
+	switch cts := cts.(type) {
 	case *ifid.IFID:
-		return rp.processIFID(u0)
+		return rp.processIFID(cts)
 	case *path_mgmt.Pld:
-		return rp.processPathMgmtSelf(u0)
+		return rp.processPathMgmtSelf(cts)
 	default:
-		rp.Error("Unsupported destination payload", "type", common.TypeOf(u0))
+		rp.Error("Unsupported destination payload", "type", common.TypeOf(cts))
 		return HookError, nil
 	}
 }
@@ -192,16 +192,16 @@ func (rp *RtrPkt) processIFID(ifid *ifid.IFID) (HookResult, error) {
 
 // processPathMgmtSelf handles Path Management SCION control messages.
 func (rp *RtrPkt) processPathMgmtSelf(p *path_mgmt.Pld) (HookResult, error) {
-	u0, err := p.Union0()
+	cts, err := p.Contents()
 	if err != nil {
 		return HookError, err
 	}
-	switch u0 := u0.(type) {
+	switch cts := cts.(type) {
 	case *path_mgmt.IFStateInfos:
-		ifstate.Process(u0)
+		ifstate.Process(cts)
 	default:
 		return HookError, common.NewCError("Unsupported destination PathMgmt payload",
-			"type", common.TypeOf(u0))
+			"type", common.TypeOf(cts))
 	}
 	return HookFinish, nil
 }

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -140,17 +140,17 @@ func (rp *RtrPkt) processDestSelf() (HookResult, error) {
 			"pldType", fmt.Sprintf("%T", rp.pld), "pld", rp.pld)
 	}
 	// Determine the type of SCION control payload.
-	cts, err := cpld.Union()
+	u, err := cpld.Union()
 	if err != nil {
 		return HookError, err
 	}
-	switch cts := cts.(type) {
+	switch pld := u.(type) {
 	case *ifid.IFID:
-		return rp.processIFID(cts)
+		return rp.processIFID(pld)
 	case *path_mgmt.Pld:
-		return rp.processPathMgmtSelf(cts)
+		return rp.processPathMgmtSelf(pld)
 	default:
-		rp.Error("Unsupported destination payload", "type", common.TypeOf(cts))
+		rp.Error("Unsupported destination payload", "type", common.TypeOf(pld))
 		return HookError, nil
 	}
 }
@@ -192,16 +192,16 @@ func (rp *RtrPkt) processIFID(ifid *ifid.IFID) (HookResult, error) {
 
 // processPathMgmtSelf handles Path Management SCION control messages.
 func (rp *RtrPkt) processPathMgmtSelf(p *path_mgmt.Pld) (HookResult, error) {
-	cts, err := p.Union()
+	u, err := p.Union()
 	if err != nil {
 		return HookError, err
 	}
-	switch cts := cts.(type) {
+	switch pld := u.(type) {
 	case *path_mgmt.IFStateInfos:
-		ifstate.Process(cts)
+		ifstate.Process(pld)
 	default:
 		return HookError, common.NewCError("Unsupported destination PathMgmt payload",
-			"type", common.TypeOf(cts))
+			"type", common.TypeOf(pld))
 	}
 	return HookFinish, nil
 }

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -140,7 +140,7 @@ func (rp *RtrPkt) processDestSelf() (HookResult, error) {
 			"pldType", fmt.Sprintf("%T", rp.pld), "pld", rp.pld)
 	}
 	// Determine the type of SCION control payload.
-	cts, err := cpld.Contents()
+	cts, err := cpld.Union()
 	if err != nil {
 		return HookError, err
 	}
@@ -192,7 +192,7 @@ func (rp *RtrPkt) processIFID(ifid *ifid.IFID) (HookResult, error) {
 
 // processPathMgmtSelf handles Path Management SCION control messages.
 func (rp *RtrPkt) processPathMgmtSelf(p *path_mgmt.Pld) (HookResult, error) {
-	cts, err := p.Contents()
+	cts, err := p.Union()
 	if err != nil {
 		return HookError, err
 	}

--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -42,16 +42,16 @@ type union struct {
 }
 
 func (u *union) set(c proto.Cerealizable) error {
-	switch u := c.(type) {
+	switch p := c.(type) {
 	case *seg.PathSegment:
 		u.Which = proto.CtrlPld_Which_pcb
-		u.PathSegment = u
+		u.PathSegment = p
 	case *ifid.IFID:
 		u.Which = proto.CtrlPld_Which_ifid
-		u.IfID = u
+		u.IfID = p
 	case *path_mgmt.Pld:
 		u.Which = proto.CtrlPld_Which_pathMgmt
-		u.PathMgmt = u
+		u.PathMgmt = p
 	default:
 		return common.NewCError("Unsupported ctrl union type (set)", "type", common.TypeOf(c))
 	}

--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ctrl handles CtrlPld control-plane payloads, which are encoded as capnp proto messages.
+// Package ctrl handles SCION control-plane payloads, which are encoded as capnp proto messages.
 // Each ctrl payload has a 4B length field prefixed to the start of the capnp message.
 package ctrl
 

--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -41,33 +41,33 @@ type union struct {
 	Sig         []byte `capnp:"-"` // Omit for now
 }
 
-func (cts *union) set(c proto.Cerealizable) error {
+func (u *union) set(c proto.Cerealizable) error {
 	switch u := c.(type) {
 	case *seg.PathSegment:
-		cts.Which = proto.CtrlPld_Which_pcb
-		cts.PathSegment = u
+		u.Which = proto.CtrlPld_Which_pcb
+		u.PathSegment = u
 	case *ifid.IFID:
-		cts.Which = proto.CtrlPld_Which_ifid
-		cts.IfID = u
+		u.Which = proto.CtrlPld_Which_ifid
+		u.IfID = u
 	case *path_mgmt.Pld:
-		cts.Which = proto.CtrlPld_Which_pathMgmt
-		cts.PathMgmt = u
+		u.Which = proto.CtrlPld_Which_pathMgmt
+		u.PathMgmt = u
 	default:
 		return common.NewCError("Unsupported ctrl union type (set)", "type", common.TypeOf(c))
 	}
 	return nil
 }
 
-func (cts *union) get() (proto.Cerealizable, error) {
-	switch cts.Which {
+func (u *union) get() (proto.Cerealizable, error) {
+	switch u.Which {
 	case proto.CtrlPld_Which_pcb:
-		return cts.PathSegment, nil
+		return u.PathSegment, nil
 	case proto.CtrlPld_Which_ifid:
-		return cts.IfID, nil
+		return u.IfID, nil
 	case proto.CtrlPld_Which_pathMgmt:
-		return cts.PathMgmt, nil
+		return u.PathMgmt, nil
 	}
-	return nil, common.NewCError("Unsupported ctrl union type (get)", "type", cts.Which)
+	return nil, common.NewCError("Unsupported ctrl union type (get)", "type", u.Which)
 }
 
 var _ common.Payload = (*Pld)(nil)
@@ -78,15 +78,15 @@ type Pld struct {
 }
 
 // NewPld creates a new control payload, containing the supplied Cerealizable instance.
-func NewPld(cts proto.Cerealizable) (*Pld, error) {
+func NewPld(u proto.Cerealizable) (*Pld, error) {
 	p := &Pld{}
-	return p, p.union.set(cts)
+	return p, p.union.set(u)
 }
 
 // NewPathMgmtPld creates a new control payload, containing a new path_mgmt payload,
 // which in turn contains the supplied Cerealizable instance.
-func NewPathMgmtPld(cts proto.Cerealizable) (*Pld, error) {
-	ppld, err := path_mgmt.NewPld(cts)
+func NewPathMgmtPld(u proto.Cerealizable) (*Pld, error) {
+	ppld, err := path_mgmt.NewPld(u)
 	if err != nil {
 		return nil, err
 	}
@@ -131,11 +131,11 @@ func (p *Pld) ProtoId() proto.ProtoIdType {
 
 func (p *Pld) String() string {
 	desc := []string{"Ctrl: Union:"}
-	cts, err := p.Union()
+	u, err := p.Union()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {
-		desc = append(desc, fmt.Sprintf("%+v", cts))
+		desc = append(desc, fmt.Sprintf("%+v", u))
 	}
 	return strings.Join(desc, " ")
 }

--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ctrl handles SCION control-plane payloads, which are encoded as capnp proto messages.
+// Package ctrl handles CtrlPld control-plane payloads, which are encoded as capnp proto messages.
 // Each ctrl payload has a 4B length field prefixed to the start of the capnp message.
 package ctrl
 
@@ -29,9 +29,9 @@ import (
 	"github.com/netsec-ethz/scion/go/proto"
 )
 
-// union0 represents the contents of the capnp union that starts at field @0.
-type union0 struct {
-	Which       proto.SCION_Which
+// contents represents the contents of the unnamed capnp union.
+type contents struct {
+	Which       proto.CtrlPld_Which
 	PathSegment *seg.PathSegment `capnp:"pcb"`
 	IfID        *ifid.IFID       `capnp:"ifid"`
 	CertMgmt    []byte           `capnp:"-"` // Omit for now
@@ -41,52 +41,52 @@ type union0 struct {
 	Sig         []byte `capnp:"-"` // Omit for now
 }
 
-func (u0 *union0) set(c proto.Cerealizable) error {
+func (cts *contents) set(c proto.Cerealizable) error {
 	switch u := c.(type) {
 	case *seg.PathSegment:
-		u0.Which = proto.SCION_Which_pcb
-		u0.PathSegment = u
+		cts.Which = proto.CtrlPld_Which_pcb
+		cts.PathSegment = u
 	case *ifid.IFID:
-		u0.Which = proto.SCION_Which_ifid
-		u0.IfID = u
+		cts.Which = proto.CtrlPld_Which_ifid
+		cts.IfID = u
 	case *path_mgmt.Pld:
-		u0.Which = proto.SCION_Which_pathMgmt
-		u0.PathMgmt = u
+		cts.Which = proto.CtrlPld_Which_pathMgmt
+		cts.PathMgmt = u
 	default:
-		return common.NewCError("Unsupported ctrl union0 type (set)", "type", common.TypeOf(c))
+		return common.NewCError("Unsupported ctrl contents type (set)", "type", common.TypeOf(c))
 	}
 	return nil
 }
 
-func (u0 *union0) get() (proto.Cerealizable, error) {
-	switch u0.Which {
-	case proto.SCION_Which_pcb:
-		return u0.PathSegment, nil
-	case proto.SCION_Which_ifid:
-		return u0.IfID, nil
-	case proto.SCION_Which_pathMgmt:
-		return u0.PathMgmt, nil
+func (cts *contents) get() (proto.Cerealizable, error) {
+	switch cts.Which {
+	case proto.CtrlPld_Which_pcb:
+		return cts.PathSegment, nil
+	case proto.CtrlPld_Which_ifid:
+		return cts.IfID, nil
+	case proto.CtrlPld_Which_pathMgmt:
+		return cts.PathMgmt, nil
 	}
-	return nil, common.NewCError("Unsupported ctrl union0 type (get)", "type", u0.Which)
+	return nil, common.NewCError("Unsupported ctrl contents type (get)", "type", cts.Which)
 }
 
 var _ common.Payload = (*Pld)(nil)
 var _ proto.Cerealizable = (*Pld)(nil)
 
 type Pld struct {
-	union0
+	contents
 }
 
 // NewPld creates a new control payload, containing the supplied Cerealizable instance.
-func NewPld(u0 proto.Cerealizable) (*Pld, error) {
+func NewPld(cts proto.Cerealizable) (*Pld, error) {
 	p := &Pld{}
-	return p, p.union0.set(u0)
+	return p, p.contents.set(cts)
 }
 
 // NewPathMgmtPld creates a new control payload, containing a new path_mgmt payload,
 // which in turn contains the supplied Cerealizable instance.
-func NewPathMgmtPld(u0 proto.Cerealizable) (*Pld, error) {
-	ppld, err := path_mgmt.NewPld(u0)
+func NewPathMgmtPld(cts proto.Cerealizable) (*Pld, error) {
+	ppld, err := path_mgmt.NewPld(cts)
 	if err != nil {
 		return nil, err
 	}
@@ -100,11 +100,11 @@ func NewPldFromRaw(b common.RawBytes) (*Pld, error) {
 		return nil, common.NewCError("Invalid ctrl payload length",
 			"expected", n+4, "actual", len(b))
 	}
-	return p, proto.ParseFromRaw(p, proto.SCION_TypeID, b[4:])
+	return p, proto.ParseFromRaw(p, proto.CtrlPld_TypeID, b[4:])
 }
 
-func (p *Pld) Union0() (proto.Cerealizable, error) {
-	return p.union0.get()
+func (p *Pld) Contents() (proto.Cerealizable, error) {
+	return p.contents.get()
 }
 
 func (p *Pld) Len() int {
@@ -126,16 +126,16 @@ func (p *Pld) WritePld(b common.RawBytes) (int, error) {
 }
 
 func (p *Pld) ProtoId() proto.ProtoIdType {
-	return proto.SCION_TypeID
+	return proto.CtrlPld_TypeID
 }
 
 func (p *Pld) String() string {
-	desc := []string{"Ctrl: Union0:"}
-	u0, err := p.Union0()
+	desc := []string{"Ctrl: Contents:"}
+	cts, err := p.Contents()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {
-		desc = append(desc, fmt.Sprintf("%+v", u0))
+		desc = append(desc, fmt.Sprintf("%+v", cts))
 	}
 	return strings.Join(desc, " ")
 }

--- a/go/lib/ctrl/path_mgmt/path_mgmt.go
+++ b/go/lib/ctrl/path_mgmt/path_mgmt.go
@@ -24,8 +24,8 @@ import (
 	"github.com/netsec-ethz/scion/go/proto"
 )
 
-// contents represents the contents of the unnamed capnp union.
-type contents struct {
+// union represents the contents of the unnamed capnp union.
+type union struct {
 	Which        proto.PathMgmt_Which
 	SegReq       *SegReq
 	SegReply     *SegReply
@@ -36,7 +36,7 @@ type contents struct {
 	IFStateInfos *IFStateInfos `capnp:"ifStateInfos"`
 }
 
-func (cts *contents) set(c proto.Cerealizable) error {
+func (cts *union) set(c proto.Cerealizable) error {
 	switch u := c.(type) {
 	case *SegReq:
 		cts.Which = proto.PathMgmt_Which_segReq
@@ -60,12 +60,12 @@ func (cts *contents) set(c proto.Cerealizable) error {
 		cts.Which = proto.PathMgmt_Which_ifStateInfos
 		cts.IFStateInfos = u
 	default:
-		return common.NewCError("Unsupported path mgmt contents type (set)", "type", common.TypeOf(c))
+		return common.NewCError("Unsupported path mgmt union type (set)", "type", common.TypeOf(c))
 	}
 	return nil
 }
 
-func (cts *contents) get() (proto.Cerealizable, error) {
+func (cts *union) get() (proto.Cerealizable, error) {
 	switch cts.Which {
 	case proto.PathMgmt_Which_segReq:
 		return cts.SegReq, nil
@@ -82,23 +82,23 @@ func (cts *contents) get() (proto.Cerealizable, error) {
 	case proto.PathMgmt_Which_ifStateInfos:
 		return cts.IFStateInfos, nil
 	}
-	return nil, common.NewCError("Unsupported path mgmt contents type (get)", "type", cts.Which)
+	return nil, common.NewCError("Unsupported path mgmt union type (get)", "type", cts.Which)
 }
 
 var _ proto.Cerealizable = (*Pld)(nil)
 
 type Pld struct {
-	contents
+	union
 }
 
 // NewPld creates a new path mgmt payload, containing the supplied Cerealizable instance.
 func NewPld(cts proto.Cerealizable) (*Pld, error) {
 	p := &Pld{}
-	return p, p.contents.set(cts)
+	return p, p.union.set(cts)
 }
 
-func (p *Pld) Contents() (proto.Cerealizable, error) {
-	return p.contents.get()
+func (p *Pld) Union() (proto.Cerealizable, error) {
+	return p.union.get()
 }
 
 func (p *Pld) ProtoId() proto.ProtoIdType {
@@ -106,8 +106,8 @@ func (p *Pld) ProtoId() proto.ProtoIdType {
 }
 
 func (p *Pld) String() string {
-	desc := []string{"PathMgmt: Contents:"}
-	cts, err := p.Contents()
+	desc := []string{"PathMgmt: Union:"}
+	cts, err := p.Union()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {

--- a/go/lib/ctrl/path_mgmt/path_mgmt.go
+++ b/go/lib/ctrl/path_mgmt/path_mgmt.go
@@ -24,8 +24,8 @@ import (
 	"github.com/netsec-ethz/scion/go/proto"
 )
 
-// union0 represents the contents of the capnp union that starts at field @0.
-type union0 struct {
+// contents represents the contents of the unnamed capnp union.
+type contents struct {
 	Which        proto.PathMgmt_Which
 	SegReq       *SegReq
 	SegReply     *SegReply
@@ -36,69 +36,69 @@ type union0 struct {
 	IFStateInfos *IFStateInfos `capnp:"ifStateInfos"`
 }
 
-func (u0 *union0) set(c proto.Cerealizable) error {
+func (cts *contents) set(c proto.Cerealizable) error {
 	switch u := c.(type) {
 	case *SegReq:
-		u0.Which = proto.PathMgmt_Which_segReq
-		u0.SegReq = u
+		cts.Which = proto.PathMgmt_Which_segReq
+		cts.SegReq = u
 	case *SegReply:
-		u0.Which = proto.PathMgmt_Which_segReply
-		u0.SegReply = u
+		cts.Which = proto.PathMgmt_Which_segReply
+		cts.SegReply = u
 	case *SegReg:
-		u0.Which = proto.PathMgmt_Which_segReg
-		u0.SegReg = u
+		cts.Which = proto.PathMgmt_Which_segReg
+		cts.SegReg = u
 	case *SegSync:
-		u0.Which = proto.PathMgmt_Which_segSync
-		u0.SegSync = u
+		cts.Which = proto.PathMgmt_Which_segSync
+		cts.SegSync = u
 	case *RevInfo:
-		u0.Which = proto.PathMgmt_Which_revInfo
-		u0.RevInfo = u
+		cts.Which = proto.PathMgmt_Which_revInfo
+		cts.RevInfo = u
 	case *IFStateReq:
-		u0.Which = proto.PathMgmt_Which_ifStateReq
-		u0.IFStateReq = u
+		cts.Which = proto.PathMgmt_Which_ifStateReq
+		cts.IFStateReq = u
 	case *IFStateInfos:
-		u0.Which = proto.PathMgmt_Which_ifStateInfos
-		u0.IFStateInfos = u
+		cts.Which = proto.PathMgmt_Which_ifStateInfos
+		cts.IFStateInfos = u
 	default:
-		return common.NewCError("Unsupported path mgmt union0 type (set)", "type", common.TypeOf(c))
+		return common.NewCError("Unsupported path mgmt contents type (set)", "type", common.TypeOf(c))
 	}
 	return nil
 }
 
-func (u0 *union0) get() (proto.Cerealizable, error) {
-	switch u0.Which {
+func (cts *contents) get() (proto.Cerealizable, error) {
+	switch cts.Which {
 	case proto.PathMgmt_Which_segReq:
-		return u0.SegReq, nil
+		return cts.SegReq, nil
 	case proto.PathMgmt_Which_segReply:
-		return u0.SegReply, nil
+		return cts.SegReply, nil
 	case proto.PathMgmt_Which_segReg:
-		return u0.SegReg, nil
+		return cts.SegReg, nil
 	case proto.PathMgmt_Which_segSync:
-		return u0.SegSync, nil
+		return cts.SegSync, nil
 	case proto.PathMgmt_Which_revInfo:
-		return u0.RevInfo, nil
+		return cts.RevInfo, nil
 	case proto.PathMgmt_Which_ifStateReq:
-		return u0.IFStateReq, nil
+		return cts.IFStateReq, nil
 	case proto.PathMgmt_Which_ifStateInfos:
-		return u0.IFStateInfos, nil
+		return cts.IFStateInfos, nil
 	}
-	return nil, common.NewCError("Unsupported path mgmt union0 type (get)", "type", u0.Which)
+	return nil, common.NewCError("Unsupported path mgmt contents type (get)", "type", cts.Which)
 }
 
 var _ proto.Cerealizable = (*Pld)(nil)
 
 type Pld struct {
-	union0
+	contents
 }
 
 // NewPld creates a new path mgmt payload, containing the supplied Cerealizable instance.
-func NewPld(u0 proto.Cerealizable) (*Pld, error) {
+func NewPld(cts proto.Cerealizable) (*Pld, error) {
 	p := &Pld{}
-	return p, p.union0.set(u0)
+	return p, p.contents.set(cts)
 }
 
-func (p *Pld) Union0() (proto.Cerealizable, error) {
-	return p.union0.get()
+func (p *Pld) Contents() (proto.Cerealizable, error) {
+	return p.contents.get()
 }
 
 func (p *Pld) ProtoId() proto.ProtoIdType {
@@ -106,12 +106,12 @@ func (p *Pld) ProtoId() proto.ProtoIdType {
 }
 
 func (p *Pld) String() string {
-	desc := []string{"PathMgmt: Union0:"}
-	u0, err := p.Union0()
+	desc := []string{"PathMgmt: Contents:"}
+	cts, err := p.Contents()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {
-		desc = append(desc, fmt.Sprintf("%+v", u0))
+		desc = append(desc, fmt.Sprintf("%+v", cts))
 	}
 	return strings.Join(desc, " ")
 }

--- a/go/lib/ctrl/path_mgmt/path_mgmt.go
+++ b/go/lib/ctrl/path_mgmt/path_mgmt.go
@@ -36,53 +36,53 @@ type union struct {
 	IFStateInfos *IFStateInfos `capnp:"ifStateInfos"`
 }
 
-func (cts *union) set(c proto.Cerealizable) error {
-	switch u := c.(type) {
+func (u *union) set(c proto.Cerealizable) error {
+	switch p := c.(type) {
 	case *SegReq:
-		cts.Which = proto.PathMgmt_Which_segReq
-		cts.SegReq = u
+		u.Which = proto.PathMgmt_Which_segReq
+		u.SegReq = p
 	case *SegReply:
-		cts.Which = proto.PathMgmt_Which_segReply
-		cts.SegReply = u
+		u.Which = proto.PathMgmt_Which_segReply
+		u.SegReply = p
 	case *SegReg:
-		cts.Which = proto.PathMgmt_Which_segReg
-		cts.SegReg = u
+		u.Which = proto.PathMgmt_Which_segReg
+		u.SegReg = p
 	case *SegSync:
-		cts.Which = proto.PathMgmt_Which_segSync
-		cts.SegSync = u
+		u.Which = proto.PathMgmt_Which_segSync
+		u.SegSync = p
 	case *RevInfo:
-		cts.Which = proto.PathMgmt_Which_revInfo
-		cts.RevInfo = u
+		u.Which = proto.PathMgmt_Which_revInfo
+		u.RevInfo = p
 	case *IFStateReq:
-		cts.Which = proto.PathMgmt_Which_ifStateReq
-		cts.IFStateReq = u
+		u.Which = proto.PathMgmt_Which_ifStateReq
+		u.IFStateReq = p
 	case *IFStateInfos:
-		cts.Which = proto.PathMgmt_Which_ifStateInfos
-		cts.IFStateInfos = u
+		u.Which = proto.PathMgmt_Which_ifStateInfos
+		u.IFStateInfos = p
 	default:
 		return common.NewCError("Unsupported path mgmt union type (set)", "type", common.TypeOf(c))
 	}
 	return nil
 }
 
-func (cts *union) get() (proto.Cerealizable, error) {
-	switch cts.Which {
+func (u *union) get() (proto.Cerealizable, error) {
+	switch u.Which {
 	case proto.PathMgmt_Which_segReq:
-		return cts.SegReq, nil
+		return u.SegReq, nil
 	case proto.PathMgmt_Which_segReply:
-		return cts.SegReply, nil
+		return u.SegReply, nil
 	case proto.PathMgmt_Which_segReg:
-		return cts.SegReg, nil
+		return u.SegReg, nil
 	case proto.PathMgmt_Which_segSync:
-		return cts.SegSync, nil
+		return u.SegSync, nil
 	case proto.PathMgmt_Which_revInfo:
-		return cts.RevInfo, nil
+		return u.RevInfo, nil
 	case proto.PathMgmt_Which_ifStateReq:
-		return cts.IFStateReq, nil
+		return u.IFStateReq, nil
 	case proto.PathMgmt_Which_ifStateInfos:
-		return cts.IFStateInfos, nil
+		return u.IFStateInfos, nil
 	}
-	return nil, common.NewCError("Unsupported path mgmt union type (get)", "type", cts.Which)
+	return nil, common.NewCError("Unsupported path mgmt union type (get)", "type", u.Which)
 }
 
 var _ proto.Cerealizable = (*Pld)(nil)
@@ -92,9 +92,9 @@ type Pld struct {
 }
 
 // NewPld creates a new path mgmt payload, containing the supplied Cerealizable instance.
-func NewPld(cts proto.Cerealizable) (*Pld, error) {
+func NewPld(u proto.Cerealizable) (*Pld, error) {
 	p := &Pld{}
-	return p, p.union.set(cts)
+	return p, p.union.set(u)
 }
 
 func (p *Pld) Union() (proto.Cerealizable, error) {
@@ -107,11 +107,11 @@ func (p *Pld) ProtoId() proto.ProtoIdType {
 
 func (p *Pld) String() string {
 	desc := []string{"PathMgmt: Union:"}
-	cts, err := p.Union()
+	u, err := p.Union()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {
-		desc = append(desc, fmt.Sprintf("%+v", cts))
+		desc = append(desc, fmt.Sprintf("%+v", u))
 	}
 	return strings.Join(desc, " ")
 }

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -75,8 +75,8 @@ func (p *Pld) ProtoId() proto.ProtoIdType {
 }
 
 func (p *Pld) String() string {
-	desc := []string{fmt.Sprintf("Sciond: Id: %d Contents: ", p.Id)}
-	u1, err := p.contents()
+	desc := []string{fmt.Sprintf("Sciond: Id: %d Union: ", p.Id)}
+	u1, err := p.union()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {
@@ -85,7 +85,7 @@ func (p *Pld) String() string {
 	return strings.Join(desc, "")
 }
 
-func (p *Pld) contents() (interface{}, error) {
+func (p *Pld) union() (interface{}, error) {
 	switch p.Which {
 	case proto.SCIONDMsg_Which_pathReq:
 		return p.PathReq, nil
@@ -108,7 +108,7 @@ func (p *Pld) contents() (interface{}, error) {
 	case proto.SCIONDMsg_Which_serviceInfoReply:
 		return p.ServiceInfoReply, nil
 	}
-	return nil, common.NewCError("Unsupported SCIOND contents type", "type", p.Which)
+	return nil, common.NewCError("Unsupported SCIOND union type", "type", p.Which)
 }
 
 type PathReq struct {

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -75,8 +75,8 @@ func (p *Pld) ProtoId() proto.ProtoIdType {
 }
 
 func (p *Pld) String() string {
-	desc := []string{fmt.Sprintf("Sciond: Id: %d Union1: ", p.Id)}
-	u1, err := p.union1()
+	desc := []string{fmt.Sprintf("Sciond: Id: %d Contents: ", p.Id)}
+	u1, err := p.contents()
 	if err != nil {
 		desc = append(desc, err.Error())
 	} else {
@@ -85,7 +85,7 @@ func (p *Pld) String() string {
 	return strings.Join(desc, "")
 }
 
-func (p *Pld) union1() (interface{}, error) {
+func (p *Pld) contents() (interface{}, error) {
 	switch p.Which {
 	case proto.SCIONDMsg_Which_pathReq:
 		return p.PathReq, nil
@@ -108,7 +108,7 @@ func (p *Pld) union1() (interface{}, error) {
 	case proto.SCIONDMsg_Which_serviceInfoReply:
 		return p.ServiceInfoReply, nil
 	}
-	return nil, common.NewCError("Unsupported SCIOND union1 type", "type", p.Which)
+	return nil, common.NewCError("Unsupported SCIOND contents type", "type", p.Which)
 }
 
 type PathReq struct {

--- a/go/proto/doc.go
+++ b/go/proto/doc.go
@@ -20,7 +20,7 @@ that needs to be nested inside a SCION control message. For example:
 	b, _ := PackRoot(cpld1)
 	// Parse new ctrl message from bytes.
 	cpld2, _ := ParseFromRaw(b)
-	// Access the first union.
+	// Access the contents (unnamed union).
 	cont, _ := cpld2.Contents()
 	// Interface-assertion to IFID type.
 	ifid2 := cont.(*ifid.IFID)

--- a/go/proto/doc.go
+++ b/go/proto/doc.go
@@ -21,8 +21,8 @@ that needs to be nested inside a SCION control message. For example:
 	// Parse new ctrl message from bytes.
 	cpld2, _ := ParseFromRaw(b)
 	// Access the first union.
-	u0, _ := cpld2.Union0()
+	cont, _ := cpld2.Contents()
 	// Interface-assertion to IFID type.
-	ifid2 := u0.(*ifid.IFID)
+	ifid2 := cont.(*ifid.IFID)
 */
 package proto

--- a/go/proto/gen.go
+++ b/go/proto/gen.go
@@ -17,7 +17,7 @@ import (
 var RootTypes = []string{
 	"PathSegment",
 	"RevInfo",
-	"SCION",
+	"CtrlPld",
 	"SCIONDMsg",
 }
 

--- a/proto/ctrl_pld.capnp
+++ b/proto/ctrl_pld.capnp
@@ -11,7 +11,7 @@ using SIBRA = import "sibra.capnp";
 using DRKeyMgmt = import "drkey_mgmt.capnp";
 using SIG = import "sig.capnp";
 
-struct SCION {
+struct CtrlPld {
     union {
         unset @0 :Void;
         pcb @1 :PCB.PathSegment;

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -273,7 +273,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         """
         Handles pcbs received from the network.
         """
-        pcb = cpld.contents
+        pcb = cpld.union
         assert isinstance(pcb, PathSegment), type(pcb)
         if meta:
             pcb.p.ifID = meta.path.get_hof().ingress_if
@@ -407,7 +407,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         :param pld: The IFIDPayload.
         :type pld: IFIDPayload
         """
-        pld = cpld.contents
+        pld = cpld.union
         assert isinstance(pld, IFIDPayload), type(pld)
         ifid = pld.p.relayIF
         with self.ifid_state_lock:
@@ -623,8 +623,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         self._process_revocation(rev_info)
 
     def _handle_revocation(self, cpld, meta):
-        pmgt = cpld.contents
-        rev_info = pmgt.contents
+        pmgt = cpld.union
+        rev_info = pmgt.union
         assert isinstance(rev_info, RevocationInfo), type(rev_info)
         logging.debug("Received revocation via TCP/UDP: %s (from %s)", rev_info.short_desc(), meta)
         if not self._validate_revocation(rev_info):
@@ -730,8 +730,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
     def _handle_ifstate_request(self, cpld, meta):
         # Only master replies to ifstate requests.
-        pmgt = cpld.contents
-        req = pmgt.contents
+        pmgt = cpld.union
+        req = pmgt.union
         assert isinstance(req, IFStateRequest), type(req)
         if not self.zk.have_lock():
             return

--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -237,8 +237,8 @@ class CertServer(SCIONElement):
 
     def process_cert_chain_request(self, cpld, meta):
         """Process a certificate chain request."""
-        cmgt = cpld.contents
-        req = cmgt.contents
+        cmgt = cpld.union
+        req = cmgt.union
         assert isinstance(req, CertChainRequest), type(req)
         key = req.isd_as(), req.p.version
         logging.info("Cert chain request received for %sv%s from %s", *key, meta)
@@ -257,8 +257,8 @@ class CertServer(SCIONElement):
 
     def process_cert_chain_reply(self, cpld, meta, from_zk=False):
         """Process a certificate chain reply."""
-        cmgt = cpld.contents
-        rep = cmgt.contents
+        cmgt = cpld.union
+        rep = cmgt.union
         assert isinstance(rep, CertChainReply), type(rep)
         ia_ver = rep.chain.get_leaf_isd_as_ver()
         logging.info("Cert chain reply received for %sv%s (ZK: %s)" %
@@ -304,8 +304,8 @@ class CertServer(SCIONElement):
 
     def process_trc_request(self, cpld, meta):
         """Process a TRC request."""
-        cmgt = cpld.contents
-        req = cmgt.contents
+        cmgt = cpld.union
+        req = cmgt.union
         assert isinstance(req, TRCRequest), type(req)
         key = req.isd_as()[0], req.p.version
         logging.info("TRC request received for %sv%s from %s", *key, meta)
@@ -329,8 +329,8 @@ class CertServer(SCIONElement):
         :param trc_rep: TRC reply.
         :type trc_rep: TRCReply
         """
-        cmgt = cpld.contents
-        trc_rep = cmgt.contents
+        cmgt = cpld.union
+        trc_rep = cmgt.union
         assert isinstance(trc_rep, TRCReply), type(trc_rep)
         isd, ver = trc_rep.trc.get_isd_ver()
         logging.info("TRCReply received for ISD %sv%s, ZK: %s",
@@ -381,8 +381,8 @@ class CertServer(SCIONElement):
         :param DRKeyRequest req: the DRKey request
         :param UDPMetadata meta: the metadata
         """
-        dpld = cpld.contents
-        req = dpld.contents
+        dpld = cpld.union
+        req = dpld.union
         assert isinstance(req, DRKeyRequest), type(req)
         logging.info("DRKeyRequest received from %s: %s", meta, req.short_desc())
         REQS_TOTAL.labels(**self._labels, type="drkey").inc()
@@ -442,8 +442,8 @@ class CertServer(SCIONElement):
         :param UDPMetadata meta: the metadata
         :param Bool from_zk: if the reply has been received from Zookeeper
         """
-        dpld = cpld.contents
-        rep = dpld.contents
+        dpld = cpld.union
+        rep = dpld.union
         assert isinstance(rep, DRKeyReply), type(rep)
         logging.info("DRKeyReply received from %s: %s", meta, rep.short_desc())
         src = meta or "ZK"

--- a/python/integration/cert_req_test.py
+++ b/python/integration/cert_req_test.py
@@ -69,8 +69,8 @@ class TestCertClient(TestClientBase):
 
     def _handle_response(self, spkt):
         cpld = spkt.parse_payload()
-        cmgt = cpld.contents
-        pld = cmgt.contents
+        cmgt = cpld.union
+        pld = cmgt.union
         logging.debug("Got:\n%s", spkt)
         if not self.cert_done:
             if (self.dst_ia, 0 == pld.chain.get_leaf_isd_as_ver()):

--- a/python/lib/app/sciond.py
+++ b/python/lib/app/sciond.py
@@ -251,7 +251,7 @@ class SCIONDConnector:
         if response.id != expected_id:
             raise SCIONDResponseError("Wrong response ID: %d (expected %d)" %
                                       (response.id, expected_id))
-        return response.contents
+        return response.union
 
     @staticmethod
     def _try_cache(cache, key_list):

--- a/python/lib/packet/ctrl_pld.py
+++ b/python/lib/packet/ctrl_pld.py
@@ -22,7 +22,7 @@ import struct
 import capnp
 
 # SCION
-import proto.scion_capnp as P
+import proto.ctrl_pld_capnp as P
 from lib.drkey.drkey_mgmt import DRKeyMgmt
 from lib.errors import SCIONParseError
 from lib.packet.cert_mgmt import CertMgmt
@@ -37,7 +37,7 @@ from lib.util import Raw
 
 class CtrlPayload(CerealBox):
     NAME = "CtrlPayload"
-    P_CLS = P.SCION
+    P_CLS = P.CtrlPld
     CLASS_FIELD_MAP = {
         PathSegment: PayloadClass.PCB,
         IFIDPayload: PayloadClass.IFID,

--- a/python/lib/packet/packet_base.py
+++ b/python/lib/packet/packet_base.py
@@ -187,8 +187,8 @@ class CerealBox(object, metaclass=ABCMeta):
 
     All child classes must define the NAME, P_CLS, and CLASS_FIELD_MAP attributes.
     """
-    def __init__(self, contents):
-        self.contents = contents
+    def __init__(self, union):
+        self.union = union
 
     @classmethod
     def from_proto(cls, p):  # pragma: no cover
@@ -200,55 +200,55 @@ class CerealBox(object, metaclass=ABCMeta):
         type_ = p.which()
         for cls_, field in cls.CLASS_FIELD_MAP.items():
             if type_ == field:
-                return cls._from_contents(p, cls_.from_proto(getattr(p, type_)))
+                return cls._from_union(p, cls_.from_proto(getattr(p, type_)))
         raise SCIONParseError("Unsupported %s proto type: %s" % (cls.NAME, type_))
 
     @classmethod
-    def _from_contents(cls, p, contents):  # pragma: no cover
+    def _from_union(cls, p, union):  # pragma: no cover
         """
         Internal constructor, overridden by sub-classes which have more fields than just a single
         unnamed union.
 
         p is passed in to be available to subclasses which override this.
         """
-        return cls(contents)
+        return cls(union)
 
     def proto(self):
         """
         Return the corresponding capnp object.
         """
-        return self.P_CLS.new_message(**{self.type(): self.contents.proto()})
+        return self.P_CLS.new_message(**{self.type(): self.union.proto()})
 
     def type(self):
         """
-        Return the type of the contents, represented by the union field name.
+        Return the type of the union, represented by the union field name.
         """
-        c = self.CLASS_FIELD_MAP.get(self.contents.__class__)
+        c = self.CLASS_FIELD_MAP.get(self.union.__class__)
         if c is not None:
             return c
         raise SCIONTypeError("Unsupported %s proto class %s (%s)" %
-                             (self.NAME, self.contents.__class__, type(self.contents)))
+                             (self.NAME, self.union.__class__, type(self.union)))
 
     def inner_type(self):
         """
         Return the type of the innermost Cerealizable object, represented by the union field name in
         the innermost CerealBox object.
         """
-        if isinstance(self.contents, CerealBox):
-            return self.contents.inner_type()
+        if isinstance(self.union, CerealBox):
+            return self.union.inner_type()
         return self.type()
 
     def pack(self):
         return self.proto().to_bytes_packed()
 
     def copy(self):
-        return self.__class__(self.contents.copy())
+        return self.__class__(self.union.copy())
 
     def __len__(self):
         return self.proto().total_size.word_count * 8
 
     def __str__(self):
-        return "%s(%dB): %s" % (self.NAME, len(self), self.contents)
+        return "%s(%dB): %s" % (self.NAME, len(self), self.union)
 
 
 class PayloadRaw(Serializable):  # pragma: no cover

--- a/python/lib/sciond_api/base.py
+++ b/python/lib/sciond_api/base.py
@@ -46,8 +46,8 @@ class SCIONDMsg(CerealBox):  # pragma: no cover
         SCIONDServiceInfoReply: SCIONDMsgType.SERVICE_REPLY,
     }
 
-    def __init__(self, contents, id):
-        super().__init__(contents)
+    def __init__(self, union, id):
+        super().__init__(union)
         self.id = id
 
     @classmethod
@@ -59,12 +59,12 @@ class SCIONDMsg(CerealBox):  # pragma: no cover
         return cls.from_proto(p)
 
     @classmethod
-    def _from_contents(cls, p, contents):  # pragma: no cover
-        return cls(contents, p.id)
+    def _from_union(cls, p, union):  # pragma: no cover
+        return cls(union, p.id)
 
     def proto(self):
         field = self.type()
-        return self.P_CLS.new_message(**{"id": self.id, field: self.contents.proto()})
+        return self.P_CLS.new_message(**{"id": self.id, field: self.union.proto()})
 
     def __str__(self):
-        return "%s(%dB): id=%s %s" % (self.NAME, len(self), self.id, self.contents)
+        return "%s(%dB): id=%s %s" % (self.NAME, len(self), self.id, self.union)

--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -225,8 +225,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
 
         :param IFStatePayload infos: The state info objects.
         """
-        pmgt = cpld.contents
-        infos = pmgt.contents
+        pmgt = cpld.union
+        infos = pmgt.union
         assert isinstance(infos, IFStatePayload), type(infos)
         for info in infos.iter_infos():
             if not info.p.active and info.p.revInfo:
@@ -242,8 +242,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
 
         :param rev_info: The RevocationInfo object.
         """
-        pmgt = cpld.contents
-        rev_info = pmgt.contents
+        pmgt = cpld.union
+        rev_info = pmgt.union
         assert isinstance(rev_info, RevocationInfo), type(rev_info)
         if not self._validate_revocation(rev_info):
             return
@@ -372,8 +372,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         """
         Handles paths received from the network.
         """
-        pmgt = cpld.contents
-        seg_recs = pmgt.contents
+        pmgt = cpld.union
+        seg_recs = pmgt.union
         assert isinstance(seg_recs, PathSegmentRecords), type(seg_recs)
         params = self._dispatch_params(seg_recs, meta)
         # Add revocations for peer interfaces included in the path segments.

--- a/python/path_server/core.py
+++ b/python/path_server/core.py
@@ -258,8 +258,8 @@ class CorePathServer(PathServer):
         pending request (False).
         Return True when resolution succeeded, False otherwise.
         """
-        pmgt = cpld.contents
-        req = pmgt.contents
+        pmgt = cpld.union
+        req = pmgt.union
         assert isinstance(req, PathSegmentReq), type(req)
         # Random ID for a request.
         req_id = req_id or random.randint(0, 2**32 - 1)

--- a/python/path_server/local.py
+++ b/python/path_server/local.py
@@ -71,8 +71,8 @@ class LocalPathServer(PathServer):
         """
         Handle generic type of a path request.
         """
-        pmgt = cpld.contents
-        req = pmgt.contents
+        pmgt = cpld.union
+        req = pmgt.union
         assert isinstance(req, PathSegmentReq), type(req)
         # Random ID for a request.
         req_id = req_id or random.randint(0, 2**32 - 1)

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -548,8 +548,8 @@ class SCIONElement(object):
         :type rep: TRCReply.
         """
         meta.close()
-        cmgt = cpld.contents
-        rep = cmgt.contents
+        cmgt = cpld.union
+        rep = cmgt.union
         assert isinstance(rep, TRCReply), type(rep)
         isd, ver = rep.trc.get_isd_ver()
         logging.info("TRC reply received for %sv%s from %s" % (isd, ver, meta))
@@ -586,8 +586,8 @@ class SCIONElement(object):
 
     def process_trc_request(self, cpld, meta):
         """Process a TRC request."""
-        cmgt = cpld.contents
-        req = cmgt.contents
+        cmgt = cpld.union
+        req = cmgt.union
         assert isinstance(req, TRCRequest), type(req)
         isd, ver = req.isd_as()[0], req.p.version
         logging.info("TRC request received for %sv%s from %s" % (isd, ver, meta))
@@ -599,8 +599,8 @@ class SCIONElement(object):
 
     def process_cert_chain_reply(self, cpld, meta):
         """Process a certificate chain reply."""
-        cmgt = cpld.contents
-        rep = cmgt.contents
+        cmgt = cpld.union
+        rep = cmgt.union
         assert isinstance(rep, CertChainReply), type(rep)
         meta.close()
         isd_as, ver = rep.chain.get_leaf_isd_as_ver()
@@ -634,8 +634,8 @@ class SCIONElement(object):
 
     def process_cert_chain_request(self, cpld, meta):
         """Process a certificate chain request."""
-        cmgt = cpld.contents
-        req = cmgt.contents
+        cmgt = cpld.union
+        req = cmgt.union
         assert isinstance(req, CertChainRequest), type(req)
         isd_as, ver = req.isd_as(), req.p.version
         logging.info("Cert chain request received for %sv%s from %s" % (isd_as, ver, meta))

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -178,8 +178,8 @@ class SCIONDaemon(SCIONElement):
         """
         Handle path reply from local path server.
         """
-        pmgt = cpld.contents
-        path_reply = pmgt.contents
+        pmgt = cpld.union
+        path_reply = pmgt.union
         assert isinstance(path_reply, PathSegmentRecords), type(path_reply)
         for rev_info in path_reply.iter_rev_infos():
             self.peer_revs.add(rev_info)
@@ -259,7 +259,7 @@ class SCIONDaemon(SCIONElement):
                 "API: type %s not supported.", TypeBase.to_str(mtype))
 
     def _api_handle_path_request(self, pld, meta):
-        request = pld.contents
+        request = pld.union
         assert isinstance(request, SCIONDPathRequest), type(request)
         req_id = pld.id
         if request.p.flags.sibra:
@@ -302,7 +302,7 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(path_reply.pack(), meta)
 
     def _api_handle_as_request(self, pld, meta):
-        request = pld.contents
+        request = pld.union
         assert isinstance(request, SCIONDASInfoRequest), type(request)
         remote_as = request.isd_as()
         if remote_as:
@@ -315,7 +315,7 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(as_reply.pack(), meta)
 
     def _api_handle_if_request(self, pld, meta):
-        request = pld.contents
+        request = pld.union
         assert isinstance(request, SCIONDIFInfoRequest), type(request)
         all_brs = request.all_brs()
         if_list = []
@@ -333,7 +333,7 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(if_reply.pack(), meta)
 
     def _api_handle_service_request(self, pld, meta):
-        request = pld.contents
+        request = pld.union
         assert isinstance(request, SCIONDServiceInfoRequest), type(request)
         all_svcs = request.all_services()
         svc_list = []
@@ -353,7 +353,7 @@ class SCIONDaemon(SCIONElement):
         self.send_meta(svc_reply.pack(), meta)
 
     def _api_handle_rev_notification(self, pld, meta):
-        request = pld.contents
+        request = pld.union
         assert isinstance(request, SCIONDRevNotification), type(request)
         status = self.handle_revocation(CtrlPayload(PathMgmt(request.rev_info())), meta)
         rev_reply = SCIONDMsg(SCIONDRevReply.from_values(status), pld.id)
@@ -364,8 +364,8 @@ class SCIONDaemon(SCIONElement):
         self.handle_revocation(CtrlPayload(PathMgmt(rev_info)), meta)
 
     def handle_revocation(self, cpld, meta):
-        pmgt = cpld.contents
-        rev_info = pmgt.contents
+        pmgt = cpld.union
+        rev_info = pmgt.union
         assert isinstance(rev_info, RevocationInfo), type(rev_info)
         if not self._validate_revocation(rev_info):
             return SCIONDRevReplyStatus.INVALID

--- a/python/sibra_server/main.py
+++ b/python/sibra_server/main.py
@@ -145,8 +145,8 @@ class SibraServerBase(SCIONElement):
         determine which interface the segments use, then pass the segment to the
         appropriate Link.
         """
-        pmgt = cpld.contents
-        payload = pmgt.contents
+        pmgt = cpld.union
+        payload = pmgt.union
         assert isinstance(payload, PathRecordsReg), type(payload)
         meta.close()
         name = PST.to_str(self.PST_TYPE)


### PR DESCRIPTION
Also:
Rename `contents` to `union` since there can only be one unnamed union in a capnp struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1257)
<!-- Reviewable:end -->
