### PR TITLE
Allow reading data from a closed ringbuf.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ bin/dispatcher
 bin/logdog
 bin/sig
 bin/topopruner
-bin/echo
+bin/echoscion
 c/dispatcher/dispatcher
 c/lib/scion/checksum_bench
 c/ssp/test/*client

--- a/go/lib/ringbuf/ringbuf.go
+++ b/go/lib/ringbuf/ringbuf.go
@@ -122,7 +122,9 @@ func (r *Ring) Read(entries EntryList, block bool) (int, bool) {
 			r.readableC.Wait()
 		}
 	}
-	if r.closed {
+	if r.closed && r.readable == 0 {
+		// Don't return -1 so long as there are still readable entries
+		// available.
 		return -1, blocked
 	}
 	n := min(r.readable, len(entries))


### PR DESCRIPTION
This prevents data-loss when a writer has finished with the ringbuf and
calls Close().

Also:
- Update .gitignore for echoscion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1265)
<!-- Reviewable:end -->
