### PR TITLE
Make SCIOND return multiple paths and not just the first one

### DIFF
--- a/go/lib/ctrl/path_mgmt/seg_recs.go
+++ b/go/lib/ctrl/path_mgmt/seg_recs.go
@@ -48,12 +48,6 @@ func (s *SegRecs) String() string {
 	return strings.Join(desc, "\n")
 }
 
-var _ proto.Cerealizable = (*SegReply)(nil)
-
-type SegReply struct {
-	*SegRecs
-}
-
 var _ proto.Cerealizable = (*SegReg)(nil)
 
 type SegReg struct {

--- a/go/lib/ctrl/path_mgmt/seg_reply.go
+++ b/go/lib/ctrl/path_mgmt/seg_reply.go
@@ -1,0 +1,48 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the Go representation of segment replies.
+
+package path_mgmt
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*SegReply)(nil)
+
+type SegReply struct {
+	Req  *SegReq
+	Recs *SegRecs
+}
+
+func NewSegReplyFromRaw(b common.RawBytes) (*SegReply, error) {
+	s := &SegReply{}
+	return s, proto.ParseFromRaw(s, s.ProtoId(), b)
+}
+
+func (s *SegReply) ProtoId() proto.ProtoIdType {
+	return proto.SegReply_TypeID
+}
+
+func (s *SegReply) Write(b common.RawBytes) (int, error) {
+	return proto.WriteRoot(s, b)
+}
+
+func (s *SegReply) String() string {
+	return fmt.Sprintf("Req: %s Reply:\n%s", s.Req, s.Recs)
+}

--- a/go/lib/ctrl/path_mgmt/seg_req.go
+++ b/go/lib/ctrl/path_mgmt/seg_req.go
@@ -24,10 +24,16 @@ import (
 	"github.com/netsec-ethz/scion/go/proto"
 )
 
