### PR TITLE
traceroute: fix setting router alert regression

### DIFF
--- a/go/pkg/traceroute/traceroute.go
+++ b/go/pkg/traceroute/traceroute.go
@@ -189,7 +189,7 @@ func (t *tracerouter) probeHop(ctx context.Context, hfIdx uint8, egress bool) (U
 		return Update{}, serrors.WrapStr("decoding path", err)
 	}
 
-	hf := decoded.HopFields[hfIdx]
+	hf := &decoded.HopFields[hfIdx]
 	if egress {
 		hf.EgressRouterAlert = true
 	} else {


### PR DESCRIPTION
Fix regression introduced in 70ed4a00c21d35ff6d7e6843c075c670f656a9f3.
This has already been fixed upstream in a7a1181011d26ab8157e7ab84375eac82719b25f.