### PR TITLE
Rebase for next scionlab version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
   - label: "Check licenses"
     command:
       - mkdir -p /tmp/test-artifacts/licenses
-      - ./tools/licenses.sh /tmp/test-artifacts/licenses
+      - ./tools/licenses.sh /tmp/test-artifacts/licenses $BUILDKITE_PIPELINE_SLUG
       - diff -rNu3 /tmp/test-artifacts/licenses ./licenses/data
     key: licenses
     retry:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Necessary steps in order to run SCION:
    ```bash
    mkdir -p "$GOPATH/src/github.com/scionproto"
    cd "$GOPATH/src/github.com/scionproto"
-   git clone https://github.com/scionproto/scion
+   git clone https://github.com/netsec-ethz/scion
    cd scion
    ```
 

--- a/go/lib/infra/modules/trust/verifier.go
+++ b/go/lib/infra/modules/trust/verifier.go
@@ -42,8 +42,8 @@ type verifier struct {
 // control-plane PKI certificates through infra.Verifier interface.
 func NewVerifier(provider CryptoProvider) infra.Verifier {
 	return &verifier{
-		AllowSkew: 1 * time.Second,
-		MaxAge:    2 * time.Second,
+		AllowSkew: 10 * time.Second, // XXX scionlab: allow up to 10s skew
+		MaxAge:    10 * time.Second, //     "
 		Store:     provider,
 	}
 }

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -190,9 +190,9 @@ func (path *Path) IsEmpty() bool {
 	return path == nil || len(path.Raw) == 0
 }
 
-// incOffsets jumps ahead skip bytes, and searches for the first routing Hop
-// Field starting at that location
-func (path *Path) incOffsets(skip int) error {
+// IncOffsetsRaw jumps ahead skip bytes, but DOES NOT by default skip VerifyOnly HF,
+// and searches for the first Hop Field starting at that location
+func (path *Path) IncOffsetsRaw(skip int, skipVerify bool) error {
 	var hopF *HopField
 	infoF, err := path.GetInfoField(path.InfOff)
 	if err != nil {
@@ -212,12 +212,24 @@ func (path *Path) incOffsets(skip int) error {
 		if hopF, err = path.GetHopField(path.HopOff); err != nil {
 			return common.NewBasicError("Hop Field parse error", err, "offset", path.HopOff)
 		}
-		if !hopF.VerifyOnly {
+		if !skipVerify || !hopF.VerifyOnly {
 			break
 		}
 		path.HopOff += HopFieldLength
 	}
 	return nil
+}
+
+// incOffsets jumps ahead skip bytes, and searches for the first routing Hop
+// Field starting at that location
+func (path *Path) incOffsets(skip int) error {
+	return path.IncOffsetsRaw(skip, true)
+}
+
+// incOffsetsAny jumps ahead skip bytes, and searches for the first Verify/Routing/any Hop
+// Field starting at that location
+func (path *Path) incOffsetsAny(skip int) error {
+	return path.IncOffsetsRaw(skip, false)
 }
 
 func (path *Path) GetInfoField(offset int) (*InfoField, error) {

--- a/go/tools/showpaths/BUILD.bazel
+++ b/go/tools/showpaths/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
         "//go/lib/env:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/sciond:go_default_library",
@@ -15,6 +16,7 @@ go_library(
         "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/snet/addrutil:go_default_library",
+        "//go/lib/spath:go_default_library",
     ],
 )
 

--- a/tools/licenses.sh
+++ b/tools/licenses.sh
@@ -7,13 +7,14 @@ ROOTDIR=$(dirname "$0")/..
 bazel build //:all
 
 DSTDIR=${1:-$ROOTDIR/licenses/data}
+PROJECT=${2:-scion}
 
 rm -rf $DSTDIR
 
-(cd $ROOTDIR/bazel-scion/external; find -L . -iregex '.*\(LICENSE\|COPYING\).*') | while IFS= read -r path ; do
+(cd $ROOTDIR/bazel-$PROJECT/external; find -L . -iregex '.*\(LICENSE\|COPYING\).*') | while IFS= read -r path ; do
     dst=$DSTDIR/$(dirname $path)
     mkdir -p $dst
-    cp $ROOTDIR/bazel-scion/external/$path $dst
+    cp $ROOTDIR/bazel-$PROJECT/external/$path $dst
 done
 
 # Bazel tools are used only for building.


### PR DESCRIPTION
_Note: due to our (somewhat messed up) workflow for the maintenance of this fork, this PR is for review only and will not be merged._

**This branch currently does not contain the (rebased) commits for DRKey**
See matzf:scionlab_nextversion_drkey for a version _with_ DRKey, based on an older SCION version, as described in more detail below.


----

Only keep relevant commits on scionlab. Here is the full log for the scionlab branch since the last update. The first column indicates how this commit was handled:
```
-: commit was cherry-picked, ignored as commit already exists on master
p: picked (with amendments)
d: dropped, no longer needed
d*: same functionality is already present upstream, dropped
```
```
p  2020-01-23 juagargi 5ceec52  Make the DRKey SV store ticker UT more robust. (#71)
-  2019-12-04 matthias 3a2301a  Ignore ENETUNREACH, EHOSTUNREACH in border io (#3448) d  2019-11-26 matthias b451095  Update README, rename netsec-scion to scion
d* 2019-11-25 matthias ff10566  Add go.mod (#69)
d  2019-10-31 matthias d7eebae  Revert "Add non-docker option for zookeeper back (#19)" (#66)
p  2019-10-25 juagargi 35722fb  Store the obtained key in scionds DB. (#67)
-  2019-10-01 matthias 786a1bb  README: https clone, not recursive (#3205)
-  2019-09-18 coding   8ca8d53  Add dependencies to the "install Bazel" step (#3164)
-  2019-09-12 kormat   91f65e0  Make env assumptions more explicit. (#3143)
-  2019-09-16 lukedirt 33df548  Remove c/ (#3144)
p  2019-10-17 juagargi bbf41d4  Drkey (#63)
d  2019-10-14 juagargi 0192671  The UT needs a TRC in the trust DB (#62)
d* 2019-09-23 kmateusz .......  Improve Segment verification (#60)
-  2019-09-11 roos     a37267b  snet: Use correct base conn (#3134)
-  2019-09-10 juagargi 4c60ffb  Fix build for ARM 32 bit (#3129)
-  2019-09-06 juagargi 7016b78  BS: Configurable RevConfig (#3111)
-  2019-09-09 juagargi 4f3e29c  dispatcher socket file mode. (#3124)
-  2019-09-05 juagargi 222e7d5  sciond socket file mode. (#3099)
-  2019-09-04 matthias b31d893  Avoid cgo in lib/overlay/conn to simplify cross-compilation (#3064)
d  2019-08-27 juagargi c34be4a  Don't fail if can't stop zookeeper.
d  2019-08-27 juagargi b45566a  in_docker (#56)
p  2019-08-27 juagargi 692af45  Allow clock drifts up to 10. (#58)
d  2019-06-07 juagargi 136497f  When running SCION ensure gen-cache is there (#38)
d  2019-04-30 matthias 56a56b5  Ignore missing gen/overlay file (#35)
d  2019-07-05 matthias 236f441  Use system zookeeper by default in local topo (#40)
d  2019-03-06 juagargi 28a05e8  Control plane buffer size also to 64K. (#28)
p  2019-03-04 wirzf    8f5e718  Add verbose flag for Hop Fields to showpaths (#25)
d  2019-02-07 matthias cd9acdd  Workaround for many paths: set pktBufSize to 64KiB
d  2019-01-17 matthias b171199  Add non-docker option for zookeeper back (#19)
p  2018-10-18 juagargi bdae933  Indicate to clone netsec-ethz/netsec-scion instead of scionproto/scion (#11)
```

All (or almost all) of these commits were modified to resolve conflicts and/or make the code build against changed APIs.

For DRKey, these changes are fairly extensive:
* initialisation of DRKey stores and runners in `cert_srv/main.go` was adapted, following scionproto/scion#3535. 
  Setting the "messenger" member for `ServiceStore` happens now directly in `NewServiceStore` instead of a separate setter (was previously necessary I guess, but now just too easy to miss (i did miss it))
* adapt `ServiceStore` to use the new `trust/v2`-API, as this is used in `cert_srv/main.go` after scionproto/scion#3538. For this, `ServiceStore.getCertChain` now uses `trustDB.GetRawChain` followed by `ParseChain`. Previously this used the old `GetChainMaxVersion` / `GetChainVersion` functions of the old trust interface. To use the new `cert.Chain` types, add a helper function `getCert` which returns only the decoded AS certificate from which the key can easily be obtained.
* load AS keys using the new `keyconf` APIs to allow loading keys in the new directory and file format. **XXX**: loads decrypt key at fixed version 1, should maybe consider highest version number
* load AS keys for tests also using this new API and update testdata
* drop now unused code in `state.go` and `state_test.go`
* adapt `Lvl1Rep` to use the `scrypto.Version` type instead of `int64`, following scionproto/scion#3206
* adapt logging in `go/lib/infra/messenger/messenger.go` following scionproto/scion#3544
* fix linter warnings (many linelen, some spellcheck, a few small others)
* extend  `go/lib/sciond/fake/fake.go` to satisfy the sciond connector interface with DRKey functions
* change ids in `proto/sciond.capnp` to avoid clash with newly added `traceId` field, regenerate the affected *.capnp.go files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/70)
<!-- Reviewable:end -->
