### PR TITLE
Add TRC to cert mgmt in go

### DIFF
--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -26,6 +26,8 @@ type union struct {
 	Which    proto.CertMgmt_Which
 	ChainReq *ChainReq `capnp:"certChainReq"`
 	ChainRep *ChainRep `capnp:"certChainRep"`
+	TRCReq   *TRCReq   `capnp:"trcReq"`
+	TRCRep   *TRCRep   `capnp:"trcRep"`
 }
 
 func (u *union) set(c proto.Cerealizable) error {
@@ -36,6 +38,12 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *ChainRep:
 		u.Which = proto.CertMgmt_Which_certChainRep
 		u.ChainRep = p
+	case *TRCReq:
+		u.Which = proto.CertMgmt_Which_trcReq
+		u.TRCReq = p
+	case *TRCRep:
+		u.Which = proto.CertMgmt_Which_trcRep
+		u.TRCRep = p
 	default:
 		return common.NewCError("Unsupported cert mgmt union type (set)", "type", common.TypeOf(c))
 	}
@@ -48,6 +56,10 @@ func (u *union) get() (proto.Cerealizable, error) {
 		return u.ChainReq, nil
 	case proto.CertMgmt_Which_certChainRep:
 		return u.ChainRep, nil
+	case proto.CertMgmt_Which_trcReq:
+		return u.TRCReq, nil
+	case proto.CertMgmt_Which_trcRep:
+		return u.TRCRep, nil
 	}
 	return nil, common.NewCError("Unsupported cert mgmt union type (get)", "type", u.Which)
 }

--- a/go/lib/ctrl/cert_mgmt/chain_req.go
+++ b/go/lib/ctrl/cert_mgmt/chain_req.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains the Go representation of IFState requests.
+// This file contains the Go representation of Certificate Chain requests.
 
 package cert_mgmt
 

--- a/go/lib/ctrl/cert_mgmt/trc_rep.go
+++ b/go/lib/ctrl/cert_mgmt/trc_rep.go
@@ -1,0 +1,45 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_mgmt
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/common"
+	"github.com/netsec-ethz/scion/go/lib/crypto/trc"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*TRCRep)(nil)
+
+type TRCRep struct {
+	RawTRC common.RawBytes `capnp:"trc"`
+}
+
+func (c *TRCRep) TRC() (*trc.TRC, error) {
+	return trc.TRCFromRaw(c.RawTRC, true)
+}
+
+func (c *TRCRep) ProtoId() proto.ProtoIdType {
+	return proto.TRCRep_TypeID
+}
+
+func (c *TRCRep) String() string {
+	trc, err := c.TRC()
+	if err != nil {
+		return fmt.Sprintf("Invalid TRC: %v", err)
+	}
+	return trc.String()
+}

--- a/go/lib/ctrl/cert_mgmt/trc_req.go
+++ b/go/lib/ctrl/cert_mgmt/trc_req.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains the Go representation of IFState requests.
+// This file contains the Go representation of TRC requests.
 
 package cert_mgmt
 

--- a/go/lib/ctrl/cert_mgmt/trc_req.go
+++ b/go/lib/ctrl/cert_mgmt/trc_req.go
@@ -1,0 +1,44 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the Go representation of IFState requests.
+
+package cert_mgmt
+
+import (
+	"fmt"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+	"github.com/netsec-ethz/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*TRCReq)(nil)
+
+type TRCReq struct {
+	RawIA     addr.IAInt `capnp:"isdas"`
+	Version   uint64
+	CacheOnly bool
+}
+
+func (t *TRCReq) ISD() int {
+	return t.RawIA.IA().I
+}
+
+func (t *TRCReq) ProtoId() proto.ProtoIdType {
+	return proto.TRCReq_TypeID
+}
+
+func (t *TRCReq) String() string {
+	return fmt.Sprintf("ISD: %d Version: %d CacheOnly: %v", t.ISD(), t.Version, t.CacheOnly)
+}


### PR DESCRIPTION
Extend support for cert management payloads in go:
 - Add support for TRC request
 - Add support for TRC reply

(extends PR #1308)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/1339)
<!-- Reviewable:end -->
