### PR TITLE
Add `info` command to `scion` binary to conveniently look up local SCION address

### DIFF
--- a/go/scion/info.go
+++ b/go/scion/info.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Anapaya Systems
+// Copyright 2021 Thorben Krüger <thorben.krueger@ovgu.de>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,11 +33,12 @@ func newInfo(pather CommandPather) *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "info [flags]",
-		Short:   "Show relevant, locally-known info about this SCION host, such as its SCION address",
+		Short:   "Show (one of) this host's SCION address(es)",
 		Example: fmt.Sprintf(`  %[1]s info`, pather.CommandPath()),
 		Long: `'info' show info about this SCION host
 
-This functionality is intended to work similarly to 'ip addr' or 'ifconfig' and return relevant, locally-known info about this host's relationship with SCION.`,
+This functionality is intended to work similarly to 'ip addr' or 'ifconfig' and 
+return relevant, locally-known info about this host's relationship with SCION.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			ctx := context.Background()
@@ -46,7 +47,6 @@ This functionality is intended to work similarly to 'ip addr' or 'ifconfig' and 
 				return serrors.WrapStr("connecting to SCION Daemon", err)
 			}
 
-			//info, err := app.QueryASInfo(traceCtx, sd)
 			info, err := app.QueryASInfo(ctx, sd)
 			if err != nil {
 				return err

--- a/go/scion/info.go
+++ b/go/scion/info.go
@@ -34,11 +34,10 @@ func newInfo(pather CommandPather) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "info [flags]",
 		Short:   "Show relevant, locally-known info about this SCION host, such as its SCION address",
-		Example: fmt.Sprint(`  %[1]s info`, pather.CommandPath()),
+		Example: fmt.Sprintf(`  %[1]s info`, pather.CommandPath()),
 		Long: `'info' show info about this SCION host
 
 This functionality is intended to work similarly to 'ip addr' or 'ifconfig' and return relevant, locally-known info about this host's relationship with SCION.`,
-		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			ctx := context.Background()
@@ -58,7 +57,7 @@ This functionality is intended to work similarly to 'ip addr' or 'ifconfig' and 
 				return err
 			}
 
-			fmt.Printf("One of this host's SCION addresses is %s,%s\n", info.IA, localIP)
+			fmt.Printf("One of this host's SCION addresses is:\n\n    %s,%s\n\n", info.IA, localIP)
 			return nil
 		},
 	}

--- a/go/scion/info.go
+++ b/go/scion/info.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/scionproto/scion/go/lib/daemon"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/snet/addrutil"
+	"github.com/scionproto/scion/go/pkg/app"
+)
+
+func newInfo(pather CommandPather) *cobra.Command {
+	var flags struct {
+		daemon string
+	}
+
+	var cmd = &cobra.Command{
+		Use:     "info [flags]",
+		Short:   "Show relevant, locally-known info about this SCION host, such as its SCION address",
+		Example: fmt.Sprint(`  %[1]s info`, pather.CommandPath()),
+		Long: `'info' show info about this SCION host
+
+This functionality is intended to work similarly to 'ip addr' or 'ifconfig' and return relevant, locally-known info about this host's relationship with SCION.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			ctx := context.Background()
+			sd, err := daemon.NewService(flags.daemon).Connect(ctx)
+			if err != nil {
+				return serrors.WrapStr("connecting to SCION Daemon", err)
+			}
+
+			//info, err := app.QueryASInfo(traceCtx, sd)
+			info, err := app.QueryASInfo(ctx, sd)
+			if err != nil {
+				return err
+			}
+
+			localIP, err := addrutil.DefaultLocalIP(ctx, sd)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("One of this host's SCION addresses is %s,%s\n", info.IA, localIP)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.daemon, "sciond", daemon.DefaultAPIAddress, "SCION Daemon address")
+	return cmd
+}

--- a/go/scion/scion.go
+++ b/go/scion/scion.go
@@ -50,6 +50,7 @@ func main() {
 		newPing(cmd),
 		newShowpaths(cmd),
 		newTraceroute(cmd),
+		newInfo(cmd),
 	)
 
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
When juggling scionlab VMs, I sometimes lose track of their SCION addresses. The `info` command for the `scion` binary is intended to work analogous to `ifconfig` or `ip addr` and return (one of) the local SCION address(es).

(I'm not particularly invested in calling this feature `info`, it could also just be called `address` or something else...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/103)
<!-- Reviewable:end -->