+type SegReqId uint64
+
+func (id SegReqId) String() string {
+	return fmt.Sprintf("%016x", uint64(id))
+}
+
 var _ proto.Cerealizable = (*SegReq)(nil)
 
 type SegReq struct {
-	Id       uint64
+	Id       SegReqId
 	RawSrcIA addr.IAInt `capnp:"srcIA"`
 	RawDstIA addr.IAInt `capnp:"dstIA"`
 	Flags    struct {
@@ -58,5 +64,5 @@ func (s *SegReq) Write(b common.RawBytes) (int, error) {
 }
 
 func (s *SegReq) String() string {
-	return fmt.Sprintf("Id: %16x %s -> %s, Flags: %v", s.Id, s.SrcIA(), s.DstIA(), s.Flags)
+	return fmt.Sprintf("Id: %s %s -> %s, Flags: %v", s.Id, s.SrcIA(), s.DstIA(), s.Flags)
 }

--- a/go/lib/ctrl/path_mgmt/seg_req.go
+++ b/go/lib/ctrl/path_mgmt/seg_req.go
@@ -58,27 +58,5 @@ func (s *SegReq) Write(b common.RawBytes) (int, error) {
 }
 
 func (s *SegReq) String() string {
-	return fmt.Sprintf("Id: %08x %v -> %v, Flags: %v", s.Id, s.SrcIA(), s.DstIA(), s.Flags)
-}
-
-type SegReply struct {
-	Id   uint64
-	Recs *SegRecs
-}
-
-func NewSegReplyFromRaw(b common.RawBytes) (*SegReply, error) {
-	s := &SegReply{}
-	return s, proto.ParseFromRaw(s, s.ProtoId(), b)
-}
-
-func (s *SegReply) ProtoId() proto.ProtoIdType {
-	return proto.SegReply_TypeID
-}
-
-func (s *SegReply) Write(b common.RawBytes) (int, error) {
-	return proto.WriteRoot(s, b)
-}
-
-func (s *SegReply) String() string {
-	return fmt.Sprintf("Id: %08x\n%s", s.Id, s.Recs)
+	return fmt.Sprintf("Id: %16x %s -> %s, Flags: %v", s.Id, s.SrcIA(), s.DstIA(), s.Flags)
 }

--- a/go/lib/ctrl/path_mgmt/seg_req.go
+++ b/go/lib/ctrl/path_mgmt/seg_req.go
@@ -27,6 +27,7 @@ import (
 var _ proto.Cerealizable = (*SegReq)(nil)
 
 type SegReq struct {
+	Id       uint64
 	RawSrcIA addr.IAInt `capnp:"srcIA"`
 	RawDstIA addr.IAInt `capnp:"dstIA"`
 	Flags    struct {
@@ -57,5 +58,27 @@ func (s *SegReq) Write(b common.RawBytes) (int, error) {
 }
 
 func (s *SegReq) String() string {
-	return fmt.Sprintf("SrcIA: %v, DstIA: %d, Flags: %v", s.SrcIA(), s.DstIA(), s.Flags)
+	return fmt.Sprintf("Id: %08x %v -> %v, Flags: %v", s.Id, s.SrcIA(), s.DstIA(), s.Flags)
+}
+
+type SegReply struct {
+	Id   uint64
+	Recs *SegRecs
+}
+
+func NewSegReplyFromRaw(b common.RawBytes) (*SegReply, error) {
+	s := &SegReply{}
+	return s, proto.ParseFromRaw(s, s.ProtoId(), b)
+}
+
+func (s *SegReply) ProtoId() proto.ProtoIdType {
+	return proto.SegReply_TypeID
+}
+
+func (s *SegReply) Write(b common.RawBytes) (int, error) {
+	return proto.WriteRoot(s, b)
+}
+
+func (s *SegReply) String() string {
+	return fmt.Sprintf("Id: %08x\n%s", s.Id, s.Recs)
 }

--- a/integration/revocation_test.sh
+++ b/integration/revocation_test.sh
@@ -43,7 +43,7 @@ if [ ${result} -ne 0 ]; then
     exit ${result}
 fi
 # Bring down routers.
-SLEEP=10
+SLEEP=3
 log "Stopping routers and waiting for ${SLEEP}s."
 ./supervisor/supervisor.sh stop "$@"
 if [ $? -ne 0 ]; then

--- a/integration/revocation_test.sh
+++ b/integration/revocation_test.sh
@@ -43,7 +43,7 @@ if [ ${result} -ne 0 ]; then
     exit ${result}
 fi
 # Bring down routers.
-SLEEP=3
+SLEEP=4
 log "Stopping routers and waiting for ${SLEEP}s."
 ./supervisor/supervisor.sh stop "$@"
 if [ $? -ne 0 ]; then

--- a/proto/path_mgmt.capnp
+++ b/proto/path_mgmt.capnp
@@ -24,7 +24,7 @@ struct SegRecs {
 }
 
 struct SegReply {
-    id @0 :UInt64;
+    req @0 :SegReq;
     recs @1 :SegRecs;
 }
 

--- a/proto/path_mgmt.capnp
+++ b/proto/path_mgmt.capnp
@@ -8,12 +8,14 @@ using IFState = import "if_state.capnp";
 using RevInfo = import "rev_info.capnp";
 
 struct SegReq {
-    srcIA @0 :UInt32;
-    dstIA @1 :UInt32;
+    id @0 :UInt64;  # Request ID
+    srcIA @1 :UInt32;
+    dstIA @2 :UInt32;
     flags :group {
-        sibra @2 :Bool;
-        cacheOnly @3 :Bool;
+        sibra @3 :Bool;
+        cacheOnly @4 :Bool;
     }
+
 }
 
 struct SegRecs {
@@ -21,11 +23,16 @@ struct SegRecs {
     revInfos @1 :List(RevInfo.RevInfo);
 }
 
+struct SegReply {
+    id @0 :UInt64;
+    recs @1 :SegRecs;
+}
+
 struct PathMgmt {
     union {
         unset @0 :Void;
         segReq @1 :SegReq;
-        segReply @2 :SegRecs;
+        segReply @2 :SegReply;
         segReg @3 :SegRecs;
         segSync @4 :SegRecs;
         revInfo @5 :RevInfo.RevInfo;

--- a/python/lib/packet/path_mgmt/base.py
+++ b/python/lib/packet/path_mgmt/base.py
@@ -24,12 +24,8 @@ from lib.packet.packet_base import CerealBox
 from lib.types import PathMgmtType
 from lib.packet.path_mgmt.ifstate import IFStatePayload, IFStateRequest
 from lib.packet.path_mgmt.rev_info import RevocationInfo
-from lib.packet.path_mgmt.seg_recs import (
-    PathRecordsReg,
-    PathRecordsReply,
-    PathRecordsSync,
-)
-from lib.packet.path_mgmt.seg_req import PathSegmentReq
+from lib.packet.path_mgmt.seg_recs import PathRecordsReg, PathRecordsSync
+from lib.packet.path_mgmt.seg_req import PathSegmentReq, PathSegmentReply
 
 
 class PathMgmt(CerealBox):  # pragma: no cover
@@ -37,7 +33,7 @@ class PathMgmt(CerealBox):  # pragma: no cover
     P_CLS = P.PathMgmt
     CLASS_FIELD_MAP = {
         PathSegmentReq: PathMgmtType.REQUEST,
-        PathRecordsReply: PathMgmtType.REPLY,
+        PathSegmentReply: PathMgmtType.REPLY,
         PathRecordsReg: PathMgmtType.REG,
         PathRecordsSync: PathMgmtType.SYNC,
         RevocationInfo: PathMgmtType.REVOCATION,

--- a/python/lib/packet/path_mgmt/seg_recs.py
+++ b/python/lib/packet/path_mgmt/seg_recs.py
@@ -86,10 +86,6 @@ class PathSegmentRecords(Cerealizable):  # pragma: no cover
         return "\n".join(s)
 
 
-class PathRecordsReply(PathSegmentRecords):
-    NAME = "PathRecordsReply"
-
-
 class PathRecordsReg(PathSegmentRecords):
     NAME = "PathRecordsReg"
 

--- a/python/lib/packet/path_mgmt/seg_recs.py
+++ b/python/lib/packet/path_mgmt/seg_recs.py
@@ -31,6 +31,7 @@ class PathSegmentRecords(Cerealizable):  # pragma: no cover
     Path Record class used for sending list of down/up-paths. Paths are
     represented as objects of the PathSegment class.
     """
+    NAME = "PathSegmentRecords"
     P_CLS = P.SegRecs
 
     @classmethod

--- a/python/lib/packet/path_mgmt/seg_req.py
+++ b/python/lib/packet/path_mgmt/seg_req.py
@@ -68,7 +68,8 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
         return self.p.id
 
     def short_desc(self):
-        return "Id: %16x %s -> %s  %s" % (self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
+        return "Id: %016x %s -> %s  %s" % (
+            self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
 
 
 class PathSegmentReply(Cerealizable):  # pragma: no cover

--- a/python/lib/packet/path_mgmt/seg_req.py
+++ b/python/lib/packet/path_mgmt/seg_req.py
@@ -22,6 +22,7 @@ import capnp  # noqa
 import proto.path_mgmt_capnp as P
 from lib.defines import PATH_FLAG_CACHEONLY, PATH_FLAG_SIBRA
 from lib.packet.packet_base import Cerealizable
+from lib.packet.path_mgmt.seg_recs import PathSegmentRecords
 from lib.packet.scion_addr import ISD_AS
 
 
@@ -32,15 +33,19 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
     P_CLS = P.SegReq
 
     @classmethod
-    def from_values(cls, src_ia, dst_ia, flags=None):
+    def from_values(cls, req_id, src_ia, dst_ia, flags=None):
         if not flags:
             flags = set()
-        p = cls.P_CLS.new_message(srcIA=int(src_ia), dstIA=int(dst_ia))
+        p = cls.P_CLS.new_message(
+            id=req_id, srcIA=int(src_ia), dstIA=int(dst_ia))
         if PATH_FLAG_SIBRA in flags:
             p.flags.sibra = True
         if PATH_FLAG_CACHEONLY in flags:
             p.flags.cacheOnly = True
         return cls(p)
+
+    def req_id(self):
+        return self.p.id
 
     def src_ia(self):
         return ISD_AS(self.p.srcIA)
@@ -57,4 +62,23 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
         return tuple(flags)
 
     def short_desc(self):
-        return "%s -> %s %s" % (self.src_ia(), self.dst_ia(), self.flags())
+        return "Id: %08x %s -> %s  %s" % (self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
+
+
+class PathSegmentReply(Cerealizable):  # pragma: no cover
+    NAME = "PathSegmentReply"
+    P_CLS = P.SegReply
+
+    @classmethod
+    def from_values(cls, req_id, recs):
+        p = cls.P_CLS.new_message(id=req_id, recs=recs.p)
+        return cls(p)
+
+    def req_id(self):
+        return self.p.id
+
+    def recs(self):
+        return PathSegmentRecords(self.p.recs)
+
+    def short_desc(self):
+        return "Id: %08x\n%s" % (self.req_id(), self.recs())

--- a/python/lib/packet/path_mgmt/seg_req.py
+++ b/python/lib/packet/path_mgmt/seg_req.py
@@ -61,6 +61,12 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
             flags.add(PATH_FLAG_CACHEONLY)
         return tuple(flags)
 
+    def __eq__(self, other):
+        return self.p.id == other.p.id
+
+    def __hash__(self):
+        return self.p.id
+
     def short_desc(self):
         return "Id: %08x %s -> %s  %s" % (self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
 
@@ -70,15 +76,15 @@ class PathSegmentReply(Cerealizable):  # pragma: no cover
     P_CLS = P.SegReply
 
     @classmethod
-    def from_values(cls, req_id, recs):
-        p = cls.P_CLS.new_message(id=req_id, recs=recs.p)
+    def from_values(cls, req, recs):
+        p = cls.P_CLS.new_message(req=req.p, recs=recs.p)
         return cls(p)
 
-    def req_id(self):
-        return self.p.id
+    def req(self):
+        return PathSegmentReq(self.p.req)
 
     def recs(self):
         return PathSegmentRecords(self.p.recs)
 
     def short_desc(self):
-        return "Id: %08x\n%s" % (self.req_id(), self.recs())
+        return "Req: %s\n%s" % (self.req(), self.recs())

--- a/python/lib/packet/path_mgmt/seg_req.py
+++ b/python/lib/packet/path_mgmt/seg_req.py
@@ -62,7 +62,7 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
 
     def __eq__(self, other):
         return (self.p.id == other.p.id and self.p.srcIA == other.p.srcIA and
-            self.p.dstIA == other.p.dstIA and self.flags() == other.flags())
+                self.p.dstIA == other.p.dstIA and self.flags() == other.flags())
 
     def __hash__(self):
         return self.p.id

--- a/python/lib/packet/path_mgmt/seg_req.py
+++ b/python/lib/packet/path_mgmt/seg_req.py
@@ -29,7 +29,6 @@ from lib.packet.scion_addr import ISD_AS
 class PathSegmentReq(Cerealizable):  # pragma: no cover
     """Describes a request for path segment(s)"""
     NAME = "PathSegmentReq"
-    LEN = 1 + 2 * ISD_AS.LEN
     P_CLS = P.SegReq
 
     @classmethod
@@ -62,13 +61,14 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
         return tuple(flags)
 
     def __eq__(self, other):
-        return self.p.id == other.p.id
+        return (self.p.id == other.p.id and self.p.srcIA == other.p.srcIA and
+            self.p.dstIA == other.p.dstIA and self.flags() == other.flags())
 
     def __hash__(self):
         return self.p.id
 
     def short_desc(self):
-        return "Id: %08x %s -> %s  %s" % (self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
+        return "Id: %16x %s -> %s  %s" % (self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
 
 
 class PathSegmentReply(Cerealizable):  # pragma: no cover

--- a/python/lib/util.py
+++ b/python/lib/util.py
@@ -21,6 +21,7 @@ Various utilities for SCION functionality.
 import json
 import logging
 import os
+import random
 import shutil
 import signal
 import sys
@@ -274,6 +275,11 @@ def recv_all(sock, total_len, flags):
             return None
         barr += buf
     return bytes(barr)
+
+
+def random_uint64():
+    """Returns a random number in the range [0, 2**64 - 1]"""
+    return random.randint(0, 2**64 - 1)
 
 
 class SCIONTime(object):

--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -64,8 +64,7 @@ from scion_elem.scion_elem import SCIONElement
 
 # Exported metrics.
 REQS_TOTAL = Counter("ps_reqs_total", "# of path requests", ["server_id", "isd_as"])
-REQS_PENDING = Gauge("ps_req_pending_total",
-                     "# of pending path requests", ["server_id", "isd_as"])
+REQS_PENDING = Gauge("ps_req_pending_total", "# of pending path requests", ["server_id", "isd_as"])
 SEGS_TO_ZK = Gauge("ps_segs_to_zk_total", "# of path segments to ZK", ["server_id", "isd_as"])
 REVS_TO_ZK = Gauge("ps_revs_to_zk_total", "# of revocations to ZK", ["server_id", "isd_as"])
 HT_ROOT_MAPPTINGS = Gauge("ps_ht_root_mappings_total", "# of hashtree root to segment mappings",
@@ -539,8 +538,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
     def _zk_write(self, data):
         hash_ = crypto_hash(data).hex()
         try:
-            self.path_cache.store("%s-%s" %
-                                  (hash_, SCIONTime.get_time()), data)
+            self.path_cache.store("%s-%s" % (hash_, SCIONTime.get_time()), data)
         except ZkNoConnection:
             logging.warning("Unable to store segment(s) in shared path: "
                             "no connection to ZK")
@@ -561,7 +559,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         # Create new formatter to include the request in the log.
         formatter = formatter = Rfc3339Formatter(
             "%(asctime)s [%(levelname)s] (%(threadName)s) %(message)s "
-            "{req=%(req)s, from=%(from)s}")
+            "{id=%(id)s, from=%(from)s}")
         add_formatter('RequestLogger', formatter)
 
     def get_request_logger(self, req, meta):
@@ -571,7 +569,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         # Create a logger for the request to log with context.
         return logging.LoggerAdapter(
             self._request_logger,
-            {"req": req.short_desc(), "from": str(meta)})
+            {"id": req.req_id(), "from": str(meta)})
 
     def _init_metrics(self):
         super()._init_metrics()

--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -336,7 +336,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             {PST.UP: up, PST.CORE: core, PST.DOWN: down},
             revs_to_add
         )
-        pld = PathSegmentReply.from_values(req.req_id(), recs)
+        pld = PathSegmentReply.from_values(req.copy(), recs)
         self.send_meta(CtrlPayload(PathMgmt(pld)), meta)
         logger.info("Sending PATH_REPLY with %d segment(s).", len(all_segs))
 

--- a/python/path_server/core.py
+++ b/python/path_server/core.py
@@ -29,8 +29,8 @@ from prometheus_client import Gauge
 from lib.defines import PATH_FLAG_CACHEONLY, PATH_FLAG_SIBRA
 from lib.packet.ctrl_pld import CtrlPayload
 from lib.packet.path_mgmt.base import PathMgmt
-from lib.packet.path_mgmt.seg_recs import PathRecordsReply
-from lib.packet.path_mgmt.seg_req import PathSegmentReq
+from lib.packet.path_mgmt.seg_recs import PathRecordsSync
+from lib.packet.path_mgmt.seg_req import PathSegmentReply, PathSegmentReq
 from lib.packet.svc import SVCType
 from lib.types import PathSegmentType as PST
 from lib.zk.errors import ZkNoConnection
@@ -50,6 +50,7 @@ class CorePathServer(PathServer):
     core segments and forwards inter-ISD path requests to the corresponding path
     server.
     """
+
     def __init__(self, server_id, conf_dir, prom_export=None):
         """
         :param str server_id: server identifier.
@@ -61,7 +62,8 @@ class CorePathServer(PathServer):
         assert self.topology.is_core_as, "This shouldn't be a local PS!"
         self._master_id = None  # Address of master core Path Server.
         self._segs_to_master = ExpiringDict(1000, 10)
-        self._segs_to_prop = ExpiringDict(1000, 2 * self.config.propagation_time)
+        self._segs_to_prop = ExpiringDict(
+            1000, 2 * self.config.propagation_time)
 
     def _update_master(self):
         """
@@ -161,7 +163,7 @@ class CorePathServer(PathServer):
 
     def _dispatch_params(self, pld, meta):
         params = {}
-        if meta.ia == self.addr.isd_as and isinstance(pld, PathRecordsReply):
+        if meta.ia == self.addr.isd_as and isinstance(pld, PathSegmentReply):
             params["from_master"] = True
         return params
 
@@ -179,8 +181,8 @@ class CorePathServer(PathServer):
         logging.debug("Propagating %d segment(s) to other core ASes",
                       len(self._segs_to_prop))
         for pcbs in self._gen_prop_recs(self._segs_to_prop):
-            reply = PathRecordsReply.from_values(pcbs)
-            self._propagate_to_core_ases(reply)
+            recs = PathRecordsSync.from_values(pcbs)
+            self._propagate_to_core_ases(recs)
 
     def _prop_to_master(self):
         assert not self.zk.have_lock()
@@ -192,8 +194,8 @@ class CorePathServer(PathServer):
         logging.debug("Propagating %d segment(s) to master PS: %s",
                       len(self._segs_to_master), self._master_id)
         for pcbs in self._gen_prop_recs(self._segs_to_master):
-            reply = PathRecordsReply.from_values(pcbs)
-            self._send_to_master(reply)
+            recs = PathRecordsSync.from_values(pcbs)
+            self._send_to_master(recs)
 
     def _send_to_master(self, pld):
         """
@@ -229,11 +231,13 @@ class CorePathServer(PathServer):
         sflags = set(flags)
         sflags.add(PATH_FLAG_CACHEONLY)
         flags = tuple(sflags)
-        req = PathSegmentReq.from_values(src_ia, dst_ia, flags=flags)
-        logger.debug("Asking master (%s) for segment: %s" % (self._master_id, req.short_desc()))
+        req_id = random.randint(0, 2**64 - 1)
+        req = PathSegmentReq.from_values(req_id, src_ia, dst_ia, flags=flags)
+        logger.debug("Asking master (%s) for segment: %s" %
+                     (self._master_id, req.short_desc()))
         self._send_to_master(req)
 
-    def _propagate_to_core_ases(self, rep_recs):
+    def _propagate_to_core_ases(self, pld):
         """
         Propagate 'pkt' to other core ASes.
         """
@@ -244,14 +248,14 @@ class CorePathServer(PathServer):
                                        last_ia=self.addr.isd_as)
             if not csegs:
                 logging.warning("Cannot propagate %s to AS %s. No path available." %
-                                (rep_recs.NAME, isd_as))
+                                (pld.NAME, isd_as))
                 continue
             cseg = csegs[0].get_path(reverse_direction=True)
             meta = self._build_meta(ia=isd_as, path=cseg,
                                     host=SVCType.PS_A, reuse=True)
-            self.send_meta(CtrlPayload(PathMgmt(rep_recs.copy())), meta)
+            self.send_meta(CtrlPayload(PathMgmt(pld.copy())), meta)
 
-    def path_resolution(self, cpld, meta, new_request=True, logger=None, req_id=None):
+    def path_resolution(self, cpld, meta, new_request=True, logger=None):
         """
         Handle generic type of a path request.
         new_request informs whether a pkt is a new request (True), or is a
@@ -261,10 +265,8 @@ class CorePathServer(PathServer):
         pmgt = cpld.union
         req = pmgt.union
         assert isinstance(req, PathSegmentReq), type(req)
-        # Random ID for a request.
-        req_id = req_id or random.randint(0, 2**32 - 1)
         if logger is None:
-            logger = self.get_request_logger(req, req_id, meta)
+            logger = self.get_request_logger(req, meta)
         dst_ia = req.dst_ia()
         if new_request:
             logger.info("PATH_REQ received")
@@ -276,21 +278,22 @@ class CorePathServer(PathServer):
         dst_is_core = self.is_core_as(dst_ia) or dst_ia[1] == 0
         if dst_is_core:
             core_segs = self._resolve_core(
-                req, req_id, meta, dst_ia, new_request, req.flags(), logger)
+                req, meta, dst_ia, new_request, req.flags(), logger)
             down_segs = set()
         else:
             core_segs, down_segs = self._resolve_not_core(
-                req, req_id, meta, dst_ia, new_request, req.flags(), logger)
+                req, meta, dst_ia, new_request, req.flags(), logger)
 
         if not (core_segs | down_segs):
             if new_request:
                 logger.debug("Segs to %s not found." % dst_ia)
             return False
 
-        self._send_path_segments(req, meta, logger, core=core_segs, down=down_segs)
+        self._send_path_segments(
+            req, meta, logger, core=core_segs, down=down_segs)
         return True
 
-    def _resolve_core(self, req, req_id, meta, dst_ia, new_request, flags, logger):
+    def _resolve_core(self, req, meta, dst_ia, new_request, flags, logger):
         """
         Dst is core AS.
         """
@@ -301,13 +304,14 @@ class CorePathServer(PathServer):
         core_segs = set(self.core_segments(**params))
         if not core_segs and new_request and PATH_FLAG_CACHEONLY not in flags:
             # Segments not found and it is a new request.
-            self.pending_req[(dst_ia, sibra)][req_id] = (req, meta, logger)
+            self.pending_req[(dst_ia, sibra)][
+                req.req_id()] = (req, meta, logger)
             # If dst is in remote ISD then a segment may be kept by master.
             if dst_ia[0] != self.addr.isd_as[0]:
                 self._query_master(dst_ia, logger, flags=flags)
         return core_segs
 
-    def _resolve_not_core(self, seg_req, req_id, meta, dst_ia, new_request, flags, logger):
+    def _resolve_not_core(self, seg_req, meta, dst_ia, new_request, flags, logger):
         """
         Dst is regular AS.
         """
@@ -317,7 +321,7 @@ class CorePathServer(PathServer):
         # Check if there exists any down-segs to dst.
         tmp_down_segs = self.down_segments(last_ia=dst_ia, sibra=sibra)
         if not tmp_down_segs and new_request and PATH_FLAG_CACHEONLY not in flags:
-            self._resolve_not_core_failed(seg_req, req_id, meta, dst_ia, flags, logger)
+            self._resolve_not_core_failed(seg_req, meta, dst_ia, flags, logger)
 
         for dseg in tmp_down_segs:
             dseg_ia = dseg.first_ia()
@@ -332,7 +336,8 @@ class CorePathServer(PathServer):
                 first_ia=dseg_ia, last_ia=self.addr.isd_as, sibra=sibra)
             if not tmp_core_segs and new_request and PATH_FLAG_CACHEONLY not in flags:
                 # Core segment not found and it is a new request.
-                self.pending_req[(dseg_ia, sibra)][req_id] = (seg_req, meta, logger)
+                self.pending_req[(dseg_ia, sibra)][
+                    seg_req.req_id()] = (seg_req, meta, logger)
                 if dst_ia[0] != self.addr.isd_as[0]:
                     # Master may know a segment.
                     self._query_master(dseg_ia, logger, flags=flags)
@@ -341,14 +346,15 @@ class CorePathServer(PathServer):
                 core_segs.update(tmp_core_segs)
         return core_segs, down_segs
 
-    def _resolve_not_core_failed(self, seg_req, req_id, meta, dst_ia, flags, logger):
+    def _resolve_not_core_failed(self, seg_req, meta, dst_ia, flags, logger):
         """
         Execute after _resolve_not_core() cannot resolve a new request, due to
         lack of corresponding down segment(s).
         This must not be executed for a pending request.
         """
         sibra = PATH_FLAG_SIBRA in flags
-        self.pending_req[(dst_ia, sibra)][req_id] = (seg_req, meta, logger)
+        self.pending_req[(dst_ia, sibra)][seg_req.req_id()
+                                          ] = (seg_req, meta, logger)
         if dst_ia[0] == self.addr.isd_as[0]:
             # Master may know down segment as dst is in local ISD.
             self._query_master(dst_ia, logger, flags=flags)
@@ -399,5 +405,6 @@ class CorePathServer(PathServer):
     def _update_metrics(self):
         super()._update_metrics()
         if self._labels:
-            SEGS_TO_MASTER.labels(**self._labels).set(len(self._segs_to_master))
+            SEGS_TO_MASTER.labels(
+                **self._labels).set(len(self._segs_to_master))
             SEGS_TO_PROP.labels(**self._labels).set(len(self._segs_to_prop))

--- a/python/path_server/core.py
+++ b/python/path_server/core.py
@@ -232,8 +232,7 @@ class CorePathServer(PathServer):
         sflags.add(PATH_FLAG_CACHEONLY)
         flags = tuple(sflags)
         req = PathSegmentReq.from_values(random_uint64(), src_ia, dst_ia, flags=flags)
-        logger.debug("Asking master (%s) for segment: %s" %
-                     (self._master_id, req.short_desc()))
+        logger.debug("Asking master (%s) for segment: %s" % (self._master_id, req.short_desc()))
         self._send_to_master(req)
 
     def _propagate_to_core_ases(self, pld):
@@ -288,8 +287,7 @@ class CorePathServer(PathServer):
                 logger.debug("Segs to %s not found." % dst_ia)
             return False
 
-        self._send_path_segments(
-            req, meta, logger, core=core_segs, down=down_segs)
+        self._send_path_segments(req, meta, logger, core=core_segs, down=down_segs)
         return True
 
     def _resolve_core(self, req, meta, dst_ia, new_request, flags, logger):
@@ -303,8 +301,7 @@ class CorePathServer(PathServer):
         core_segs = set(self.core_segments(**params))
         if not core_segs and new_request and PATH_FLAG_CACHEONLY not in flags:
             # Segments not found and it is a new request.
-            self.pending_req[(dst_ia, sibra)][
-                req.req_id()] = (req, meta, logger)
+            self.pending_req[(dst_ia, sibra)][req.req_id()] = (req, meta, logger)
             # If dst is in remote ISD then a segment may be kept by master.
             if dst_ia[0] != self.addr.isd_as[0]:
                 self._query_master(dst_ia, logger, flags=flags)
@@ -335,8 +332,7 @@ class CorePathServer(PathServer):
                 first_ia=dseg_ia, last_ia=self.addr.isd_as, sibra=sibra)
             if not tmp_core_segs and new_request and PATH_FLAG_CACHEONLY not in flags:
                 # Core segment not found and it is a new request.
-                self.pending_req[(dseg_ia, sibra)][
-                    seg_req.req_id()] = (seg_req, meta, logger)
+                self.pending_req[(dseg_ia, sibra)][seg_req.req_id()] = (seg_req, meta, logger)
                 if dst_ia[0] != self.addr.isd_as[0]:
                     # Master may know a segment.
                     self._query_master(dseg_ia, logger, flags=flags)
@@ -403,6 +399,5 @@ class CorePathServer(PathServer):
     def _update_metrics(self):
         super()._update_metrics()
         if self._labels:
-            SEGS_TO_MASTER.labels(
-                **self._labels).set(len(self._segs_to_master))
+            SEGS_TO_MASTER.labels(**self._labels).set(len(self._segs_to_master))
             SEGS_TO_PROP.labels(**self._labels).set(len(self._segs_to_prop))

--- a/python/path_server/core.py
+++ b/python/path_server/core.py
@@ -17,7 +17,6 @@
 """
 # Stdlib
 import logging
-import random
 
 # External
 from external.expiring_dict import ExpiringDict
@@ -33,6 +32,7 @@ from lib.packet.path_mgmt.seg_recs import PathRecordsSync
 from lib.packet.path_mgmt.seg_req import PathSegmentReply, PathSegmentReq
 from lib.packet.svc import SVCType
 from lib.types import PathSegmentType as PST
+from lib.util import random_uint64
 from lib.zk.errors import ZkNoConnection
 from path_server.base import PathServer, REQS_TOTAL
 
@@ -231,8 +231,7 @@ class CorePathServer(PathServer):
         sflags = set(flags)
         sflags.add(PATH_FLAG_CACHEONLY)
         flags = tuple(sflags)
-        req_id = random.randint(0, 2**64 - 1)
-        req = PathSegmentReq.from_values(req_id, src_ia, dst_ia, flags=flags)
+        req = PathSegmentReq.from_values(random_uint64(), src_ia, dst_ia, flags=flags)
         logger.debug("Asking master (%s) for segment: %s" %
                      (self._master_id, req.short_desc()))
         self._send_to_master(req)

--- a/python/path_server/core.py
+++ b/python/path_server/core.py
@@ -353,8 +353,7 @@ class CorePathServer(PathServer):
         This must not be executed for a pending request.
         """
         sibra = PATH_FLAG_SIBRA in flags
-        self.pending_req[(dst_ia, sibra)][seg_req.req_id()
-                                          ] = (seg_req, meta, logger)
+        self.pending_req[(dst_ia, sibra)][seg_req.req_id()] = (seg_req, meta, logger)
         if dst_ia[0] == self.addr.isd_as[0]:
             # Master may know down segment as dst is in local ISD.
             self._query_master(dst_ia, logger, flags=flags)

--- a/python/path_server/core.py
+++ b/python/path_server/core.py
@@ -62,8 +62,7 @@ class CorePathServer(PathServer):
         assert self.topology.is_core_as, "This shouldn't be a local PS!"
         self._master_id = None  # Address of master core Path Server.
         self._segs_to_master = ExpiringDict(1000, 10)
-        self._segs_to_prop = ExpiringDict(
-            1000, 2 * self.config.propagation_time)
+        self._segs_to_prop = ExpiringDict(1000, 2 * self.config.propagation_time)
 
     def _update_master(self):
         """

--- a/python/path_server/local.py
+++ b/python/path_server/local.py
@@ -17,7 +17,6 @@
 """
 # Stdlib
 import logging
-import random
 
 # SCION
 from lib.packet.svc import SVCType
@@ -34,6 +33,7 @@ class LocalPathServer(PathServer):
     SCION Path Server in a non-core AS. Stores up-segments to the core and
     registers down-segments with the CPS. Can cache segments learned from a CPS.
     """
+
     def __init__(self, server_id, conf_dir, prom_export=None):
         """
         :param str server_id: server identifier.
@@ -45,7 +45,8 @@ class LocalPathServer(PathServer):
         assert not self.topology.is_core_as, "This shouldn't be a core PS!"
         # Database of up-segments to the core.
         up_labels = {**self._labels, "type": "up"} if self._labels else None
-        self.up_segments = PathSegmentDB(max_res_no=self.MAX_SEG_NO, labels=up_labels)
+        self.up_segments = PathSegmentDB(
+            max_res_no=self.MAX_SEG_NO, labels=up_labels)
 
     def _handle_up_segment_record(self, pcb, from_zk=False):
         if not from_zk:
@@ -67,17 +68,15 @@ class LocalPathServer(PathServer):
             return set([(pcb.first_ia(), pcb.is_sibra())])
         return set()
 
-    def path_resolution(self, cpld, meta, new_request=True, logger=None, req_id=None):
+    def path_resolution(self, cpld, meta, new_request=True, logger=None):
         """
         Handle generic type of a path request.
         """
         pmgt = cpld.union
         req = pmgt.union
         assert isinstance(req, PathSegmentReq), type(req)
-        # Random ID for a request.
-        req_id = req_id or random.randint(0, 2**32 - 1)
         if logger is None:
-            logger = self.get_request_logger(req, req_id, meta)
+            logger = self.get_request_logger(req, meta)
         dst_ia = req.dst_ia()
         if new_request:
             logger.info("PATH_REQ received")
@@ -94,11 +93,13 @@ class LocalPathServer(PathServer):
         else:
             self._resolve_not_core(req, up_segs, core_segs, down_segs)
         if up_segs | core_segs | down_segs:
-            self._send_path_segments(req, meta, logger, up_segs, core_segs, down_segs)
+            self._send_path_segments(
+                req, meta, logger, up_segs, core_segs, down_segs)
             return True
         if new_request:
             self._request_paths_from_core(req, logger)
-            self.pending_req[(dst_ia, req.p.flags.sibra)][req_id] = (req, meta, logger)
+            self.pending_req[(dst_ia, req.p.flags.sibra)][
+                req.req_id()] = (req, meta, logger)
 
         return False
 

--- a/python/path_server/local.py
+++ b/python/path_server/local.py
@@ -45,8 +45,7 @@ class LocalPathServer(PathServer):
         assert not self.topology.is_core_as, "This shouldn't be a core PS!"
         # Database of up-segments to the core.
         up_labels = {**self._labels, "type": "up"} if self._labels else None
-        self.up_segments = PathSegmentDB(
-            max_res_no=self.MAX_SEG_NO, labels=up_labels)
+        self.up_segments = PathSegmentDB(max_res_no=self.MAX_SEG_NO, labels=up_labels)
 
     def _handle_up_segment_record(self, pcb, from_zk=False):
         if not from_zk:
@@ -93,13 +92,11 @@ class LocalPathServer(PathServer):
         else:
             self._resolve_not_core(req, up_segs, core_segs, down_segs)
         if up_segs | core_segs | down_segs:
-            self._send_path_segments(
-                req, meta, logger, up_segs, core_segs, down_segs)
+            self._send_path_segments(req, meta, logger, up_segs, core_segs, down_segs)
             return True
         if new_request:
             self._request_paths_from_core(req, logger)
-            self.pending_req[(dst_ia, req.p.flags.sibra)][
-                req.req_id()] = (req, meta, logger)
+            self.pending_req[(dst_ia, req.p.flags.sibra)][req.req_id()] = (req, meta, logger)
 
         return False
 

--- a/python/sciond/req.py
+++ b/python/sciond/req.py
@@ -22,11 +22,15 @@ _WAIT_TIME = 0.5
 
 
 class RequestState:  # pragma: no cover
-    """RequestState stores state about path requests issued by SCIOND to the local PS."""
+    """
+    RequestState stores state about path requests issued by SCIOND to the local PS.
+
+
+    """
     def __init__(self, req, checkf):
         self.req = req
         self.reply = None
-        self.checkf = checkf
+        self._checkf = checkf
         self._e = threading.Event()
         self._segs_to_verify = 0
         self._wait = True
@@ -87,7 +91,7 @@ class RequestState:  # pragma: no cover
 
     def _check(self):
         """Checks if a request can be fulfilled."""
-        if self.checkf(self.req.dst_ia(), self.req.flags()):
+        if self._checkf(self.req.dst_ia(), self.req.flags()):
             self._done()
             return True
         return False

--- a/python/sciond/req.py
+++ b/python/sciond/req.py
@@ -1,0 +1,99 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stdlib
+import logging
+import threading
+
+# SCIO
+from lib.defines import PATH_REQ_TOUT
+
+
+class RequestState:  # pragma: no cover
+    """RequestState stores state about path requests issued by SCIOND to the local PS."""
+    def __init__(self, req, checkf):
+        self.req = req
+        self.reply = None
+        self.checkf = checkf
+        self._e = threading.Event()
+        self._ver_tout = None
+        self._segs_to_verify = 0
+        self._timeout = threading.Timer(PATH_REQ_TOUT, self._done)
+        self._wait = True
+        self._timed_out = False
+        logging.debug("Start: %s", req.short_desc())
+
+    def wait(self):
+        self._e.wait()
+
+    def set_reply(self, reply):
+        logging.debug("SetReply: %s", reply.short_desc())
+        self.reply = reply
+        self._segs_to_verify = self.reply.recs().num_segs()
+        self._ver_tout = threading.Timer(0.3, self._ver_tout_fired)
+        self._ver_tout.start()
+
+    def verified_segment(self):
+        """
+        Gets called when a PathSegment of the reply got succesfully verified.
+        Immediately try to fulfill a request if self._wait is False. Otherwise,
+        wait for more verifications.
+        """
+        if self._segs_to_verify == 0:
+            return
+        self._segs_to_verify -= 1
+        logging.debug("Verified Segment (%d oustanding): %s",
+            self._segs_to_verify, self.req.short_desc())
+        if not self._wait:
+            self._check()
+            return
+        # If we have verified all received path segments we can wake up all waiters.
+        if self._segs_to_verify == 0:
+            self._done()
+
+    def timed_out(self):
+        return self._timed_out
+
+    def _check(self):
+        """Checks if a request can be fulfilled."""
+        if self.checkf(self.req.dst_ia(), self.req.flags()):
+            logging.debug("Can fulfill: %s", self.req.short_desc())
+            self._done()
+
+    def _ver_tout_fired(self):
+        """
+        Gets called when the verification timer fired. From now on we try to immediately
+        fullfil requests as new path segments get verified.
+        """
+        logging.debug("Verification Timeout fired for: %s", self.req.short_desc())
+        self._wait = False
+        self.ver_tout = None
+        self._check()
+
+    def _timeout_fired(self):
+        logging.debug("Timeout fired for: %s", self.req.short_desc())
+        self._timed_out = True
+        self._timeout = None
+        self._done()
+
+    def _done(self):
+        logging.debug("Done: %s", self.req.short_desc())
+        # Cancel outstanding timers if there are some.
+        if self._ver_tout:
+            self._ver_tout.cancel()
+            self._ver_tout = None
+        if self._timeout:
+            self._timeout.cancel()
+            self._timeout = None
+        self._e.set()

--- a/python/sciond/req.py
+++ b/python/sciond/req.py
@@ -15,91 +15,42 @@
 # Stdlib
 import threading
 
-# SCIO
-from lib.defines import PATH_REQ_TOUT
-
-_WAIT_TIME = 0.5
+# How long to wait (at most) after segments are received before considering the request done.
+_WAIT_TIME = 0.2
 
 
 class RequestState:  # pragma: no cover
-    """
-    RequestState stores state about path requests issued by SCIOND to the local PS.
-
-
-    """
-    def __init__(self, req, checkf):
+    """RequestState stores state about path requests issued by SCIOND to the local PS."""
+    def __init__(self, req):
         self.req = req
-        self.reply = None
-        self._checkf = checkf
-        self._e = threading.Event()
+        self.e = threading.Event()
         self._segs_to_verify = 0
-        self._wait = True
-        self._timed_out = False
-        self._lock = threading.Lock()
-        self._timer = threading.Timer(_WAIT_TIME, self._first_timer_fired)
-        self._timer.start()
+        self._lock = threading.RLock()
+        self._timer = threading.Timer(_WAIT_TIME, self.done)
+        self._done = False
 
-    def wait(self):
-        self._e.wait()
-
-    def set_reply(self, reply):
+    def notify_reply(self, reply):
         with self._lock:
-            self.reply = reply
-            self._segs_to_verify = self.reply.recs().num_segs()
+            if self._done:
+                return
+            self._segs_to_verify = reply.recs().num_segs()
+            if self._segs_to_verify > 0:
+                self._timer.start()
+            else:
+                self.done()
 
     def verified_segment(self):
-        """
-        Gets called when a PathSegment of the reply got succesfully verified.
-        Immediately try to fulfill a request if self._wait is False. Otherwise,
-        wait for more verifications.
-        """
+        """Gets called when a PathSegment of the reply got succesfully verified."""
         with self._lock:
-            if self._segs_to_verify == 0:
+            if self._done:
                 return
             self._segs_to_verify -= 1
-            if not self._wait:
-                self._check()
-                return
-            # If we have verified all received path segments we can wake up all waiters.
             if self._segs_to_verify == 0:
-                self._done()
+                self.done()
 
-    def timed_out(self):
-        with self._lock:
-            return self._timed_out
-
-    def _first_timer_fired(self):
-        """
-        Gets called when the first timer fired. From now on we try to immediately
-        fulfill requests as new path segments get verified.
-        """
-        with self._lock:
-            self._wait = False
-            if not self._check():
-                self._timer = threading.Timer(PATH_REQ_TOUT - _WAIT_TIME, self._second_timer_fired)
-                self._timer.start()
-
-    def _second_timer_fired(self):
-        """
-        Gets called when the second timer fired. Wake up all waiters and do not
-        bother waiting any longer for a reply or verifications.
-        """
-        with self._lock:
-            self._timed_out = True
-            self._timer = None
-            self._done()
-
-    def _check(self):
-        """Checks if a request can be fulfilled."""
-        if self._checkf(self.req.dst_ia(), self.req.flags()):
-            self._done()
-            return True
-        return False
-
-    def _done(self):
+    def done(self):
         """Wake up all waiters."""
-        # Cancel outstanding timer if there is one.
-        if self._timer:
+        with self._lock:
+            self._done = True
             self._timer.cancel()
-            self._timer = None
-        self._e.set()
+            self.e.set()

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -489,7 +489,6 @@ class SCIONDaemon(SCIONElement):
             # Delete the request from requested_paths
             with self.req_path_lock:
                 if key in self.requested_paths:
-                    logging.debug("Removing request for: %s", key)
                     del self.requested_paths[key]
             # Check if we can fulfill the path request.
             paths = self.path_resolution(dst_ia, flags=flags)

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -104,12 +104,9 @@ class SCIONDaemon(SCIONElement):
                        "type": "down"} if self._labels else None
         core_labels = {**self._labels,
                        "type": "core"} if self._labels else None
-        self.up_segments = PathSegmentDB(
-            segment_ttl=self.SEGMENT_TTL, labels=up_labels)
-        self.down_segments = PathSegmentDB(
-            segment_ttl=self.SEGMENT_TTL, labels=down_labels)
-        self.core_segments = PathSegmentDB(
-            segment_ttl=self.SEGMENT_TTL, labels=core_labels)
+        self.up_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL, labels=up_labels)
+        self.down_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL, labels=down_labels)
+        self.core_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL, labels=core_labels)
         self.peer_revs = RevCache()
         # Keep track of requested paths.
         self.requested_paths = ExpiringDict(self.MAX_REQS, PATH_REQ_TOUT)
@@ -140,8 +137,7 @@ class SCIONDaemon(SCIONElement):
         }
 
         if run_local_api:
