### PR TITLE
Return correct err on response error from DB query

### DIFF
--- a/go/tools/pathdb_dump/pathdb_dump.go
+++ b/go/tools/pathdb_dump/pathdb_dump.go
@@ -70,7 +70,7 @@ func realMain() error {
 	var segments []segment
 	for res := range ch {
 		if res.Err != nil {
-			return err
+			return res.Err
 		}
 		seg, err := newSegment(res.Result)
 		if err != nil {


### PR DESCRIPTION
When looping over the responses from the DB the error of the response should be returned.
Now no error is returned since `err` will always be `nil`; otherwise it either stops before at line 68; or after at line 77.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/74)
<!-- Reviewable:end -->
