### PR TITLE
Fix broken DRKey.

### DIFF
--- a/go/daemon/main.go
+++ b/go/daemon/main.go
@@ -252,6 +252,7 @@ func realMain(ctx context.Context) error {
 			),
 			Engine:     engine,
 			RevCache:   revCache,
+			DRKeyStore: drkeyStore,
 			ColFetcher: colibri.NewFetcher(dialer),
 			ColClient:  &colibri.DaemonClient{Dialer: dialer},
 		},


### PR DESCRIPTION
The DRKey store is not being passed to the daemon server,
always resulting in DRKey being disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/108)
<!-- Reviewable:end -->
