### PR TITLE
Reduce imports by go/sig/{mgmt,sigcmn}

### DIFF
--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -37,7 +37,7 @@ func PollReqHdlr() {
 			continue
 		}
 		//log.Debug("PollReqHdlr: got PollReq", "src", rpld.Addr, "pld", req)
-		spld, err := mgmt.NewPld(rpld.Id, mgmt.NewPollRep(req.Session))
+		spld, err := mgmt.NewPld(rpld.Id, mgmt.NewPollRep(sigcmn.MgmtAddr, req.Session))
 		if err != nil {
 			log.Error("PollReqHdlr: Error creating SIGCtrl payload", "err", err)
 			break

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -26,7 +26,6 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/pktdisp"
 	"github.com/netsec-ethz/scion/go/lib/snet"
 	"github.com/netsec-ethz/scion/go/sig/mgmt"
-	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 )
 
 func Init(conn *snet.Conn) {
@@ -152,6 +151,6 @@ func dispFunc(dp *pktdisp.DispPkt) {
 
 type RegPollKey string
 
-func MkRegPollKey(ia *addr.ISD_AS, session sigcmn.SessionType) RegPollKey {
+func MkRegPollKey(ia *addr.ISD_AS, session mgmt.SessionType) RegPollKey {
 	return RegPollKey(fmt.Sprintf("%s-%s", ia, session))
 }

--- a/go/sig/egress/session.go
+++ b/go/sig/egress/session.go
@@ -27,6 +27,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/pktdisp"
 	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 	"github.com/netsec-ethz/scion/go/lib/snet"
+	"github.com/netsec-ethz/scion/go/sig/mgmt"
 	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 	"github.com/netsec-ethz/scion/go/sig/siginfo"
 )
@@ -36,7 +37,7 @@ import (
 type Session struct {
 	log.Logger
 	IA     *addr.ISD_AS
-	SessId sigcmn.SessionType
+	SessId mgmt.SessionType
 	// pool of paths, managed by pathmgr
 	pool *pathmgr.SyncPaths
 	// remote SIGs
@@ -52,7 +53,7 @@ type Session struct {
 	workerStopped  chan struct{}
 }
 
-func NewSession(dstIA *addr.ISD_AS, sessId sigcmn.SessionType,
+func NewSession(dstIA *addr.ISD_AS, sessId mgmt.SessionType,
 	sigMap *siginfo.SigMap, logger log.Logger) (*Session, error) {
 	var err error
 	s := &Session{

--- a/go/sig/egress/sessmon.go
+++ b/go/sig/egress/sessmon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/spath"
 	"github.com/netsec-ethz/scion/go/sig/disp"
 	"github.com/netsec-ethz/scion/go/sig/mgmt"
+	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 	"github.com/netsec-ethz/scion/go/sig/siginfo"
 )
 
@@ -182,7 +183,7 @@ func (sm *sessMonitor) sendReq() {
 		sm.updateMsgId = msgId
 		sm.Debug("sessMonitor: trying new remote", "msgId", msgId, "remote", sm.smRemote)
 	}
-	spld, err := mgmt.NewPld(msgId, mgmt.NewPollReq(sm.sess.SessId))
+	spld, err := mgmt.NewPld(msgId, mgmt.NewPollReq(sigcmn.MgmtAddr, sm.sess.SessId))
 	if err != nil {
 		sm.Error("sessMonitor: Error creating SIGCtrl payload", "err", err)
 		return

--- a/go/sig/egress/worker.go
+++ b/go/sig/egress/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/spkt"
 	"github.com/netsec-ethz/scion/go/lib/util"
 	"github.com/netsec-ethz/scion/go/sig/metrics"
+	"github.com/netsec-ethz/scion/go/sig/mgmt"
 	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 	"github.com/netsec-ethz/scion/go/sig/siginfo"
 )
@@ -246,7 +247,7 @@ func (f *frame) startPkt(pktLen uint16) {
 	f.offset += PktLenSize
 }
 
-func (f *frame) writeHdr(sessId sigcmn.SessionType, epoch uint16, seq uint32) {
+func (f *frame) writeHdr(sessId mgmt.SessionType, epoch uint16, seq uint32) {
 	var buf bytes.Buffer
 	binary.Write(&buf, common.Order, seq)
 

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 	"github.com/netsec-ethz/scion/go/lib/snet"
 	"github.com/netsec-ethz/scion/go/sig/metrics"
+	"github.com/netsec-ethz/scion/go/sig/mgmt"
 	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 	"github.com/netsec-ethz/scion/go/sig/xnet"
 )
@@ -108,7 +109,7 @@ func (d *Dispatcher) read() {
 // dispatch dispatches a frame to the corresponding worker, spawning one if none
 // exist yet. Dispatching is done based on source ISD-AS -> source host Addr -> Sess Id.
 func (d *Dispatcher) dispatch(frame *FrameBuf, src *snet.Addr) {
-	sessId := sigcmn.SessionType((frame.raw[0]))
+	sessId := mgmt.SessionType((frame.raw[0]))
 	dispatchStr := fmt.Sprintf("%s/%s/%s", src.IA, src.Host, sessId)
 	// Check if we already have a worker running and start one if not.
 	worker, ok := d.workers[dispatchStr]

--- a/go/sig/ingress/worker.go
+++ b/go/sig/ingress/worker.go
@@ -25,7 +25,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/ringbuf"
 	"github.com/netsec-ethz/scion/go/lib/snet"
 	"github.com/netsec-ethz/scion/go/sig/metrics"
-	"github.com/netsec-ethz/scion/go/sig/sigcmn"
+	"github.com/netsec-ethz/scion/go/sig/mgmt"
 )
 
 const (
@@ -39,13 +39,13 @@ const (
 type Worker struct {
 	log.Logger
 	Remote           *snet.Addr
-	SessId           sigcmn.SessionType
+	SessId           mgmt.SessionType
 	Ring             *ringbuf.Ring
 	reassemblyLists  map[int]*ReassemblyList
 	markedForCleanup bool
 }
 
-func NewWorker(remote *snet.Addr, sessId sigcmn.SessionType) *Worker {
+func NewWorker(remote *snet.Addr, sessId mgmt.SessionType) *Worker {
 	// FIXME(kormat): these labels don't allow us to identify traffic from a
 	// specific remote sig, but adding the remote sig addr would cause a label
 	// explosion :/

--- a/go/sig/mgmt/addr.go
+++ b/go/sig/mgmt/addr.go
@@ -17,10 +17,10 @@ package mgmt
 import (
 	"fmt"
 
+	"github.com/netsec-ethz/scion/go/lib/addr"
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/sciond"
 	"github.com/netsec-ethz/scion/go/proto"
-	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 )
 
 var _ proto.Cerealizable = (*Addr)(nil)
@@ -30,10 +30,10 @@ type Addr struct {
 	EncapPort uint16
 }
 
-func newAddr() *Addr {
+func NewAddr(host addr.HostAddr, ctrlPort, encapPort uint16) *Addr {
 	return &Addr{
-		Ctrl:      sciond.HostInfoFromHostAddr(sigcmn.Host, uint16(*sigcmn.CtrlPort)),
-		EncapPort: uint16(*sigcmn.EncapPort),
+		Ctrl:      sciond.HostInfoFromHostAddr(host, ctrlPort),
+		EncapPort: encapPort,
 	}
 }
 

--- a/go/sig/mgmt/common.go
+++ b/go/sig/mgmt/common.go
@@ -1,0 +1,25 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mgmt
+
+import (
+	"fmt"
+)
+
+type SessionType uint8
+
+func (st SessionType) String() string {
+	return fmt.Sprintf("0x%02x", uint8(st))
+}

--- a/go/sig/mgmt/poll.go
+++ b/go/sig/mgmt/poll.go
@@ -21,18 +21,17 @@ import (
 
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/proto"
-	"github.com/netsec-ethz/scion/go/sig/sigcmn"
 )
 
 var _ proto.Cerealizable = (*poll)(nil)
 
 type poll struct {
 	Addr    *Addr
-	Session sigcmn.SessionType
+	Session SessionType
 }
 
-func newPoll(s sigcmn.SessionType) *poll {
-	return &poll{Addr: newAddr(), Session: s}
+func newPoll(a *Addr, s SessionType) *poll {
+	return &poll{Addr: a, Session: s}
 }
 
 func (p *poll) ProtoId() proto.ProtoIdType {
@@ -51,14 +50,14 @@ type PollReq struct {
 	*poll
 }
 
-func NewPollReq(s sigcmn.SessionType) *PollReq {
-	return &PollReq{newPoll(s)}
+func NewPollReq(a *Addr, s SessionType) *PollReq {
+	return &PollReq{newPoll(a, s)}
 }
 
 type PollRep struct {
 	*poll
 }
 
-func NewPollRep(s sigcmn.SessionType) *PollRep {
-	return &PollRep{newPoll(s)}
+func NewPollRep(a *Addr, s SessionType) *PollRep {
+	return &PollRep{newPoll(a, s)}
 }

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netsec-ethz/scion/go/lib/common"
 	"github.com/netsec-ethz/scion/go/lib/pathmgr"
 	"github.com/netsec-ethz/scion/go/lib/snet"
+	"github.com/netsec-ethz/scion/go/sig/mgmt"
 )
 
 const (
@@ -47,6 +48,7 @@ var (
 	Host     addr.HostAddr
 	PathMgr  *pathmgr.PR
 	CtrlConn *snet.Conn
+	MgmtAddr *mgmt.Addr
 )
 
 func Init(ia *addr.ISD_AS, ip net.IP) error {
@@ -59,6 +61,7 @@ func Init(ia *addr.ISD_AS, ip net.IP) error {
 	if err = ValidatePort("local encap", *EncapPort); err != nil {
 		return err
 	}
+	MgmtAddr = mgmt.NewAddr(Host, uint16(*CtrlPort), uint16(*EncapPort))
 	if *sciondPath == "" {
 		*sciondPath = fmt.Sprintf("/run/shm/sciond/sd%s.sock", ia)
 	}
@@ -94,10 +97,4 @@ func ValidatePort(desc string, port int) error {
 			"min", 1, "max", MaxPort, "actual", port)
 	}
 	return nil
-}
-
-type SessionType uint8
-
-func (st SessionType) String() string {
-	return fmt.Sprintf("0x%02x", uint8(st))
 }


### PR DESCRIPTION
go/lib/ctrl depends on go/sig/mgmt, which depends on go/sig/sigcmn,
which depends... on a lot of other things. One symptom is that all go
binaries that included go/lib/ctrl would get the SIG's command-line
flags. This change removes the need for go/sig/mgmt to import
go/sig/sigcmn.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1333)
<!-- Reviewable:end -->
