### PR TITLE
Fix PS._validate_segment to use the correct interface IDs.

### DIFF
--- a/go/lib/ctrl/seg/hop.go
+++ b/go/lib/ctrl/seg/hop.go
@@ -23,10 +23,10 @@ import (
 
 type HopEntry struct {
 	RawInIA     uint32 `capnp:"inIA"`
-	InIF        uint64
+	RemoteInIF  uint64
 	InMTU       uint16 `capnp:"inMTU"`
 	RawOutIA    uint32 `capnp:"outIA"`
-	OutIF       uint64
+	RemoteOutIF uint64
 	RawHopField []byte `capnp:"hof"`
 }
 

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -84,14 +84,19 @@ func (ps *PathSegment) String() string {
 	desc = append(desc, info.Timestamp().UTC().Format(common.TimeFmt))
 	hops_desc := []string{}
 	for _, as := range ps.ASEntries {
-		hop := as.HopEntries[0]
+		hop_entry := as.HopEntries[0]
+		hop, err := hop_entry.HopField()
+		if err != nil {
+			hops_desc = append(hops_desc, err.Error())
+			continue
+		}
 		hop_desc := []string{}
-		if hop.InIF > 0 {
-			hop_desc = append(hop_desc, fmt.Sprintf("%v ", hop.InIF))
+		if hop.Ingress > 0 {
+			hop_desc = append(hop_desc, fmt.Sprintf("%v ", hop.Ingress))
 		}
 		hop_desc = append(hop_desc, as.IA().String())
-		if hop.OutIF > 0 {
-			hop_desc = append(hop_desc, fmt.Sprintf(" %v", hop.OutIF))
+		if hop.Egress > 0 {
+			hop_desc = append(hop_desc, fmt.Sprintf(" %v", hop.Egress))
 		}
 		hops_desc = append(hops_desc, strings.Join(hop_desc, ""))
 	}

--- a/proto/pcb.capnp
+++ b/proto/pcb.capnp
@@ -8,10 +8,10 @@ using Exts = import "asm_exts.capnp";
 
 struct PCBMarking {
     inIA @0 :UInt32;  # Ingress (incl peer) ISD-AS
-    inIF @1 :UInt64; # Interface ID on far end of ingress link
+    remoteInIF @1 :UInt64; # Interface ID on far end of ingress link
     inMTU @2 :UInt16;  # Ingress Link MTU
     outIA @3 :UInt32;  # Downstream ISD-AS
-    outIF @4 :UInt64; # Interface ID on far end of egress link
+    remoteOutIF @4 :UInt64; # Interface ID on far end of egress link
     hof @5 :Data;
 }
 

--- a/python/lib/packet/pcb.py
+++ b/python/lib/packet/pcb.py
@@ -48,11 +48,11 @@ class PCBMarking(Cerealizable):
     VER = len(P_CLS.schema.fields) - 1
 
     @classmethod
-    def from_values(cls, in_ia, in_ifid, in_mtu, out_ia, out_ifid,
+    def from_values(cls, in_ia, remote_in_ifid, in_mtu, out_ia, remote_out_ifid,
                     hof):  # pragma: no cover
         return cls(cls.P_CLS.new_message(
-            inIA=int(in_ia), inIF=in_ifid, inMTU=in_mtu,
-            outIA=int(out_ia), outIF=out_ifid, hof=hof.pack()))
+            inIA=int(in_ia), remoteInIF=remote_in_ifid, inMTU=in_mtu,
+            outIA=int(out_ia), remoteOutIF=remote_out_ifid, hof=hof.pack()))
 
     def inIA(self):  # pragma: no cover
         return ISD_AS(self.p.inIA)
@@ -71,18 +71,18 @@ class PCBMarking(Cerealizable):
         if self.VER != 5:
             raise SCIONSigVerError("PCBMarking.sig_pack5 cannot support version %s", self.VER)
         b.append(self.p.inIA.to_bytes(4, 'big'))
-        b.append(self.p.inIF.to_bytes(8, 'big'))
+        b.append(self.p.remoteInIF.to_bytes(8, 'big'))
         b.append(self.p.inMTU.to_bytes(2, 'big'))
         b.append(self.p.outIA.to_bytes(4, 'big'))
-        b.append(self.p.outIF.to_bytes(8, 'big'))
+        b.append(self.p.remoteOutIF.to_bytes(8, 'big'))
         b.append(self.p.hof)
         return b"".join(b)
 
     def short_desc(self):
         s = []
         s.append("From: %s (IF: %s) To: %s (IF: %s) Ingress MTU:%s" %
-                 (self.inIA(), self.p.inIF, self.outIA(),
-                  self.p.outIF, self.p.inMTU))
+                 (self.inIA(), self.p.remoteInIF, self.outIA(),
+                  self.p.remoteOutIF, self.p.inMTU))
         s.append("  %s" % self.hof())
         return "\n".join(s)
 

--- a/python/lib/path_combinator.py
+++ b/python/lib/path_combinator.py
@@ -349,8 +349,8 @@ def _find_peer_hfs(up_asm, down_asm, peer_revs):
         for down_peer in down_asm.iter_pcbms(1):
             down_hof = down_peer.hof()
             if (up_peer.inIA() == down_ia and down_peer.inIA() == up_ia and
-                    up_peer.p.inIF == down_hof.ingress_if and
-                    up_hof.ingress_if == down_peer.p.inIF):
+                    up_peer.p.remoteInIF == down_hof.ingress_if and
+                    up_hof.ingress_if == down_peer.p.remoteInIF):
                 # Check that there is no valid revocation for the peering
                 # interface.
                 up_rev = peer_revs.get((up_ia, up_hof.ingress_if))

--- a/python/lib/path_store.py
+++ b/python/lib/path_store.py
@@ -124,9 +124,9 @@ class PathPolicy(object):
         """
         for asm in pcb.iter_asms():
             for pcbm in asm.iter_pcbms():
-                if pcbm.inIA().int() and not pcbm.p.inIF:
+                if pcbm.inIA().int() and not pcbm.p.remoteInIF:
                     return pcbm.inIA()
-                if pcbm.outIA().int() and not pcbm.p.outIF:
+                if pcbm.outIA().int() and not pcbm.p.remoteOutIF:
                     return pcbm.outIA()
         return None
 

--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -438,7 +438,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         """
         for asm in seg.iter_asms():
             pcbm = asm.pcbm(0)
-            for if_id in [pcbm.p.inIF, pcbm.p.outIF]:
+            for if_id in [pcbm.hof().ingress_if, pcbm.hof().egress_if]:
                 rev_info = self.revocations.get((asm.isd_as(), if_id))
                 if rev_info:
                     logging.debug("Found revoked interface (%d, %s) in segment %s." %

--- a/python/test/lib/packet/pcb_test.py
+++ b/python/test/lib/packet/pcb_test.py
@@ -33,10 +33,10 @@ _ISD_AS1_BYTES = _ISD_AS1.to_bytes(4, 'big')
 _ISD_AS2_BYTES = _ISD_AS2.to_bytes(4, 'big')
 
 
-def mk_pcbm_p(inIF=22):
+def mk_pcbm_p(remoteInIF=22):
     return create_mock_full({
-        "inIA": _ISD_AS1, "inIF": inIF, "inMTU": 4000, "outIA": _ISD_AS2,
-        "outIF": 33, "hof": b"hof"},
+        "inIA": _ISD_AS1, "remoteInIF": remoteInIF, "inMTU": 4000, "outIA": _ISD_AS2,
+        "remoteOutIF": 33, "hof": b"hof"},
         class_=PCBMarking)
 
 

--- a/python/test/lib/path_combinator_test.py
+++ b/python/test/lib/path_combinator_test.py
@@ -517,9 +517,9 @@ class TestPathCombinatorFindPeerHfs(object):
         ]
         return up_pcbms, down_pcbms
 
-    def _mk_pcbm(self, inIA, inIF, hof_ingress, mtu):
+    def _mk_pcbm(self, inIA, remoteInIF, hof_ingress, mtu):
         hof = create_mock_full({"ingress_if": hof_ingress})
-        p = create_mock_full({"inIF": inIF, "inMTU": mtu})
+        p = create_mock_full({"remoteInIF": remoteInIF, "inMTU": mtu})
         return create_mock_full({"inIA()": inIA, "p": p, "hof()": hof})
 
     def test(self):


### PR DESCRIPTION
Also: Globally renamed in/outIF to remoteIn/remoteOutIF

```
sam@workbox:~/go/src/github.com/netsec-ethz/scion$ git grep '\.inIF'
sam@workbox:~/go/src/github.com/netsec-ethz/scion$ git grep '\.outIF'
sam@workbox:~/go/src/github.com/netsec-ethz/scion$ 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1260)
<!-- Reviewable:end -->
