### PR TITLE
SIG updates and trimming.

### DIFF
--- a/go/lib/hpkt/hpkt_test.go
+++ b/go/lib/hpkt/hpkt_test.go
@@ -95,7 +95,6 @@ func Test_ParseScnPkt(t *testing.T) {
 		s := &spkt.ScnPkt{
 			DstIA: &addr.ISD_AS{},
 			SrcIA: &addr.ISD_AS{},
-			Path:  &spath.Path{},
 		}
 		err := ParseScnPkt(s, common.RawBytes(testParsePkt))
 
@@ -109,9 +108,7 @@ func Test_ParseScnPkt(t *testing.T) {
 		SoMsg("AddrHdr.DstHostAddr", s.DstHost.IP(), ShouldResemble, net.IP{169, 254, 1, 2})
 		SoMsg("AddrHdr.SrcHostAddr", s.SrcHost.IP(), ShouldResemble, net.IP{169, 254, 2, 2})
 
-		SoMsg("Path", s.Path.Raw, ShouldResemble, common.RawBytes{})
-		SoMsg("Path.InfOff", s.Path.InfOff, ShouldEqual, 0)
-		SoMsg("Path.HopOff", s.Path.HopOff, ShouldEqual, 0)
+		SoMsg("Path", s.Path, ShouldBeNil)
 
 		udpHdr, ok := s.L4.(*l4.UDP)
 		SoMsg("L4Hdr", ok, ShouldEqual, true)

--- a/go/lib/hpkt/read.go
+++ b/go/lib/hpkt/read.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/l4"
 	"github.com/netsec-ethz/scion/go/lib/scmp"
+	"github.com/netsec-ethz/scion/go/lib/spath"
 	"github.com/netsec-ethz/scion/go/lib/spkt"
 	"github.com/netsec-ethz/scion/go/lib/util"
 )
@@ -255,10 +256,15 @@ func (p *parseCtx) DefaultAddrHdrParser() error {
 func (p *parseCtx) DefaultFwdPathParser() error {
 	p.fwdPathOffsets.start = p.offset
 	pathLen := p.cmnHdr.HdrLenBytes() - p.offset
-	p.s.Path.Raw = p.b[p.offset : p.offset+pathLen]
-	p.s.Path.InfOff = p.cmnHdr.InfoFOffBytes()
-	p.s.Path.HopOff = p.cmnHdr.HopFOffBytes()
-	p.offset += pathLen
+	if pathLen > 0 {
+		if p.s.Path == nil {
+			p.s.Path = &spath.Path{}
+		}
+		p.s.Path.Raw = p.b[p.offset : p.offset+pathLen]
+		p.s.Path.InfOff = p.cmnHdr.InfoFOffBytes() - p.offset
+		p.s.Path.HopOff = p.cmnHdr.HopFOffBytes() - p.offset
+		p.offset += pathLen
+	}
 	p.fwdPathOffsets.end = p.offset
 	return nil
 }

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -76,12 +76,19 @@ func (a *Addr) Copy() *Addr {
 	if a == nil {
 		return nil
 	}
-	// N.B.: Does not copy path.
-	return &Addr{
-		IA:     a.IA.Copy(),
-		Host:   a.Host.Copy(),
-		L4Port: a.L4Port,
+	newA := &Addr{
+		IA:          a.IA.Copy(),
+		Host:        a.Host.Copy(),
+		L4Port:      a.L4Port,
+		NextHopPort: a.NextHopPort,
 	}
+	if a.Path != nil {
+		newA.Path = a.Path.Copy()
+	}
+	if a.NextHopHost != nil {
+		newA.NextHopHost = a.NextHopHost.Copy()
+	}
+	return newA
 }
 
 // AddrFromString converts an address string of format isd-as,[ipaddr]:port

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -214,10 +214,10 @@ func (c *Conn) write(b []byte, raddr *Addr) (int, error) {
 			path = spath.New(pathEntry.Path.FwdPath)
 			nextHopHost = pathEntry.HostInfo.Host()
 			nextHopPort = pathEntry.HostInfo.Port
-		}
-		err = path.InitOffsets()
-		if err != nil {
-			return 0, common.NewCError("Unable to initialize path", "err", err)
+			err = path.InitOffsets()
+			if err != nil {
+				return 0, common.NewCError("Unable to initialize path", "err", err)
+			}
 		}
 	}
 

--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -200,7 +200,7 @@ func (ae *ASEntry) Cleanup() error {
 		ae.Error("Error closing TUN io", "dev", ae.DevName, "err", err)
 	}
 	// Clean up sessions, and associated workers.
-	ae.cleanSess()
+	ae.cleanSessions()
 	for _, ne := range ae.Nets {
 		if err := ne.Cleanup(); err != nil {
 			cerr := err.(*common.CError)
@@ -215,7 +215,7 @@ func (ae *ASEntry) Cleanup() error {
 	return nil
 }
 
-func (ae *ASEntry) cleanSess() {
+func (ae *ASEntry) cleanSessions() {
 	if err := ae.Session.Cleanup(); err != nil {
 		ae.Session.Error("Error cleaning up session", "err", err)
 	}

--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -199,10 +199,8 @@ func (ae *ASEntry) Cleanup() error {
 	if err := ae.tunIO.Close(); err != nil {
 		ae.Error("Error closing TUN io", "dev", ae.DevName, "err", err)
 	}
-	// Clean up session, and its associated workers.
-	if err := ae.Session.Cleanup(); err != nil {
-		ae.Session.Error("Error cleaning up session", "err", err)
-	}
+	// Clean up sessions, and associated workers.
+	ae.cleanSess()
 	for _, ne := range ae.Nets {
 		if err := ne.Cleanup(); err != nil {
 			cerr := err.(*common.CError)
@@ -215,4 +213,10 @@ func (ae *ASEntry) Cleanup() error {
 			"ia", ae.IA, "dev", ae.DevName, "err", err)
 	}
 	return nil
+}
+
+func (ae *ASEntry) cleanSess() {
+	if err := ae.Session.Cleanup(); err != nil {
+		ae.Session.Error("Error cleaning up session", "err", err)
+	}
 }

--- a/go/sig/base/map.go
+++ b/go/sig/base/map.go
@@ -50,7 +50,10 @@ func (am *ASMap) AddIA(ia *addr.ISD_AS) (*ASEntry, error) {
 	if ok {
 		return ae, nil
 	}
-	ae = newASEntry(ia)
+	ae, err := newASEntry(ia)
+	if err != nil {
+		return nil, err
+	}
 	am.t[key] = ae
 	log.Info("Added IA", "ia", ia)
 	return ae, nil

--- a/go/sig/config/config.go
+++ b/go/sig/config/config.go
@@ -31,8 +31,6 @@ import (
 // Cfg is a direct Go representation of the JSON file format.
 type Cfg struct {
 	ASes map[addr.ISD_AS]*ASEntry
-	//PktClasses map[string]*PktClassifier
-	//PathPolicies map[string]*PathPolicy
 }
 
 // Load a JSON config file from path and parse it into a Cfg struct.
@@ -48,7 +46,6 @@ func LoadFromFile(path string) (*Cfg, error) {
 	if len(cfg.ASes) == 0 {
 		return nil, common.NewCError("Empty ASTable in config")
 	}
-	// TODO(kormat): Also ensure that class/action references are valid when those are added.
 	return cfg, nil
 }
 

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -126,18 +126,19 @@ func (dm *dispRegistry) sigCtrl(pld *mgmt.Pld, addr *snet.Addr) {
 
 func dispFunc(dp *snet.DispPkt) {
 	cpld, err := ctrl.NewPldFromRaw(dp.Raw)
+	src := dp.Addr.Copy()
 	if err != nil {
-		log.Error("Unable to parse ctrl payload", "err", err, "src", dp.Addr)
+		log.Error("Unable to parse ctrl payload", "err", err, "src", src)
 		return
 	}
 	u, err := cpld.Union()
 	if err != nil {
-		log.Error("Unable to extract ctrl payload union", "err", err, "src", dp.Addr)
+		log.Error("Unable to extract ctrl payload union", "err", err, "src", src)
 		return
 	}
 	switch pld := u.(type) {
 	case *mgmt.Pld:
-		Dispatcher.sigCtrl(pld, dp.Addr)
+		Dispatcher.sigCtrl(pld, src)
 	default:
 		log.Error("Unsupported ctrl payload type", common.TypeOf(pld))
 	}

--- a/go/sig/egress/dispatcher.go
+++ b/go/sig/egress/dispatcher.go
@@ -79,13 +79,13 @@ func (ed *egressDispatcher) Run() {
 				continue
 			}
 			buf = buf[:length]
-			sess := ed.chooseSess()
+			sess := ed.chooseSess(buf)
 			if sess == nil {
 				// FIXME(kormat): replace with metric.
 				log.Debug("Unable to find session")
 				continue
 			}
-			ed.sess.ring.Write(ringbuf.EntryList{buf}, true)
+			sess.ring.Write(ringbuf.EntryList{buf}, true)
 			pktsRecv.Inc()
 			pktBytesRecv.Add(float64(length))
 		}
@@ -93,6 +93,6 @@ func (ed *egressDispatcher) Run() {
 	ed.Info("EgressDispatcher: stopping")
 }
 
-func (ed *egressDispatcher) chooseSess() *Session {
+func (ed *egressDispatcher) chooseSess(b common.RawBytes) *Session {
 	return ed.sess
 }

--- a/go/sig/egress/session.go
+++ b/go/sig/egress/session.go
@@ -68,7 +68,7 @@ func NewSession(dstIA *addr.ISD_AS, sessId sigcmn.SessionType,
 		prometheus.Labels{"ringId": dstIA.String(), "sessId": sessId.String()})
 	// Not using a fixed local port, as this is for outgoing data only.
 	s.conn, err = snet.ListenSCION("udp4", &snet.Addr{IA: sigcmn.IA, Host: sigcmn.Host})
-	// spawn a PktDispatcher to log any unexpected messages receivedon a write-only connection.
+	// spawn a PktDispatcher to log any unexpected messages received on a write-only connection.
 	go snet.PktDispatcher(s.conn, snet.DispLogger)
 	s.sessMonStop = make(chan struct{})
 	s.sessMonStopped = make(chan struct{})

--- a/go/sig/egress/session.go
+++ b/go/sig/egress/session.go
@@ -22,8 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/netsec-ethz/scion/go/lib/addr"
-	"github.com/netsec-ethz/scion/go/lib/common"
-	liblog "github.com/netsec-ethz/scion/go/lib/log"
 	"github.com/netsec-ethz/scion/go/lib/pathmgr"
 	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 	"github.com/netsec-ethz/scion/go/lib/snet"
@@ -31,37 +29,20 @@ import (
 	"github.com/netsec-ethz/scion/go/sig/siginfo"
 )
 
-type SyncSession struct {
-	atomic.Value
-}
-
-func NewSyncSession() *SyncSession {
-	ss := &SyncSession{}
-	ss.Store(([]*Session)(nil))
-	return ss
-}
-
-func (ss *SyncSession) Load() []*Session {
-	return ss.Value.Load().([]*Session)
-}
-
-// FIXME(kormat): update
-// Session contains the path policy for a given remote AS. This means having
-// a pool of paths that match the specified policy, metrics about those paths,
+// Session contains a pool of paths to the remote AS, metrics about those paths,
 // as well as maintaining the currently favoured path and remote SIG to use.
 type Session struct {
 	log.Logger
-	IA      *addr.ISD_AS
-	SessId  sigcmn.SessionType
-	PolName string
-	// FIXME(kormat): not implemented yet :P contstrains what interfaces to route through.
-	policy interface{}
-	// pool of paths that meet the policy requirement, managed by pathmgr
+	IA     *addr.ISD_AS
+	SessId sigcmn.SessionType
+	// pool of paths, managed by pathmgr
 	pool *pathmgr.SyncPaths
 	// function pointer to return SigMap from parent ASEntry.
 	sigMapF func() siginfo.SigMap
 	// *RemoteInfo
-	currRemote     atomic.Value
+	currRemote atomic.Value
+	// bool
+	healthy        atomic.Value
 	ring           *ringbuf.Ring
 	conn           *snet.Conn
 	sessMonStop    chan struct{}
@@ -69,23 +50,25 @@ type Session struct {
 	workerStopped  chan struct{}
 }
 
-func NewSession(dstIA *addr.ISD_AS, sessId sigcmn.SessionType, polName string,
-	policy interface{}, sigMapF func() siginfo.SigMap) (*Session, error) {
+func NewSession(dstIA *addr.ISD_AS, sessId sigcmn.SessionType,
+	sigMapF func() siginfo.SigMap, logger log.Logger) (*Session, error) {
 	var err error
 	s := &Session{
-		IA: dstIA, SessId: sessId, PolName: polName, policy: policy, sigMapF: sigMapF,
+		Logger:  logger.New("sessId", sessId),
+		IA:      dstIA,
+		SessId:  sessId,
+		sigMapF: sigMapF,
 	}
-	s.Logger = log.New("ia", s.IA, "sessId", s.SessId, "policy", s.PolName)
-	// FIXME(kormat): change to `RegisterFilter once pathmgr supports policies.
-	s.pool, err = sigcmn.PathMgr.Register(sigcmn.IA, dstIA)
-	if err != nil {
+	if s.pool, err = sigcmn.PathMgr.Register(sigcmn.IA, s.IA); err != nil {
 		return nil, err
 	}
 	s.currRemote.Store((*RemoteInfo)(nil))
+	s.healthy.Store(false)
 	s.ring = ringbuf.New(64, nil, "egress",
 		prometheus.Labels{"ringId": dstIA.String(), "sessId": sessId.String()})
 	// Not using a fixed local port, as this is for outgoing data only.
 	s.conn, err = snet.ListenSCION("udp4", &snet.Addr{IA: sigcmn.IA, Host: sigcmn.Host})
+	// spawn a PktDispatcher to log any unexpected messages receivedon a write-only connection.
 	go snet.PktDispatcher(s.conn, snet.DispLogger)
 	s.sessMonStop = make(chan struct{})
 	s.sessMonStopped = make(chan struct{})
@@ -95,8 +78,7 @@ func NewSession(dstIA *addr.ISD_AS, sessId sigcmn.SessionType, polName string,
 
 func (s *Session) Start() {
 	go newSessMonitor(s).run()
-	go NewWorker(s).Run()
-	go connReader(s.conn, "session")
+	go NewWorker(s, s.Logger).Run()
 }
 
 func (s *Session) Cleanup() error {
@@ -114,6 +96,11 @@ func (s *Session) Remote() *RemoteInfo {
 	return s.currRemote.Load().(*RemoteInfo)
 }
 
+func (s *Session) Healthy() bool {
+	// FIxME(kormat): export as metric.
+	return s.healthy.Load().(bool)
+}
+
 type RemoteInfo struct {
 	Sig      *siginfo.Sig
 	sessPath *sessPath
@@ -121,20 +108,4 @@ type RemoteInfo struct {
 
 func (r *RemoteInfo) String() string {
 	return fmt.Sprintf("Sig: %s Path: %s", r.Sig, r.sessPath)
-}
-
-// connReader logs everything read from conn. This is used to make sure the
-// dispatcher doesn't block if it tries to deliver unexpected messages to a
-// write-only connection.
-func connReader(conn *snet.Conn, name string) {
-	defer liblog.LogPanicAndExit()
-	buf := make(common.RawBytes, common.MaxMTU)
-	for {
-		l, src, err := conn.ReadFromSCION(buf)
-		if err != nil {
-			log.Error("connReader error", "name", name, "err", err)
-			continue
-		}
-		log.Warn("connReader", "name", name, "src", src, "raw", buf[:l])
-	}
 }

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -110,8 +110,6 @@ func (d *Dispatcher) read() {
 // exist yet. Dispatching is done based on source ISD-AS -> source host Addr -> Sess Id.
 func (d *Dispatcher) dispatch(frame *FrameBuf, src *snet.Addr) {
 	sessId := sigcmn.SessionType((frame.raw[0]))
-	// FIXME(shitz): Remove as soon as egress sets session id correctly.
-	sessId = 0
 	dispatchStr := fmt.Sprintf("%s/%s/%s", src.IA, src.Host, sessId)
 	// Check if we already have a worker running and start one if not.
 	worker, ok := d.workers[dispatchStr]

--- a/go/sig/ingress/worker.go
+++ b/go/sig/ingress/worker.go
@@ -104,9 +104,9 @@ func (w *Worker) run() {
 // packets to the wire and then adding the frame to the corresponding reassembly
 // list if needed.
 func (w *Worker) processFrame(frame *FrameBuf) {
-	seqNr := int(common.Order.Uint32(frame.raw[:4]))
-	index := int(common.Order.Uint16(frame.raw[4:6]))
-	epoch := int(common.Order.Uint16(frame.raw[6:8]))
+	epoch := int(common.Order.Uint16(frame.raw[1:3]))
+	seqNr := int(common.Order.Uint32(frame.raw[2:6]) & 0x00FFFFFF)
+	index := int(common.Order.Uint16(frame.raw[6:8]))
 	frame.seqNr = seqNr
 	frame.index = index
 	//log.Debug("Received Frame", "seqNr", seqNr, "index", index, "epoch", epoch,

--- a/go/sig/sig.go
+++ b/go/sig/sig.go
@@ -124,15 +124,13 @@ func loadConfig(path string) bool {
 			if encapPort == 0 {
 				encapPort = sigcmn.DefaultEncapPort
 			}
-			err := ae.AddSig(id, sig.Addr, ctrlPort, encapPort, true)
-			if err != nil {
+			if err := ae.AddSig(id, sig.Addr, ctrlPort, encapPort, true); err != nil {
 				cerr := err.(*common.CError)
 				log.Error(cerr.Desc, cerr.Ctx...)
 				success = false
 				continue
 			}
 		}
-		// TODO(kormat): add classes here
 		for _, netw := range cfgEntry.Nets {
 			if err := ae.AddNet(netw.IPNet()); err != nil {
 				cerr := err.(*common.CError)
@@ -141,8 +139,6 @@ func loadConfig(path string) bool {
 				continue
 			}
 		}
-		// TODO(kormat): add sessions here FIXME(kormat): this is probably the wrong ordering.
-		ae.AddSession(11, "placeholder", nil)
 	}
 	return success
 }


### PR DESCRIPTION
- Have a single, default session per remote AS.
- Add subloggers to various SIG elements, for cleaner logging.
- Take a copy of the src addr when processing ctrl packets, as otherwise the
  address gets overwritten by the next packet.
- Make session monitor more robust.
- Update encap header to have session Id, and reorder fields (work by @shitz).:

Also:
- Fix a bug in setting spath offsets when reading a packet.
- Expand snet.Addr's Copy() to copy the path and next hop info.
- Only call InitOffsets on pathmgr-supplied paths in snet.Conn's write()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1289)
<!-- Reviewable:end -->
