### PR TITLE
Fix a race-condition in Rpkt reference counting.

### DIFF
--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -60,7 +60,7 @@ func (rp *RtrPkt) Route() error {
 		return common.NewCError("No routing information found", "egress", rp.Egress,
 			"dirFrom", rp.DirFrom, "dirTo", rp.DirTo, "raw", rp.Raw)
 	}
-	rp.refCnt += len(rp.Egress)
+	rp.refInc(len(rp.Egress))
 	// Call all egress functions.
 	for _, epair := range rp.Egress {
 		epair.S.Ring.Write(ringbuf.EntryList{&EgressRtrPkt{rp, epair.Dst}}, true)


### PR DESCRIPTION
As Rpkt.Release() is called from multiple goroutines, the reference
decrement needs to be atomic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1327)
<!-- Reviewable:end -->
