### PR TITLE
Full revocation support in snet

### DIFF
--- a/go/lib/hpkt/read.go
+++ b/go/lib/hpkt/read.go
@@ -299,7 +299,10 @@ func (p *parseCtx) DefaultL4Parser() error {
 	case common.L4UDP:
 		p.s.Pld = common.RawBytes(p.b[p.offset : p.offset+pldLen])
 	case common.L4SCMP:
-		hdr, _ := p.s.L4.(*scmp.Hdr)
+		hdr, ok := p.s.L4.(*scmp.Hdr)
+		if !ok {
+			return common.NewCError("Unable to extract SCMP payload, type assertion failed.")
+		}
 		p.s.Pld, err = scmp.PldFromRaw(p.b[p.offset:p.offset+pldLen],
 			scmp.ClassType{Class: hdr.Class, Type: hdr.Type})
 		if err != nil {

--- a/go/lib/pathmgr/apppath.go
+++ b/go/lib/pathmgr/apppath.go
@@ -17,6 +17,8 @@ package pathmgr
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"fmt"
+	"strings"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/sciond"
@@ -55,12 +57,26 @@ func (aps AppPathSet) Copy() AppPathSet {
 	return newAPS
 }
 
-// GetAppPath returns an arbitrary path from aps.
-func (aps AppPathSet) GetAppPath() *AppPath {
+// GetAppPath returns an AppPath from the set. It first tries to find
+// a path with key pref; if one cannot be found, an arbitrary one
+// is returned.
+func (aps AppPathSet) GetAppPath(pref PathKey) *AppPath {
+	ap, ok := aps[pref]
+	if ok {
+		return ap
+	}
 	for _, v := range aps {
 		return v
 	}
 	return nil
+}
+
+func (aps AppPathSet) String() string {
+	var desc []string
+	for _, path := range aps {
+		desc = append(desc, fmt.Sprintf("%v", path.Entry.Path.Interfaces))
+	}
+	return "{" + strings.Join(desc, ";") + "}"
 }
 
 // AppPath contains a SCIOND path entry.

--- a/go/lib/pathmgr/apppath.go
+++ b/go/lib/pathmgr/apppath.go
@@ -17,7 +17,6 @@ package pathmgr
 import (
 	"crypto/sha256"
 	"encoding/binary"
-	"fmt"
 	"strings"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
@@ -74,7 +73,7 @@ func (aps AppPathSet) GetAppPath(pref PathKey) *AppPath {
 func (aps AppPathSet) String() string {
 	var desc []string
 	for _, path := range aps {
-		desc = append(desc, fmt.Sprintf("%v", path.Entry.Path.Interfaces))
+		desc = append(desc, path.Entry.Path.String())
 	}
 	return "{" + strings.Join(desc, ";") + "}"
 }

--- a/go/lib/pathmgr/apppath.go
+++ b/go/lib/pathmgr/apppath.go
@@ -60,9 +60,11 @@ func (aps AppPathSet) Copy() AppPathSet {
 // a path with key pref; if one cannot be found, an arbitrary one
 // is returned.
 func (aps AppPathSet) GetAppPath(pref PathKey) *AppPath {
-	ap, ok := aps[pref]
-	if ok {
-		return ap
+	if len(pref) > 0 {
+		ap, ok := aps[pref]
+		if ok {
+			return ap
+		}
 	}
 	for _, v := range aps {
 		return v
@@ -75,7 +77,7 @@ func (aps AppPathSet) String() string {
 	for _, path := range aps {
 		desc = append(desc, path.Entry.Path.String())
 	}
-	return "{" + strings.Join(desc, ";") + "}"
+	return "{" + strings.Join(desc, "; ") + "}"
 }
 
 // AppPath contains a SCIOND path entry.

--- a/go/lib/scmp/info.go
+++ b/go/lib/scmp/info.go
@@ -182,9 +182,10 @@ func NewInfoRevocation(infoF, hopF, ifID uint16, ingress bool,
 
 func InfoRevocationFromRaw(b common.RawBytes) (*InfoRevocation, error) {
 	p := &InfoRevocation{InfoPathOffsets: &InfoPathOffsets{}}
-	if err := restruct.Unpack(b, common.Order, &p.InfoPathOffsets); err != nil {
-		return nil, common.NewCError("Failed to unpack SCMP Revocation info", "err", err)
-	}
+	p.InfoPathOffsets.InfoF = common.Order.Uint16(b[0:])
+	p.InfoPathOffsets.HopF = common.Order.Uint16(b[2:])
+	p.InfoPathOffsets.IfID = common.Order.Uint16(b[4:])
+	p.InfoPathOffsets.Ingress = (b[6] & 0x01) == 0x01
 	p.RevToken = b[8:]
 	return p, nil
 }

--- a/go/lib/scmp/info.go
+++ b/go/lib/scmp/info.go
@@ -134,9 +134,10 @@ type InfoPathOffsets struct {
 
 func InfoPathOffsetsFromRaw(b common.RawBytes) (*InfoPathOffsets, error) {
 	p := &InfoPathOffsets{}
-	if err := restruct.Unpack(b, common.Order, p); err != nil {
-		return nil, common.NewCError("Failed to unpack SCMP Path Offsets info", "err", err)
-	}
+	p.InfoF = common.Order.Uint16(b[0:])
+	p.HopF = common.Order.Uint16(b[2:])
+	p.IfID = common.Order.Uint16(b[4:])
+	p.Ingress = (b[6] & 0x01) == 0x01
 	return p, nil
 }
 
@@ -181,11 +182,12 @@ func NewInfoRevocation(infoF, hopF, ifID uint16, ingress bool,
 }
 
 func InfoRevocationFromRaw(b common.RawBytes) (*InfoRevocation, error) {
+	var err error
 	p := &InfoRevocation{InfoPathOffsets: &InfoPathOffsets{}}
-	p.InfoPathOffsets.InfoF = common.Order.Uint16(b[0:])
-	p.InfoPathOffsets.HopF = common.Order.Uint16(b[2:])
-	p.InfoPathOffsets.IfID = common.Order.Uint16(b[4:])
-	p.InfoPathOffsets.Ingress = (b[6] & 0x01) == 0x01
+	p.InfoPathOffsets, err = InfoPathOffsetsFromRaw(b)
+	if err != nil {
+		return nil, common.NewCError("Unable to parse path offsets", "err", err)
+	}
 	p.RevToken = b[8:]
 	return p, nil
 }

--- a/go/lib/scmp/info.go
+++ b/go/lib/scmp/info.go
@@ -183,7 +183,7 @@ func NewInfoRevocation(infoF, hopF, ifID uint16, ingress bool,
 
 func InfoRevocationFromRaw(b common.RawBytes) (*InfoRevocation, error) {
 	var err error
-	p := &InfoRevocation{InfoPathOffsets: &InfoPathOffsets{}}
+	p := &InfoRevocation{}
 	p.InfoPathOffsets, err = InfoPathOffsetsFromRaw(b)
 	if err != nil {
 		return nil, common.NewCError("Unable to parse path offsets", "err", err)

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -319,10 +319,7 @@ func (c *Conn) selectPathEntry(raddr *Addr) (*sciond.PathReplyEntry, error) {
 	var pathSet pathmgr.AppPathSet
 	// If the remote address is fixed, register source and destination for
 	// continous path updates
-	// FIXME(scrye): Temporarily, while the SIG uses Listen for the data plane
-	// have all traffic use Register instead of one shot Query
-	// if c.raddr == nil {
-	if false {
+	if c.raddr == nil {
 		pathSet = c.scionNet.pathResolver.Query(c.laddr.IA, raddr.IA)
 	} else {
 		// Sanity check, as Dial already initializes this

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build infrarunning
-
 package snet
 
 import (

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build infrarunning
+
 package snet
 
 import (


### PR DESCRIPTION
This PR adds revocation support to the Go application networking stack.

Due to concurrency issues, it depends on the changes suggested by @jpcsmith in https://github.com/netsec-ethz/scion/pull/1253.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1272)
<!-- Reviewable:end -->
