### PR TITLE
Fix cert/trc request test

### DIFF
--- a/python/integration/base_cli_srv.py
+++ b/python/integration/base_cli_srv.py
@@ -167,6 +167,8 @@ class TestClientBase(TestBase):
             r_code = self._handle_response(spkt)
             if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
                 self._stop(success=bool(r_code))
+            elif r_code == ResponseRV.CONTINUE:
+                continue
             else:
                 # Rate limit retries to 1 request per second.
                 self._retry_or_stop(1.0 - recv_dur)

--- a/python/integration/base_cli_srv.py
+++ b/python/integration/base_cli_srv.py
@@ -58,6 +58,7 @@ class ResponseRV:
     FAILURE = 0
     SUCCESS = 1
     RETRY = 2
+    CONTINUE = 3
 
 
 class TestBase(object, metaclass=ABCMeta):

--- a/python/integration/cert_req_test.py
+++ b/python/integration/cert_req_test.py
@@ -20,7 +20,6 @@
 # Stdlib
 import logging
 import threading
-import time
 
 # SCION
 import lib.app.sciond as lib_sciond
@@ -88,26 +87,6 @@ class TestCertClient(TestClientBase):
             return ResponseRV.SUCCESS
         logging.error("TRC query failed")
         return ResponseRV.FAILURE
-
-    def run(self):
-        while not self.finished.is_set():
-            self._send()
-            start = time.time()
-            spkt = self._recv()
-            recv_dur = time.time() - start
-            if not spkt:
-                logging.info("Timeout waiting for response.")
-                self._retry_or_stop(flush=True)
-                continue
-            r_code = self._handle_response(spkt)
-            if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
-                self._stop(success=bool(r_code))
-            elif r_code == ResponseRV.CONTINUE:
-                continue
-            else:
-                # Rate limit retries to 1 request per second.
-                self._retry_or_stop(1.0 - recv_dur)
-        self._shutdown()
 
 
 class TestCertReq(TestClientServerBase):

--- a/python/integration/cert_req_test.py
+++ b/python/integration/cert_req_test.py
@@ -78,7 +78,7 @@ class TestCertClient(TestClientBase):
             if (self.dst_ia, 0) == pld.chain.get_leaf_isd_as_ver():
                 logging.debug("Cert query success")
                 self.cert_done = True
-                return ResponseRV.SUCCESS
+                return ResponseRV.CONTINUE
             logging.error("Cert query failed")
             return ResponseRV.FAILURE
         if (self.dst_ia[0], 0) == pld.trc.get_isd_ver():
@@ -101,9 +101,9 @@ class TestCertClient(TestClientBase):
                 continue
             r_code = self._handle_response(spkt)
             if r_code in [ResponseRV.FAILURE, ResponseRV.SUCCESS]:
-                if not self.success:
-                    continue
                 self._stop(success=bool(r_code))
+            elif r_code == ResponseRV.CONTINUE:
+                continue
             else:
                 # Rate limit retries to 1 request per second.
                 self._retry_or_stop(1.0 - recv_dur)


### PR DESCRIPTION
Currently, cert_req_test.py only sends certificate requests, but no TRC requests are issued.
In this PR, cert_req_test.py requests TRC, after CertChain has been successfully received.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1291)
<!-- Reviewable:end -->
