### PR TITLE
Workaround for issue scionproto/4019.

### DIFF
--- a/go/pkg/router/control/bfd.go
+++ b/go/pkg/router/control/bfd.go
@@ -54,7 +54,10 @@ func withDefaults(cfg BFD) BFD {
 
 var (
 	bfdDefaults = BFD{
-		DetectMult:            3,
+		// XXX(juagargi) patching the default value of DetectMult from 3 to 100 to
+		// workaround a problem where BFD packets are dropped when the router is under heavy
+		// load (issue #4019). Once it's solved, rollback to a value of 3
+		DetectMult:            100,
 		DesiredMinTxInterval:  200 * time.Millisecond,
 		RequiredMinRxInterval: 200 * time.Millisecond,
 		// Disable indicates if BFD is disabled globally.


### PR DESCRIPTION
This is temporary (tm).
Issue scionproto/4019 reports a problem with the BFD
packets when the border router is under heavy load.
To temporarily workaround this issue, set the default value
of the detection time multipler to 100, instead of 3.
Since most configuration in scionlab do not specify values
for BFD, the detection time will be 100 * tx_interval =
100 * 200ms = 20s .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/89)
<!-- Reviewable:end -->