-            self._api_sock = ReliableSocket(
-                bind_unix=(self.api_addr, "sciond"))
+            self._api_sock = ReliableSocket(bind_unix=(self.api_addr, "sciond"))
             self._socks.add(self._api_sock, self.handle_accept)
 
     @classmethod
@@ -304,8 +300,7 @@ class SCIONDaemon(SCIONElement):
         self._send_path_reply(req_id, reply_entries, error, meta)
 
     def _send_path_reply(self, req_id, reply_entries, error, meta):
-        path_reply = SCIONDMsg(SCIONDPathReply.from_values(
-            reply_entries, error), req_id)
+        path_reply = SCIONDMsg(SCIONDPathReply.from_values(reply_entries, error), req_id)
         self.send_meta(path_reply.pack(), meta)
 
     def _api_handle_as_request(self, pld, meta):
@@ -318,8 +313,7 @@ class SCIONDaemon(SCIONElement):
         else:
             reply_entry = SCIONDASInfoReplyEntry.from_values(
                 self.addr.isd_as, self.is_core_as(), self.topology.mtu)
-        as_reply = SCIONDMsg(
-            SCIONDASInfoReply.from_values([reply_entry]), pld.id)
+        as_reply = SCIONDMsg(SCIONDASInfoReply.from_values([reply_entry]), pld.id)
         self.send_meta(as_reply.pack(), meta)
 
     def _api_handle_if_request(self, pld, meta):
