### PR TITLE
Move PathPredicate from pktcls to pathmgr.

### DIFF
--- a/go/lib/pathmgr/filter_map.go
+++ b/go/lib/pathmgr/filter_map.go
@@ -16,7 +16,6 @@ package pathmgr
 
 import (
 	"github.com/netsec-ethz/scion/go/lib/addr"
-	"github.com/netsec-ethz/scion/go/lib/pktcls"
 )
 
 // filterMap maps iaKey(src, dst) to a filterSet, which is itself a map from a
@@ -30,7 +29,7 @@ type filterMap map[string]filterSet
 
 // get returns the *SyncPaths object for source src, destination dst and path filter pp.
 // If the entry does not exist, the second returned value is false.
-func (fm filterMap) get(src, dst *addr.ISD_AS, pp *pktcls.PathPredicate) (*SyncPaths, bool) {
+func (fm filterMap) get(src, dst *addr.ISD_AS, pp *PathPredicate) (*SyncPaths, bool) {
 	key := iaKey(src, dst)
 	filterSet, ok := fm[key]
 	if !ok {
@@ -53,7 +52,7 @@ func (fm filterMap) get(src, dst *addr.ISD_AS, pp *pktcls.PathPredicate) (*SyncP
 // returned.  Path resolver code can use this object to store up-to-date paths
 // within it, and further expose it to user applications that want up-to-date
 // paths satisfying predicate pp.
-func (fm filterMap) set(src, dst *addr.ISD_AS, pp *pktcls.PathPredicate) *SyncPaths {
+func (fm filterMap) set(src, dst *addr.ISD_AS, pp *PathPredicate) *SyncPaths {
 	var fs filterSet
 	key := iaKey(src, dst)
 
@@ -103,7 +102,7 @@ func (fs filterSet) update(aps AppPathSet) {
 
 type pathFilter struct {
 	sp *SyncPaths
-	pp *pktcls.PathPredicate
+	pp *PathPredicate
 }
 
 // Function update changes paths within the SyncPaths object of pf to the ones

--- a/go/lib/pathmgr/filter_map_test.go
+++ b/go/lib/pathmgr/filter_map_test.go
@@ -21,14 +21,13 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
-	"github.com/netsec-ethz/scion/go/lib/pktcls"
 )
 
 func TestFilterMap(t *testing.T) {
 	Convey("Compile path predicates", t, func() {
-		ppA, err := pktcls.NewPathPredicate("2-21#69")
+		ppA, err := NewPathPredicate("2-21#69")
 		SoMsg("err A", err, ShouldBeNil)
-		ppB, err := pktcls.NewPathPredicate("1-12#0,2-22#0")
+		ppB, err := NewPathPredicate("1-12#0,2-22#0")
 		SoMsg("err B", err, ShouldBeNil)
 		fm := make(filterMap)
 		src := &addr.ISD_AS{I: 1, A: 10}

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -46,7 +46,6 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/ctrl/path_mgmt"
-	"github.com/netsec-ethz/scion/go/lib/pktcls"
 	"github.com/netsec-ethz/scion/go/lib/sciond"
 )
 
@@ -159,7 +158,7 @@ func (r *PR) Register(src, dst *addr.ISD_AS) (*SyncPaths, error) {
 //
 // RegisterFilter also adds pair src-dst to the list of tracked paths (if it
 // wasn't already tracked).
-func (r *PR) RegisterFilter(src, dst *addr.ISD_AS, filter *pktcls.PathPredicate) (*SyncPaths, error) {
+func (r *PR) RegisterFilter(src, dst *addr.ISD_AS, filter *PathPredicate) (*SyncPaths, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -213,7 +212,7 @@ func (r *PR) register(src, dst *addr.ISD_AS) (*SyncPaths, error) {
 }
 
 // UnregisterFilter deletes a previously registered filter.
-func (r *PR) UnregisterFilter(src, dst *addr.ISD_AS, filter *pktcls.PathPredicate) error {
+func (r *PR) UnregisterFilter(src, dst *addr.ISD_AS, filter *PathPredicate) error {
 	// TODO(scrye): implement this
 	return common.NewCError("Not implemented")
 }

--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
-	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
 )

--- a/go/lib/pathmgr/pred.go
+++ b/go/lib/pathmgr/pred.go
@@ -1,0 +1,123 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/sciond"
+)
+
+// A PathPredicate's Eval method returns true if the slice of interfaces in
+// Match is included in the AppPath parameter. Zero values in Match symbolize
+// wildcard matches. For more information and examples, consult the pktcls
+// documentation.
+type PathPredicate struct {
+	Match []sciond.PathInterface
+}
+
+func NewPathPredicate(expr string) (*PathPredicate, error) {
+	var ifaces []sciond.PathInterface
+	ifaceStrs := strings.Split(expr, ",")
+	for _, ifaceStr := range ifaceStrs {
+		iface, err := ppParseIface(ifaceStr)
+		if err != nil {
+			return nil, err
+		}
+
+		ifaces = append(ifaces, iface)
+	}
+	return &PathPredicate{Match: ifaces}, nil
+}
+
+func (pp *PathPredicate) Eval(path *sciond.PathReplyEntry) bool {
+	ifaces := path.Path.Interfaces
+	mIdx := 0
+	for i := range ifaces {
+		if ppWildcardEquals(&ifaces[i], &pp.Match[mIdx]) {
+			mIdx += 1
+			if mIdx == len(pp.Match) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (pp *PathPredicate) String() string {
+	var desc []string
+	for _, iface := range pp.Match {
+		isdas := iface.ISD_AS()
+		desc = append(desc, fmt.Sprintf("%d-%d#%d", isdas.I, isdas.A, iface.IfID))
+	}
+	return strings.Join(desc, ",")
+}
+
+func (pp *PathPredicate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pp.String())
+}
+
+func (pp *PathPredicate) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	other, err := NewPathPredicate(s)
+	if err != nil {
+		return common.NewCError("Unable to parse PathPredicate operand", "err", err)
+	}
+	pp.Match = other.Match
+	return nil
+}
+
+func ppParseIface(str string) (sciond.PathInterface, error) {
+	tokens := strings.Split(str, "#")
+	if len(tokens) != 2 {
+		return sciond.PathInterface{},
+			common.NewCError("Failed to parse interface spec", "value", str)
+	}
+	var iface sciond.PathInterface
+	ia, err := addr.IAFromString(tokens[0])
+	if err != nil {
+		return sciond.PathInterface{}, err
+	}
+	iface.RawIsdas = ia.IAInt()
+	ifid, err := strconv.ParseUint(tokens[1], 10, 64)
+	if err != nil {
+		return sciond.PathInterface{}, err
+	}
+	iface.IfID = ifid
+	return iface, nil
+}
+
+func ppWildcardEquals(x, y *sciond.PathInterface) bool {
+	xIA, yIA := x.ISD_AS(), y.ISD_AS()
+	if xIA.I != 0 && yIA.I != 0 && xIA.I != yIA.I {
+		return false
+	}
+	if xIA.A != 0 && yIA.A != 0 && xIA.A != yIA.A {
+		return false
+	}
+	if x.IfID != 0 && y.IfID != 0 && x.IfID != y.IfID {
+		return false
+	}
+	return true
+}

--- a/go/lib/pathmgr/pred_test.go
+++ b/go/lib/pathmgr/pred_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pktcls
+package pathmgr
 
 import (
 	"fmt"
@@ -24,7 +24,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/sciond"
 )
 
-var paths = map[string]*sciond.PathReplyEntry{
+var ppPaths = map[string]*sciond.PathReplyEntry{
 	"1-19->2-25": {
 		Path: sciond.FwdPathMeta{
 			Interfaces: []sciond.PathInterface{
@@ -131,7 +131,7 @@ func TestPathPredicates(t *testing.T) {
 				pp, err := NewPathPredicate(tc.predicateStr)
 				SoMsg("err", err, ShouldBeNil)
 				SoMsg("pp", pp, ShouldNotBeNil)
-				match := pp.Eval(paths[tc.appPathStr])
+				match := pp.Eval(ppPaths[tc.appPathStr])
 				SoMsg("match", match, ShouldEqual, tc.expected)
 			})
 		}

--- a/go/lib/pktcls/action.go
+++ b/go/lib/pktcls/action.go
@@ -15,14 +15,7 @@
 package pktcls
 
 import (
-	"encoding/json"
-	"fmt"
-	"strconv"
-	"strings"
-
-	"github.com/netsec-ethz/scion/go/lib/addr"
-	"github.com/netsec-ethz/scion/go/lib/common"
-	"github.com/netsec-ethz/scion/go/lib/sciond"
+	"github.com/netsec-ethz/scion/go/lib/pathmgr"
 )
 
 // Interface Action defines how paths and packets may be processed in a way
@@ -40,11 +33,11 @@ var _ Action = (*ActionFilterPaths)(nil)
 
 // Filter only paths which match the embedded PathPredicate.
 type ActionFilterPaths struct {
-	Contains *PathPredicate
+	Contains *pathmgr.PathPredicate
 	Name     string `json:"-"`
 }
 
-func NewActionFilterPaths(name string, pp *PathPredicate) *ActionFilterPaths {
+func NewActionFilterPaths(name string, pp *pathmgr.PathPredicate) *ActionFilterPaths {
 	return &ActionFilterPaths{Name: name, Contains: pp}
 }
 
@@ -64,105 +57,4 @@ func (a *ActionFilterPaths) setName(name string) {
 
 func (a *ActionFilterPaths) Type() string {
 	return TypeActionFilterPaths
-}
-
-// FIXME(scrye): PathPredicate does not necessarily belong in this package.
-// Additionally, AppPathSet is needed to implement Actions on paths, but this
-// causes a circular dependency. Both should be refactored out to a single
-// package in the future.
-
-// A PathPredicate's Eval method returns true if the slice of interfaces in
-// Match is included in the AppPath parameter. Zero values in Match symbolize
-// wildcard matches. For more information and examples, consult the package
-// level documentation.
-type PathPredicate struct {
-	Match []sciond.PathInterface
-}
-
-func NewPathPredicate(expr string) (*PathPredicate, error) {
-	var ifaces []sciond.PathInterface
-	ifaceStrs := strings.Split(expr, ",")
-	for _, ifaceStr := range ifaceStrs {
-		iface, err := parseIface(ifaceStr)
-		if err != nil {
-			return nil, err
-		}
-
-		ifaces = append(ifaces, iface)
-	}
-	return &PathPredicate{Match: ifaces}, nil
-}
-
-func (pp *PathPredicate) Eval(path *sciond.PathReplyEntry) bool {
-	ifaces := path.Path.Interfaces
-	mIdx := 0
-	for i := range ifaces {
-		if wildcardEquals(&ifaces[i], &pp.Match[mIdx]) {
-			mIdx += 1
-			if mIdx == len(pp.Match) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func wildcardEquals(x, y *sciond.PathInterface) bool {
-	xIA, yIA := x.ISD_AS(), y.ISD_AS()
-	if xIA.I != 0 && yIA.I != 0 && xIA.I != yIA.I {
-		return false
-	}
-	if xIA.A != 0 && yIA.A != 0 && xIA.A != yIA.A {
-		return false
-	}
-	if x.IfID != 0 && y.IfID != 0 && x.IfID != y.IfID {
-		return false
-	}
-	return true
-}
-
-func (pp *PathPredicate) String() string {
-	var desc []string
-	for _, iface := range pp.Match {
-		isdas := iface.ISD_AS()
-		desc = append(desc, fmt.Sprintf("%d-%d#%d", isdas.I, isdas.A, iface.IfID))
-	}
-	return strings.Join(desc, ",")
-}
-
-func (pp *PathPredicate) MarshalJSON() ([]byte, error) {
-	return json.Marshal(pp.String())
-}
-
-func (pp *PathPredicate) UnmarshalJSON(b []byte) error {
-	var s string
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	other, err := NewPathPredicate(s)
-	if err != nil {
-		return common.NewCError("Unable to parse PathPredicate operand", "err", err)
-	}
-	pp.Match = other.Match
-	return nil
-}
-
-func parseIface(str string) (sciond.PathInterface, error) {
-	tokens := strings.Split(str, "#")
-	if len(tokens) != 2 {
-		return sciond.PathInterface{}, common.NewCError("Failed to parse interface spec", "value", str)
-	}
-	var iface sciond.PathInterface
-	ia, err := addr.IAFromString(tokens[0])
-	if err != nil {
-		return sciond.PathInterface{}, err
-	}
-	iface.RawIsdas = ia.IAInt()
-	ifid, err := strconv.ParseUint(tokens[1], 10, 64)
-	if err != nil {
-		return sciond.PathInterface{}, err
-	}
-	iface.IfID = ifid
-	return iface, nil
 }

--- a/go/lib/pktcls/action_map_test.go
+++ b/go/lib/pktcls/action_map_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/netsec-ethz/scion/go/lib/pathmgr"
 )
 
 func TestActionMap(t *testing.T) {
 	Convey("Compile path predicates", t, func() {
-		pp, err := NewPathPredicate("1-11#18,1-11#87")
+		pp, err := pathmgr.NewPathPredicate("1-11#18,1-11#87")
 		SoMsg("err", err, ShouldBeNil)
 		SoMsg("pp", pp, ShouldNotBeNil)
 		Convey("Create action map", func() {
@@ -60,10 +62,10 @@ func TestActionMap(t *testing.T) {
 
 func TestMarshalJSONActions(t *testing.T) {
 	Convey("Initialize path predicates", t, func() {
-		ppA, err := NewPathPredicate("1-11#18,1-11#87")
+		ppA, err := pathmgr.NewPathPredicate("1-11#18,1-11#87")
 		SoMsg("ppA err", err, ShouldBeNil)
 		SoMsg("ppA", ppA, ShouldNotBeNil)
-		ppB, err := NewPathPredicate("2-0#0")
+		ppB, err := pathmgr.NewPathPredicate("2-0#0")
 		SoMsg("ppB err", err, ShouldBeNil)
 		SoMsg("ppB", ppB, ShouldNotBeNil)
 		Convey("Create action map", func() {


### PR DESCRIPTION
This will prevent the BR from importing `gopacket` via ctrl->sigmgmt->sigcmn->snet->pathmgr->pktcls->gopacket, and therefore reverse the resident memory usage jump from ~20M to ~40M, which is causing CI to fail due to running out of memory.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1286)
<!-- Reviewable:end -->
