### PR TITLE
Make the DRKey SV store ticker UT more robust.

### DIFF
--- a/go/lib/drkey/epoch.go
+++ b/go/lib/drkey/epoch.go
@@ -42,5 +42,5 @@ func NewEpoch(begin, end uint32) Epoch {
 
 // Contains indicates whether the time point is inside this Epoch.
 func (e *Epoch) Contains(t time.Time) bool {
-	return t.After(e.Begin) && e.End.After(t)
+	return !e.Begin.After(t) && e.End.After(t)
 }


### PR DESCRIPTION
It fails ~ 1 / 2000 times otherwise. 
It should be visible with `bazel test  //go/cert_srv/internal/drkey:go_default_test --runs_per_test=20000` ; that's 20k runs of the test functions.
Because we don't want to add sync primitives in the store only to be able to UT it, we split the test in two: check that the ticker runs when the store is created, and check that when the clean function is called it removes the expired keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/71)
<!-- Reviewable:end -->
