### PR TITLE
Fix SIG seq nr wrapping.

### DIFF
--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -176,11 +176,13 @@ func (ae *ASEntry) sigMgr() {
 	defer liblog.LogPanicAndExit()
 	ticker := time.NewTicker(sigMgrTick)
 	defer ticker.Stop()
+	log.Info("sigMgr starting")
+Top:
 	for {
 		// TODO(kormat): handle adding new SIGs from discovery, and updating existing ones.
 		select {
 		case <-ae.sigMgrStop:
-			break
+			break Top
 		case <-ticker.C:
 			smap := ae.SigMap()
 			for _, sig := range smap {
@@ -188,6 +190,7 @@ func (ae *ASEntry) sigMgr() {
 			}
 		}
 	}
+	log.Info("sigMgr stopping")
 }
 
 func (ae *ASEntry) Cleanup() error {

--- a/go/sig/egress/sessmon.go
+++ b/go/sig/egress/sessmon.go
@@ -114,10 +114,10 @@ func (sm *sessMonitor) updateRemote() {
 			currSig.Fail()
 		}
 		if currSessPath != nil {
+			// FIXME(kormat): these debug statements should be converted to prom metrics.
+			sm.Debug("Timeout", "remote", currRemote, "duration", since)
 			currSessPath.fail()
 		}
-		// FIXME(kormat): these debug statements should be converted to prom metrics.
-		sm.Debug("Timeout", "remote", currRemote, "duration", since)
 		currSig = sm.getNewSig(currSig)
 		currSessPath = sm.getNewPath(currSessPath)
 		sm.needUpdate = true

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -23,7 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/netsec-ethz/scion/go/lib/common"
-	liblog "github.com/netsec-ethz/scion/go/lib/log"
 	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 	"github.com/netsec-ethz/scion/go/lib/snet"
 	"github.com/netsec-ethz/scion/go/sig/metrics"
@@ -115,8 +114,8 @@ func (d *Dispatcher) dispatch(frame *FrameBuf, src *snet.Addr) {
 	worker, ok := d.workers[dispatchStr]
 	if !ok {
 		worker = NewWorker(src, sessId)
-		worker.Start()
 		d.workers[dispatchStr] = worker
+		go worker.Run()
 	}
 	worker.markedForCleanup = false
 	worker.Ring.Write(ringbuf.EntryList{frame}, true)
@@ -124,22 +123,12 @@ func (d *Dispatcher) dispatch(frame *FrameBuf, src *snet.Addr) {
 
 // cleanup periodically stops and releases idle workers.
 func (d *Dispatcher) cleanup() {
-	var toCleanup []*Worker
 	for key, worker := range d.workers {
 		if worker.markedForCleanup {
 			delete(d.workers, key)
-			toCleanup = append(toCleanup, worker)
+			go worker.Stop()
 		} else {
 			worker.markedForCleanup = true
 		}
-	}
-	// Perform the stopping in separate go-routine, since worker.Stop can block,
-	if len(toCleanup) > 0 {
-		go func() {
-			defer liblog.LogPanicAndExit()
-			for _, worker := range toCleanup {
-				worker.Stop()
-			}
-		}()
 	}
 }


### PR DESCRIPTION
As the SIG sequence number is now 24bit, we can't rely on uint32
handling the wrapping for us. This caused the receiving SIG to consider
all frames in an epoch after the first 16mil as "too old", and drop them.

Also:
- Fix a bug that would prevent sigmgr from shutting down.
- Add some extra log statements to mark the start/stop of major go
  routines.
- Don't log timeouts if there is no path.
- Simplify ingress worker start/stop/cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1315)
<!-- Reviewable:end -->