@@ -357,15 +351,13 @@ class SCIONDaemon(SCIONElement):
                 reply_entry = SCIONDServiceInfoReplyEntry.from_values(
                     svc_type, host_infos)
                 svc_entries.append(reply_entry)
-        svc_reply = SCIONDMsg(
-            SCIONDServiceInfoReply.from_values(svc_entries), pld.id)
+        svc_reply = SCIONDMsg(SCIONDServiceInfoReply.from_values(svc_entries), pld.id)
         self.send_meta(svc_reply.pack(), meta)
 
     def _api_handle_rev_notification(self, pld, meta):
         request = pld.union
         assert isinstance(request, SCIONDRevNotification), type(request)
-        status = self.handle_revocation(
-            CtrlPayload(PathMgmt(request.rev_info())), meta)
+        status = self.handle_revocation(CtrlPayload(PathMgmt(request.rev_info())), meta)
         rev_reply = SCIONDMsg(SCIONDRevReply.from_values(status), pld.id)
         self.send_meta(rev_reply.pack(), meta)
 
@@ -447,8 +439,7 @@ class SCIONDaemon(SCIONElement):
         for segment in db(full=True):
             for asm in segment.iter_asms():
                 if self._verify_revocation_for_asm(rev_info, asm):
-                    logging.debug("Removing segment: %s" %
-                                  segment.short_desc())
+                    logging.debug("Removing segment: %s" % segment.short_desc())
                     to_remove.append(segment.get_hops_hash())
         return db.delete_all(to_remove)
 
