### PR TITLE
Use public addresses as map keys in BR.

### DIFF
--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -81,7 +81,10 @@ func (r *Router) genPkt(dstIA *addr.ISD_AS, dstHost addr.HostAddr, dstL4Port int
 			rp.Egress = append(rp.Egress, rpkt.EgressPair{S: ctx.LocSockOut[0], Dst: ai})
 		}
 	} else {
-		ifid := ctx.Conf.Net.IFAddrMap[srcAddr.Key()]
+		ifid, ok := ctx.Conf.Net.IFAddrMap[srcAddr.Key()]
+		if !ok {
+			return common.NewCError("genPkt: unable to find ifid for address", "addr", srcAddr)
+		}
 		rp.Egress = append(rp.Egress, rpkt.EgressPair{S: ctx.ExtSockOut[ifid]})
 	}
 	return rp.Route()

--- a/go/border/netconf/interface.go
+++ b/go/border/netconf/interface.go
@@ -40,9 +40,9 @@ type NetConf struct {
 	LocAddr []*topology.TopoAddr
 	// IFs maps interface IDs to Interfaces.
 	IFs map[common.IFIDType]*Interface
-	// LocAddrMap maps local address strings to LocAddr indices.
+	// LocAddrMap maps local public address strings to LocAddr indices.
 	LocAddrMap map[string]int
-	// IFAddrMap maps external address strings to interface IDs.
+	// IFAddrMap maps external public address strings to interface IDs.
 	IFAddrMap map[string]common.IFIDType
 	// LocAddrIFIDMap maps local address strings to (potentially multiple)
 	// interface IDs.
@@ -91,7 +91,7 @@ func FromTopo(intfs []common.IFIDType, infomap map[common.IFIDType]topology.IFIn
 	n.IFAddrMap = make(map[string]common.IFIDType, len(n.IFs))
 	for ifid, intf := range n.IFs {
 		var key string
-		// Add mapping of interface bind address to this interface ID.
+		// Add mapping of interface public address to this interface ID.
 		if intf.IFAddr.IPv4 != nil {
 			n.IFAddrMap[keyFromTopoAddr(intf.IFAddr, overlay.IPv4)] = ifid
 		}
@@ -163,7 +163,7 @@ func intfFromTopoIF(t *topology.IFInfo, ifid common.IFIDType) *Interface {
 // This format must be kept in sync with AddrInfo.Key() (from lib/topology/addr.go)
 func keyFromTopoAddr(t *topology.TopoAddr, ot overlay.Type) string {
 	if ot.IsIPv4() {
-		return fmt.Sprintf("%s:%d", t.IPv4.BindAddr(), t.IPv4.BindL4Port())
+		return fmt.Sprintf("%s:%d", t.IPv4.PublicAddr(), t.IPv4.PublicL4Port())
 	}
-	return fmt.Sprintf("%s:%d", t.IPv6.BindAddr(), t.IPv6.BindL4Port())
+	return fmt.Sprintf("%s:%d", t.IPv6.PublicAddr(), t.IPv6.PublicL4Port())
 }

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -222,20 +222,21 @@ func (r *Router) setupNet(ctx *rctx.Ctx, oldCtx *rctx.Ctx) error {
 func setupPosixAddLocal(r *Router, ctx *rctx.Ctx, idx int, ta *topology.TopoAddr,
 	labels prometheus.Labels, oldCtx *rctx.Ctx) (rpkt.HookResult, error) {
 	// No old context. This happens during startup of the router.
+	pai := ta.PublicAddrInfo(ctx.Conf.Topo.Overlay)
+	bai := ta.BindAddrInfo(ctx.Conf.Topo.Overlay)
 	if oldCtx == nil {
-		if err := addPosixLocal(r, ctx, idx, ta.BindAddrInfo(ctx.Conf.Topo.Overlay), labels); err != nil {
+		if err := addPosixLocal(r, ctx, idx, bai, labels); err != nil {
 			return rpkt.HookError, err
 		}
 		return rpkt.HookFinish, nil
 	}
-	ba := ta.BindAddrInfo(ctx.Conf.Topo.Overlay)
-	if oldIdx, ok := oldCtx.Conf.Net.LocAddrMap[ba.Key()]; !ok {
+	if oldIdx, ok := oldCtx.Conf.Net.LocAddrMap[pai.Key()]; !ok {
 		// New local address got added. Configure Posix I/O.
-		if err := addPosixLocal(r, ctx, idx, ba, labels); err != nil {
+		if err := addPosixLocal(r, ctx, idx, bai, labels); err != nil {
 			return rpkt.HookError, err
 		}
 	} else {
-		log.Debug("No change detected for local socket.", "bindaddr", ba)
+		log.Debug("No change detected for local socket.", "pubAddr", pai)
 		// Nothing changed. Copy I/O functions from old context.
 		ctx.LocSockIn[idx] = oldCtx.LocSockIn[oldIdx]
 		ctx.LocSockOut[idx] = oldCtx.LocSockOut[oldIdx]

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -230,6 +230,9 @@ func setupPosixAddLocal(r *Router, ctx *rctx.Ctx, idx int, ta *topology.TopoAddr
 		}
 		return rpkt.HookFinish, nil
 	}
+	// FIXME(kormat): cases not currently handled:
+	// - a local addr moves idx
+	// - a local addr has its bind address change
 	if oldIdx, ok := oldCtx.Conf.Net.LocAddrMap[pai.Key()]; !ok {
 		// New local address got added. Configure Posix I/O.
 		if err := addPosixLocal(r, ctx, idx, bai, labels); err != nil {


### PR DESCRIPTION
This fixes a bug where generating an IFID packet for a NAT'd interface
will cause an interface id lookup to fail, and currently causes a
nil-pointer panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1301)
<!-- Reviewable:end -->
