### PR TITLE
Make go/proto build cleanly even after proto renaming.

### DIFF
--- a/go/proto/Makefile
+++ b/go/proto/Makefile
@@ -1,12 +1,18 @@
-.PHONY: all clean
+.PHONY: all stale clean
 
 PROTO_DIR = ../../proto
 SRCS := $(wildcard $(PROTO_DIR)/*.capnp)
 SRCS := $(filter-out $(PROTO_DIR)/go.capnp, $(SRCS))
 SRCS := $(filter-out $(PROTO_DIR)/*.gen, $(SRCS))
 OUTS = $(patsubst $(PROTO_DIR)/%, %.go, $(SRCS))
+STALE := $(filter-out $(OUTS),$(wildcard *.capnp.go))
 
-all: $(OUTS) structs.gen.go
+all: stale $(OUTS) structs.gen.go
+
+stale:
+ifdef STALE
+	@rm -v $(STALE)
+endif
 
 %.go: $(PROTO_DIR)/%
 	capnp compile -I../vendor/zombiezen.com/go/capnproto2/std -ogo --src-prefix=$(PROTO_DIR) $<


### PR DESCRIPTION
Currently if a `proto/*.capnp` file gets renamed, the generated
`go/proto/*.capnp.go` file doesn't get removed, and then compilation
fails as the same type is defined in multiple .go files. This change
allows make to detect and remove these stale files (and without using
shell, so `make -q` has the knowledge).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1335)
<!-- Reviewable:end -->
