### PR TITLE
shutdown gracefully CS and COL

### DIFF
--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -633,6 +633,7 @@ func realMain(ctx context.Context) error {
 			defer log.HandlePanic()
 			return quicTLSServer.Serve(quicStack.TLSListener)
 		})
+		cleanup.Add(func() error { quicTLSServer.GracefulStop(); return nil })
 	}
 
 	if globalCfg.API.Addr != "" {


### PR DESCRIPTION
Closes #85 
Due to a slight oversight the DRKey TLS server is not gracefully shutdown. This prevents the CS from finishing cleanly.

The COLIBRI service was never gracefully terminated, now it is. Also its DB is closed appropriately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/124)
<!-- Reviewable:end -->
