### PR TITLE
Add cert mgmt support to go

### DIFF
--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -1,0 +1,84 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_mgmt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+type union struct {
+	Which    proto.CertMgmt_Which
+	ChainReq *ChainReq `capnp:"certChainReq"`
+	ChainRep *ChainRep `capnp:"certChainRep"`
+}
+
+func (u *union) set(c proto.Cerealizable) error {
+	switch p := c.(type) {
+	case *ChainReq:
+		u.Which = proto.CertMgmt_Which_certChainReq
+		u.ChainReq = p
+	case *ChainRep:
+		u.Which = proto.CertMgmt_Which_certChainRep
+		u.ChainRep = p
+	default:
+		return common.NewCError("Unsupported cert mgmt union type (set)", "type", common.TypeOf(c))
+	}
+	return nil
+}
+
+func (u *union) get() (proto.Cerealizable, error) {
+	switch u.Which {
+	case proto.CertMgmt_Which_certChainReq:
+		return u.ChainReq, nil
+	case proto.CertMgmt_Which_certChainRep:
+		return u.ChainRep, nil
+	}
+	return nil, common.NewCError("Unsupported cert mgmt union type (get)", "type", u.Which)
+}
+
+var _ proto.Cerealizable = (*Pld)(nil)
+
+type Pld struct {
+	union
+}
+
+// NewPld creates a new cert mgmt payload, containing the supplied Cerealizable instance.
+func NewPld(u proto.Cerealizable) (*Pld, error) {
+	p := &Pld{}
+	return p, p.union.set(u)
+}
+
+func (p *Pld) Union() (proto.Cerealizable, error) {
+	return p.union.get()
+}
+
+func (p *Pld) ProtoId() proto.ProtoIdType {
+	return proto.CertMgmt_TypeID
+}
+
+func (p *Pld) String() string {
+	desc := []string{"CertMgmt: Union:"}
+	u, err := p.Union()
+	if err != nil {
+		desc = append(desc, err.Error())
+	} else {
+		desc = append(desc, fmt.Sprintf("%+v", u))
+	}
+	return strings.Join(desc, " ")
+}

--- a/go/lib/ctrl/cert_mgmt/chain_rep.go
+++ b/go/lib/ctrl/cert_mgmt/chain_rep.go
@@ -1,0 +1,45 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_mgmt
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/crypto/cert"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*ChainRep)(nil)
+
+type ChainRep struct {
+	RawChain common.RawBytes `capnp:"chain"`
+}
+
+func (c *ChainRep) Chain() (*cert.Chain, error) {
+	return cert.ChainFromRaw(c.RawChain, true)
+}
+
+func (c *ChainRep) ProtoId() proto.ProtoIdType {
+	return proto.CertChainRep_TypeID
+}
+
+func (c *ChainRep) String() string {
+	chain, err := c.Chain()
+	if err != nil {
+		return fmt.Sprintf("Invalid CertificateChain: %v", err)
+	}
+	return chain.String()
+}

--- a/go/lib/ctrl/cert_mgmt/chain_req.go
+++ b/go/lib/ctrl/cert_mgmt/chain_req.go
@@ -40,5 +40,5 @@ func (c *ChainReq) ProtoId() proto.ProtoIdType {
 }
 
 func (c *ChainReq) String() string {
-	return fmt.Sprintf("ISD-AS: %v Version: %v CacheOnly: %v", c.IA(), c.Version, c.CacheOnly)
+	return fmt.Sprintf("ISD-AS: %s Version: %v CacheOnly: %v", c.IA(), c.Version, c.CacheOnly)
 }

--- a/go/lib/ctrl/cert_mgmt/chain_req.go
+++ b/go/lib/ctrl/cert_mgmt/chain_req.go
@@ -1,0 +1,44 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the Go representation of IFState requests.
+
+package cert_mgmt
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*ChainReq)(nil)
+
+type ChainReq struct {
+	RawIA     addr.IAInt `capnp:"isdas"`
+	Version   uint32
+	CacheOnly bool
+}
+
+func (c *ChainReq) IA() *addr.ISD_AS {
+	return c.RawIA.IA()
+}
+
+func (c *ChainReq) ProtoId() proto.ProtoIdType {
+	return proto.CertChainReq_TypeID
+}
+
+func (c *ChainReq) String() string {
+	return fmt.Sprintf("ISD-AS: %v Version: %v CacheOnly: %v", c.IA(), c.Version, c.CacheOnly)
+}


### PR DESCRIPTION
Add support for cert managment payloads to go:
 - Add support for chain request
 - Add support for chain reply

Not supported yet:
 - TRC req
 - TRC rep

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1308)
<!-- Reviewable:end -->
