### PR TITLE
colibri: add support for a single dispatcher serving multiple ASes.

### DIFF
--- a/go/dispatcher/dispatcher/BUILD.bazel
+++ b/go/dispatcher/dispatcher/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//go/lib/ringbuf:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/slayers:go_default_library",
+        "//go/lib/slayers/path/colibri:go_default_library",
         "//go/lib/underlay/conn:go_default_library",
         "@com_github_google_gopacket//:go_default_library",
     ],

--- a/go/dispatcher/dispatcher/underlay.go
+++ b/go/dispatcher/dispatcher/underlay.go
@@ -92,6 +92,8 @@ func getDstUDP(pkt *respool.Packet) (Destination, error) {
 		return nil, err
 	}
 
+	// XXX(mawyss): This is a temporary solution to allow the dispatcher to forward Colibri
+	// control packets to the right destination.
 	// For Colibri control packets, i.e., for packets where the `C`-flag is set, ignore the
 	// destination ISD/AS. Instead, read the ISD/AS from the high-precision timestamp. The
 	// timestamp field was overritten by the ingress border router to contain the current ISD/AS.

--- a/go/dispatcher/dispatcher/underlay.go
+++ b/go/dispatcher/dispatcher/underlay.go
@@ -16,6 +16,7 @@
 package dispatcher
 
 import (
+	"encoding/binary"
 	"net"
 
 	"github.com/google/gopacket"
@@ -28,6 +29,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ringbuf"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/slayers"
+	"github.com/scionproto/scion/go/lib/slayers/path/colibri"
 )
 
 const (
@@ -84,14 +86,30 @@ func getDst(pkt *respool.Packet) (Destination, error) {
 }
 
 func getDstUDP(pkt *respool.Packet) (Destination, error) {
+	dstIA := pkt.SCION.DstIA
 	dst, err := pkt.SCION.DstAddr()
 	if err != nil {
 		return nil, err
 	}
+
+	// For Colibri control packets, i.e., for packets where the `C`-flag is set, ignore the
+	// destination ISD/AS. Instead, read the ISD/AS from the high-precision timestamp. The
+	// timestamp field was overritten by the ingress border router to contain the current ISD/AS.
+	// This serves the purpose of supporting a single dispatcher for multiple ASes.
+	if pkt.SCION.PathType == colibri.PathType {
+		colPath, ok := pkt.SCION.Path.(*colibri.ColibriPathMinimal)
+		if !ok {
+			return nil, serrors.New("not a colibri path", "path", pkt.SCION.Path)
+		}
+		if colPath.InfoField.C == true {
+			dstIA = addr.IA(binary.BigEndian.Uint64(colPath.PacketTimestamp[:]))
+		}
+	}
+
 	switch d := dst.(type) {
 	case *net.IPAddr:
 		return UDPDestination{
-			IA: pkt.SCION.DstIA,
+			IA: dstIA,
 			Public: &net.UDPAddr{
 				IP:   d.IP,
 				Port: int(pkt.UDP.DstPort),
@@ -99,7 +117,7 @@ func getDstUDP(pkt *respool.Packet) (Destination, error) {
 		}, nil
 	case addr.HostSVC:
 		return SVCDestination{
-			IA:  pkt.SCION.DstIA,
+			IA:  dstIA,
 			Svc: d,
 		}, nil
 	default:

--- a/go/dispatcher/dispatcher/underlay.go
+++ b/go/dispatcher/dispatcher/underlay.go
@@ -93,7 +93,7 @@ func getDstUDP(pkt *respool.Packet) (Destination, error) {
 	}
 
 	// XXX(mawyss): This is a temporary solution to allow the dispatcher to forward Colibri
-	// control packets to the right destination.
+	// control packets to the right destination (https://github.com/netsec-ethz/scion/pull/116).
 	// For Colibri control packets, i.e., for packets where the `C`-flag is set, ignore the
 	// destination ISD/AS. Instead, read the ISD/AS from the high-precision timestamp. The
 	// timestamp field was overritten by the ingress border router to contain the current ISD/AS.

--- a/go/pkg/router/colibri_processing.go
+++ b/go/pkg/router/colibri_processing.go
@@ -243,6 +243,8 @@ func (c *colibriPacketProcessor) forwardToColibriSvc() (processResult, error) {
 		return processResult{}, serrors.New("no colibri service registered at border router")
 	}
 
+	// XXX(mawyss): This is a temporary solution to allow the dispatcher to forward Colibri
+	// control packets to the right destination.
 	// Encode the current ISD/AS in the Colibri high-precision timestamp field of control
 	// packets (C=1). This serves the purpose of supporting one single dispatcher for multiple
 	// ASes, as now the dispatcher can know to which AS the Colibri control packet should be

--- a/go/pkg/router/colibri_processing.go
+++ b/go/pkg/router/colibri_processing.go
@@ -15,6 +15,7 @@
 package router
 
 import (
+	"encoding/binary"
 	"time"
 
 	"github.com/google/gopacket"
@@ -241,5 +242,15 @@ func (c *colibriPacketProcessor) forwardToColibriSvc() (processResult, error) {
 	if !ok {
 		return processResult{}, serrors.New("no colibri service registered at border router")
 	}
+
+	// Encode the current ISD/AS in the Colibri high-precision timestamp field of control
+	// packets (C=1). This serves the purpose of supporting one single dispatcher for multiple
+	// ASes, as now the dispatcher can know to which AS the Colibri control packet should be
+	// forwarded.
+	binary.BigEndian.PutUint64(c.colibriPathMinimal.PacketTimestamp[:], uint64(c.d.localIA))
+	if err := c.colibriPathMinimal.SerializeToInternal(); err != nil {
+		return processResult{}, err
+	}
+
 	return processResult{OutConn: c.d.internal, OutAddr: a, OutPkt: c.rawPkt}, nil
 }

--- a/go/pkg/router/colibri_processing.go
+++ b/go/pkg/router/colibri_processing.go
@@ -244,7 +244,7 @@ func (c *colibriPacketProcessor) forwardToColibriSvc() (processResult, error) {
 	}
 
 	// XXX(mawyss): This is a temporary solution to allow the dispatcher to forward Colibri
-	// control packets to the right destination.
+	// control packets to the right destination (https://github.com/netsec-ethz/scion/pull/116).
 	// Encode the current ISD/AS in the Colibri high-precision timestamp field of control
 	// packets (C=1). This serves the purpose of supporting one single dispatcher for multiple
 	// ASes, as now the dispatcher can know to which AS the Colibri control packet should be


### PR DESCRIPTION
Currently there is a problem when running Colibri in the local scion setup, which is running only a single dispatcher serving multiple ASes. Example for the tiny topology:
If a Colibri control packet is sent on the path `112->110->111` (destination AS = `AS 111`), then the packet is correctly forwarded at the ingress BR of `AS 110` to the IP of the host running the Colibri service (because `C = 1`). However, in the local test setup, the dispatcher then tries to find which AS is hosting the Colibri service, and it thinks it is `AS 111`, as this is the destination AS in the packet header.
We want the packet to arrive at the Colibri service of `AS 110`.

Considered solutions:
- Run one dispatcher per AS.
- Let the ingress BR overwrite the destination ISD/AS with its local ISD/AS.

The solution taken in this PR is yet another one:
- The ingress BR encodes the ISD/AS in the high-precision timestamp field of Colibri control packets (C=1). The timestamp field is present in all Colibri packets,  but it is currently only defined/used for EER data packets (C=0).
- The dispatcher then  uses the ISD/AS encoded in the timestamp field instead of the ISD/AS in the SCION address header to forward the packet to the Colibri service of the correct AS.

This is just a quick fix to solve the problem for now, such that this issue does not hinder progress for the more important parts of the Colibri implementation. Better solutions might be considered in the future, any suggestions for alternative approaches are appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/116)
<!-- Reviewable:end -->