@@ -473,7 +464,6 @@ class SCIONDaemon(SCIONElement):
             empty_meta = FwdPathMeta.from_values(empty, [], self.topology.mtu)
             return [empty_meta], SCIONDPathReplyError.OK
         paths = self.path_resolution(dst_ia, flags=flags)
-        error_code = SCIONDPathReplyError.OK
         if not paths:
             key = dst_ia, flags
             with self.req_path_lock:
@@ -499,7 +489,7 @@ class SCIONDaemon(SCIONElement):
             if not paths:
                 logging.error("No paths found for %s", dst_ia)
                 return [], SCIONDPathReplyError.NO_PATHS
-        return paths, error_code
+        return paths, SCIONDPathReplyError.OK
 
     def path_resolution(self, dst_ia, flags=()):
         # dst as == 0 means any core AS in the specified ISD.

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -213,17 +213,9 @@ class SCIONDaemon(SCIONElement):
             PST.CORE: self._handle_core_seg,
         }
         map_[type_](pcb)
-        # if not ret:
-        #     return
         r = seg_meta.params[0]
         if r:
             r.verified_segment()
-        # with self.req_path_lock:
-        #     # .items() makes a copy on an expiring dict, so deleting entries is safe.
-        #     for key, e in self.requested_paths.items():
-        #         if self.path_resolution(*key):
-        #             e.set()
-        #             del self.requested_paths[key]
 
     def _handle_up_seg(self, pcb):
         if self.addr.isd_as != pcb.last_ia():

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -18,7 +18,6 @@
 # Stdlib
 import logging
 import os
