### PR TITLE
cs/drkey: handle situations where no path to a peer AS can be found

### DIFF
--- a/go/pkg/cs/drkey/grpc/drkey_fetcher.go
+++ b/go/pkg/cs/drkey/grpc/drkey_fetcher.go
@@ -48,8 +48,8 @@ func (f Lvl1KeyFetcher) GetLvl1Key(ctx context.Context, srcIA addr.IA,
 
 	logger.Info("Resolving server", "srcIA", srcIA.String())
 	path, err := f.Router.Route(ctx, srcIA)
-	if err != nil {
-		return nil, serrors.WrapStr("retrieving paths", err)
+	if err != nil || path == nil {
+		return nil, serrors.WrapStr("unable to find path to", err, "IA", srcIA)
 	}
 	remote := &snet.SVCAddr{
 		IA:      srcIA,

--- a/go/pkg/cs/drkey/grpc/drkey_service.go
+++ b/go/pkg/cs/drkey/grpc/drkey_service.go
@@ -116,7 +116,7 @@ func (d *DRKeyServer) DRKeyLvl2(ctx context.Context,
 	}
 	lvl1Key, err := d.Store.GetLvl1Key(ctx, lvl1Meta, parsedReq.ValTime)
 	if err != nil {
-		logger.Debug("[DRKey gRPC server] Error getting the level 1 key",
+		logger.Error("[DRKey gRPC server] Error getting the level 1 key",
 			"err", err)
 		return nil, err
 	}

--- a/go/pkg/cs/drkey/grpc/drkey_service.go
+++ b/go/pkg/cs/drkey/grpc/drkey_service.go
@@ -116,7 +116,7 @@ func (d *DRKeyServer) DRKeyLvl2(ctx context.Context,
 	}
 	lvl1Key, err := d.Store.GetLvl1Key(ctx, lvl1Meta, parsedReq.ValTime)
 	if err != nil {
-		logger.Error("[DRKey gRPC server] Error getting the level 1 key",
+		logger.Debug("[DRKey gRPC server] Error getting the level 1 key",
 			"err", err)
 		return nil, err
 	}


### PR DESCRIPTION
This condition is now handled analog to a similar condition in github.com/scionproto/scion/go/pkg/trust.AuthRouter.ChooseServer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/90)
<!-- Reviewable:end -->