-import random
 import threading
 from itertools import product
 
@@ -77,7 +76,7 @@ from lib.types import (
     ServiceType,
     TypeBase,
 )
-from lib.util import SCIONTime
+from lib.util import random_uint64, SCIONTime
 from sciond.req import RequestState
 from scion_elem.scion_elem import SCIONElement
 
@@ -478,9 +477,8 @@ class SCIONDaemon(SCIONElement):
             with self.req_path_lock:
                 if key not in self.requested_paths:
                     # No previous outstanding request
-                    req_id = random.randint(0, 2**64 - 1)
                     req = PathSegmentReq.from_values(
-                        req_id, self.addr.isd_as, dst_ia, flags=flags)
+                        random_uint64(), self.addr.isd_as, dst_ia, flags=flags)
                     self.requested_paths[key] = RequestState(req.copy(), self.path_resolution)
                     self._fetch_segments(req)
                 r = self.requested_paths[key]

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -497,6 +497,7 @@ class SCIONDaemon(SCIONElement):
             # Delete the request from requested_paths
             with self.req_path_lock:
                 if key in self.requested_paths:
+                    logging.debug("Removing request for: %s", key)
                     del self.requested_paths[key]
             # Check if we can fulfill the path request.
             paths = self.path_resolution(dst_ia, flags=flags)


### PR DESCRIPTION
Also:
PathReplies now include the PathRequest they are responding to.
PathRecordsSync is now used to propagate path segments to other core PSes and to the master PS.
Fix a race condition in path request handling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1280)
<!-- Reviewable:end -->
