### PR TITLE
colibri gateway performance improvements

### DIFF
--- a/go/co/main.go
+++ b/go/co/main.go
@@ -187,9 +187,9 @@ func setupColibri(g *errgroup.Group, cleanup *app.Cleanup, cfg *config.Config, c
 	}
 	// TODO(juagargi) Add security for connection with colibri gateway.
 	colibriService := &colgrpc.ColibriService{
-		Store:     colibriStore,
-		Coligates: coligateAddresses,
+		Store: colibriStore,
 	}
+	colibriService.PrepareColibriGatewayServiceClients(&coligateAddresses)
 	colServer := coliquic.NewGrpcServer(libgrpc.UnaryServerInterceptor())
 	tcpColServer := grpc.NewServer(libgrpc.UnaryServerInterceptor())
 	colpb.RegisterColibriServiceServer(colServer, colibriService)

--- a/go/coligate/processing/BUILD.bazel
+++ b/go/coligate/processing/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//go/pkg/coligate/config:go_default_library",
         "@com_github_google_gopacket//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_x_net//ipv4:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/go/coligate/processing/BUILD.bazel
+++ b/go/coligate/processing/BUILD.bazel
@@ -3,6 +3,7 @@ load("//lint:go.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "forwarder.go",
         "processing.go",
         "processor.go",
     ],
@@ -47,13 +48,13 @@ go_test(
         "//go/coligate/storage:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/dataplane:go_default_library",
+        "//go/lib/log:go_default_library",
         "//go/lib/slayers:go_default_library",
         "//go/lib/slayers/path/colibri:go_default_library",
         "//go/pkg/coligate:go_default_library",
         "//go/pkg/coligate/config:go_default_library",
         "@com_github_google_gopacket//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
-        "@org_golang_x_net//ipv4:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/go/coligate/processing/BUILD.bazel
+++ b/go/coligate/processing/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//go/lib/slayers/path/colibri:go_default_library",
         "//go/pkg/coligate:go_default_library",
         "//go/pkg/coligate/config:go_default_library",
+        "@com_github_google_gopacket//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_x_net//ipv4:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -71,12 +71,16 @@ func (p *Processor) CreateControlDeletionChannels(numberWorkers int,
 }
 
 func (p *Processor) WorkerReceiveEntry(config *config.ColigateConfig,
-	workerId uint32, gatewayId uint32, localAS libaddr.AS, r *map[uint16]*ipv4.PacketConn) error {
-	return p.workerReceiveEntry(config, workerId, gatewayId, localAS, r)
+	workerId uint32, gatewayId uint32, localAS libaddr.AS) error {
+	return p.workerReceiveEntry(config, workerId, gatewayId, localAS)
 }
 
 func InitializeMetrics() *ColigateMetrics {
 	return initializeMetrics(common.NewMetrics())
+}
+
+func (p *Processor) SetBorderRouterConnections(conn map[uint16]*ipv4.PacketConn) {
+	p.borderRouters = conn
 }
 
 func (p *Processor) SetMetrics(m *ColigateMetrics) {

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -126,35 +126,35 @@ type DataPacket struct {
 	Id             [12]byte
 }
 
-func (proc *DataPacket) Convert() *dataPacket {
+func (pkt *DataPacket) Convert() *dataPacket {
 	return &dataPacket{
-		pktArrivalTime: proc.PktArrivalTime,
-		scionLayer:     proc.ScionLayer,
-		colibriPath:    proc.ColibriPath,
-		reservation:    proc.Reservation,
-		rawPacket:      proc.RawPacket,
-		id:             proc.Id,
+		pktArrivalTime: pkt.PktArrivalTime,
+		scionLayer:     pkt.ScionLayer,
+		colibriPath:    pkt.ColibriPath,
+		reservation:    pkt.Reservation,
+		rawPacket:      pkt.RawPacket,
+		id:             pkt.Id,
 	}
 }
 
-func (w *Worker) Validate(proc *DataPacket) error {
-	return w.validate(proc.Convert())
+func (w *Worker) Validate(pkt *dataPacket) error {
+	return w.validate(pkt)
 }
 
-func (w *Worker) PerformTrafficMonitoring(proc *DataPacket) error {
-	return w.performTrafficMonitoring(proc.Convert())
+func (w *Worker) PerformTrafficMonitoring(pkt *dataPacket) error {
+	return w.performTrafficMonitoring(pkt)
 }
 
-func (w *Worker) Stamp(d *DataPacket) error {
-	return w.stamp(d.Convert())
+func (w *Worker) Stamp(pkt *dataPacket) error {
+	return w.stamp(pkt)
 }
 
-func (w *Worker) Process(d *DataPacket) error {
-	return w.process(d.Convert())
+func (w *Worker) Process(pkt *dataPacket) error {
+	return w.process(pkt)
 }
 
-func (w *Worker) ForwardPacket(d *DataPacket) {
-	w.forwardPacket(d.Convert())
+func (w *Worker) ForwardPacket(pkt *dataPacket) {
+	w.forwardPacket(pkt)
 }
 
 func (w *Worker) UpdateCounter() {

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -127,6 +127,14 @@ func (w *Worker) Process(d *DataPacket) error {
 	return w.process(d.Parse())
 }
 
+func (w *Worker) ForwardPacket(d *DataPacket) {
+	w.forwardPacket(d.Parse())
+}
+
 func (w *Worker) UpdateCounter() {
 	w.updateCounter()
+}
+
+func (w *Worker) Exit() {
+	w.exit()
 }

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -71,8 +71,8 @@ func (p *Processor) CreateControlDeletionChannels(numberWorkers int,
 }
 
 func (p *Processor) WorkerReceiveEntry(config *config.ColigateConfig,
-	workerId uint32, gatewayId uint32, localAS libaddr.AS) error {
-	return p.workerReceiveEntry(config, workerId, gatewayId, localAS)
+	workerId uint32, gatewayId uint32, localAS libaddr.AS, r *map[uint16]*ipv4.PacketConn) error {
+	return p.workerReceiveEntry(config, workerId, gatewayId, localAS, r)
 }
 
 func InitializeMetrics() *ColigateMetrics {
@@ -85,10 +85,6 @@ func (p *Processor) SetMetrics(m *ColigateMetrics) {
 
 func (p *Processor) Shutdown() {
 	p.shutdown()
-}
-
-func (p *Processor) SetBorderRouterConnections(conn map[uint16]*ipv4.PacketConn) {
-	p.borderRouters = conn
 }
 
 type DataPacket struct {

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -97,6 +97,7 @@ type DataPacket struct {
 	ColibriPath    *colibri.ColibriPath
 	Reservation    *storage.Reservation
 	RawPacket      []byte
+	Id             [12]byte
 }
 
 func (proc *DataPacket) Parse() *dataPacket {
@@ -106,6 +107,7 @@ func (proc *DataPacket) Parse() *dataPacket {
 		colibriPath:    proc.ColibriPath,
 		reservation:    proc.Reservation,
 		rawPacket:      proc.RawPacket,
+		id:             proc.Id,
 	}
 }
 

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -80,7 +80,9 @@ func InitializeMetrics() *ColigateMetrics {
 	return initializeMetrics(common.NewMetrics())
 }
 
-func (p *Processor) SetupPacketForwarder(g *errgroup.Group, m map[uint16]*net.UDPAddr, coligateMetrics *ColigateMetrics) {
+func (p *Processor) SetupPacketForwarder(g *errgroup.Group, m map[uint16]*net.UDPAddr,
+	coligateMetrics *ColigateMetrics) {
+
 	forwardChannels := make(map[uint16]chan []byte)
 	for ifid, info := range m {
 		ch := make(chan []byte, numOfMessages)

--- a/go/coligate/processing/export_test.go
+++ b/go/coligate/processing/export_test.go
@@ -121,6 +121,10 @@ func (w *Worker) Stamp(d *DataPacket) error {
 	return w.stamp(d.Parse())
 }
 
+func (w *Worker) Process(d *DataPacket) error {
+	return w.process(d.Parse())
+}
+
 func (w *Worker) UpdateCounter() {
 	w.updateCounter()
 }

--- a/go/coligate/processing/forwarder.go
+++ b/go/coligate/processing/forwarder.go
@@ -1,0 +1,93 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package processing
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/scionproto/scion/go/lib/log"
+	"golang.org/x/net/ipv4"
+)
+
+type packetForwarder struct {
+	addr         *net.UDPAddr
+	metrics      *ColigateMetrics
+	batchSize    int
+	ForwardTasks chan []byte
+}
+
+func NewPacketForwarder(addr *net.UDPAddr, batchSize int, ch chan []byte,
+	metrics *ColigateMetrics) *packetForwarder {
+	return &packetForwarder{
+		addr:         addr,
+		batchSize:    batchSize,
+		metrics:      metrics,
+		ForwardTasks: ch,
+	}
+}
+
+// Starts the packet forwarder. This should be called in a new
+// go routine.
+func (p *packetForwarder) Start() {
+	workerPacketOutTotalPromCounter := p.metrics.WorkerPacketOutTotal
+	workerPacketOutErrorPromCounter := p.metrics.WorkerPacketOutError
+	writeMsgs := make([]ipv4.Message, p.batchSize)
+	for i := 0; i < p.batchSize; i++ {
+		writeMsgs[i].Buffers = [][]byte{make([]byte, bufSize)}
+	}
+	conn, err := net.DialUDP("udp", nil, p.addr)
+	if err != nil {
+		log.Debug("PacketForwarder error while dialing", "err", err)
+	}
+	packetConn := ipv4.NewPacketConn(conn)
+	defer packetConn.Close()
+	exit := false
+	for !exit {
+		task := <-p.ForwardTasks
+		if task == nil {
+			return
+		}
+		writeMsgs[0].Buffers[0] = task
+		i := 1
+		// do we have more messages to send right now?
+	loop:
+		for i < p.batchSize {
+			select {
+			case task := <-p.ForwardTasks:
+				if task == nil {
+					// process all current packets, then exit
+					exit = true
+					break loop
+				}
+				writeMsgs[i].Buffers[0] = task
+				i++
+			default:
+				break loop
+			}
+		}
+		k, err := packetConn.WriteBatch(writeMsgs[:i], syscall.MSG_DONTWAIT)
+		if err != nil {
+			log.Debug("PacketForwarder error while sending", "err", err)
+			workerPacketOutErrorPromCounter.Add(float64(i))
+			continue
+		}
+
+		// check whether all packets have been sent or not
+		if k != i {
+			workerPacketOutErrorPromCounter.Add(float64(i - k))
+		}
+		workerPacketOutTotalPromCounter.Add(float64(k))
+	}
+}

--- a/go/coligate/processing/forwarder.go
+++ b/go/coligate/processing/forwarder.go
@@ -22,6 +22,11 @@ import (
 	"golang.org/x/net/ipv4"
 )
 
+type packetForwarderContainer struct {
+	Length       uint32
+	ForwardTasks []chan []byte
+}
+
 type packetForwarder struct {
 	addr         *net.UDPAddr
 	metrics      *ColigateMetrics

--- a/go/coligate/processing/processing.go
+++ b/go/coligate/processing/processing.go
@@ -66,7 +66,7 @@ func Parse(rawPacket []byte) (*dataPacket, error) {
 	if len(rawPacket) < offsetToColibriHeader+40 {
 		return nil, serrors.New("raw packet length too small")
 	}
-	copy(dataPacket.id[:], rawPacket[offsetToColibriHeader+12:])
+	copy(dataPacket.id[:12], rawPacket[offsetToColibriHeader+12:])
 	return &dataPacket, nil
 }
 
@@ -265,7 +265,9 @@ func (w *Worker) stamp(d *dataPacket) error {
 	d.colibriPath.PacketTimestamp = libcolibri.CreateColibriTimestampCustom(tsRel, w.CoreIdCounter)
 	// Pre-initialize and store all ciphers if they are not initialized already
 	if currentIndex.Ciphers == nil {
-		w.initializeCiphers(d, currentIndex)
+		if err := w.initializeCiphers(d, currentIndex); err != nil {
+			return err
+		}
 	}
 	// Set HVF values
 	for i, cipher := range currentIndex.Ciphers {

--- a/go/coligate/processing/processing.go
+++ b/go/coligate/processing/processing.go
@@ -32,11 +32,12 @@ import (
 )
 
 type Worker struct {
+	Id             uint32
 	CoreIdCounter  uint32
 	NumCounterBits int
 
 	Storage         *storage.Storage
-	forwardChannels map[uint16]chan []byte
+	forwardChannels map[uint16]packetForwarderContainer
 	LocalAS         libaddr.AS
 	metrics         *ColigateMetrics
 }
@@ -77,8 +78,9 @@ func Parse(rawPacket []byte) (*dataPacket, error) {
 
 // NewWorker initializes the worker with its id, tokenbuckets and reservations
 func NewWorker(config *config.ColigateConfig, workerId uint32, gatewayId uint32,
-	localAS libaddr.AS, forwardChannels map[uint16]chan []byte, metrics *ColigateMetrics) *Worker {
+	localAS libaddr.AS, forwardChannels map[uint16]packetForwarderContainer, metrics *ColigateMetrics) *Worker {
 	w := &Worker{
+		Id: workerId,
 		CoreIdCounter: (gatewayId << (32 - config.NumBitsForGatewayId)) |
 			(workerId << (32 - config.NumBitsForGatewayId - config.NumBitsForWorkerId)),
 		NumCounterBits:  config.NumBitsForPerWorkerCounter,
@@ -256,10 +258,11 @@ func (w *Worker) stamp(d *dataPacket) error {
 
 func (w *Worker) forwardPacket(d *dataPacket) error {
 	egressId := d.colibriPath.GetCurrentHopField().EgressId
-	forwardChannel, found := w.forwardChannels[egressId]
+	forwarderContainer, found := w.forwardChannels[egressId]
 	if !found {
 		return serrors.New("Forward Channel for egress id not found", "egressId", egressId)
 	}
-	forwardChannel <- d.rawPacket
+	index := w.Id % uint32(forwarderContainer.Length)
+	forwarderContainer.ForwardTasks[index] <- d.rawPacket
 	return nil
 }

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -979,7 +979,9 @@ func TestUpdateMacs(t *testing.T) {
 	assert.Error(t, err)
 
 	// Update mac fields of EE data packet with correct sigma
-	d.Reservation.Indices[0].Sigmas[0] = sigmaBuffer
+	d.Reservation.Indices[0].Sigmas = [][]byte{
+		sigmaBuffer,
+	}
 	d.Reservation.Indices[0].Ciphers = nil
 	err = w.Stamp(d)
 	assert.NoError(t, err)

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -1046,8 +1046,10 @@ func BenchmarkParsing(b *testing.B) {
 	buffer := gopacket.NewSerializeBuffer()
 	err := s.SerializeTo(buffer, gopacket.SerializeOptions{})
 	assert.NoError(b, err)
+	payload := make([]byte, payloadLen)
 	bytes := []byte{}
 	bytes = append(bytes, buffer.Bytes()...)
+	bytes = append(bytes, payload...)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := processing.Parse(bytes)
@@ -1066,7 +1068,7 @@ func BenchmarkProcess(b *testing.B) {
 		2: borderRouterAddr,
 	}, coligateMetrics)
 
-	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1,
+	w := processing.NewWorker(getColigateConfiguration(), 1, 1, addr.MustIAFrom(1, 1).AS(),
 		c.GetPacketForwarderChannels(), coligateMetrics)
 	now := time.Now()
 	resStore := map[[12]byte]*storage.Reservation{

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -114,7 +114,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateReservationBelongsToOtherAS",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -130,11 +130,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 							},
 						},
 						ScionLayer: &slayers.SCION{
@@ -150,11 +150,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 							},
 						},
 						ScionLayer: &slayers.SCION{
@@ -169,7 +169,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateInvalidNumberOfHopfields",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -185,11 +185,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 							},
 						},
 						ScionLayer: &slayers.SCION{
@@ -204,7 +204,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateCurrHFIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -220,11 +220,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								CurrHF:      1,
 							},
 							HopFields: make([]*colibri.HopField, 1),
@@ -241,7 +241,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateBwClsIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -257,11 +257,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								CurrHF:      0,
 								BwCls:       2,
 							},
@@ -279,7 +279,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateRlcIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -296,11 +296,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								CurrHF:      0,
 								BwCls:       1,
 								Rlc:         2,
@@ -319,7 +319,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateExpTickIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -336,11 +336,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								CurrHF:      0,
 								BwCls:       1,
 								Rlc:         1,
@@ -360,7 +360,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateInvalidIngressId",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id: reservationIdOne,
 					Hops: []storage.HopField{
 						{
 							IngressId: 1,
@@ -382,11 +382,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								Ver:         0,
 								BwCls:       1,
 								Rlc:         1,
@@ -412,7 +412,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateInvalidEgressId",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id: reservationIdOne,
 					Hops: []storage.HopField{
 						{
 							IngressId: 1,
@@ -434,11 +434,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								Ver:         0,
 								BwCls:       1,
 								Rlc:         1,
@@ -464,7 +464,7 @@ func TestValidate(t *testing.T) {
 			name: "TestValidateAllValid",
 			resStore: map[[12]byte]*storage.Reservation{
 				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-					Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+					Id: reservationIdOne,
 					Hops: []storage.HopField{
 						{
 							IngressId: 1,
@@ -486,11 +486,11 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
-						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						Id:             reservationIdOne,
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
-								ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+								ResIdSuffix: reservationIdOne[:],
 								Ver:         0,
 								BwCls:       1,
 								Rlc:         1,
@@ -552,7 +552,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -570,7 +570,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -593,7 +593,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -611,7 +611,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -629,7 +629,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -647,7 +647,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -665,7 +665,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -688,7 +688,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -729,7 +729,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -747,7 +747,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -775,7 +775,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -793,7 +793,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2750),
 						PktArrivalTime: startTime.Add(1 * time.Second),
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -821,7 +821,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2750),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -839,7 +839,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime.Add(1 * time.Second),
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								1: {
@@ -857,7 +857,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime.Add(1 * time.Second),
 						Reservation: &storage.Reservation{
-							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+							Id:            reservationIdOne,
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								1: {
@@ -953,7 +953,7 @@ func TestUpdateMacs(t *testing.T) {
 			PathType:    colibri.PathType,
 		},
 		Reservation: &storage.Reservation{
-			Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Id:            reservationIdOne,
 			ActiveIndexId: 0,
 			Hops: []storage.HopField{
 				{
@@ -1069,11 +1069,11 @@ func BenchmarkProcess(b *testing.B) {
 	}, coligateMetrics)
 
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, addr.MustIAFrom(1, 1).AS(),
-		c.GetPacketForwarderChannels(), coligateMetrics)
+		c.GetPacketForwarderContainers(), coligateMetrics)
 	now := time.Now()
 	resStore := map[[12]byte]*storage.Reservation{
 		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-			Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Id: reservationIdOne,
 			Indices: map[uint8]*storage.ReservationIndex{
 				1: {
 					Index:    0,
@@ -1119,7 +1119,7 @@ func BenchmarkProcess(b *testing.B) {
 	}
 	w.Storage.InitStorageWithData(resStore)
 	defaultPkt := &processing.DataPacket{
-		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		Id:             reservationIdOne,
 		PktArrivalTime: time.Now(),
 		ScionLayer: &slayers.SCION{
 			PathType: 4,
@@ -1128,7 +1128,7 @@ func BenchmarkProcess(b *testing.B) {
 		ColibriPath: &colibri.ColibriPath{
 			InfoField: &colibri.InfoField{
 				Ver:         1,
-				ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+				ResIdSuffix: reservationIdOne[:],
 				BwCls:       60,
 				ExpTick:     uint32(now.Add(12*time.Second).Unix() / 4),
 			},
@@ -1188,7 +1188,7 @@ func BenchmarkValidate(b *testing.B) {
 
 	resStore := map[[12]byte]*storage.Reservation{
 		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
-			Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Id: reservationIdOne,
 			Hops: []storage.HopField{
 				{
 					IngressId: 1,
@@ -1209,11 +1209,11 @@ func BenchmarkValidate(b *testing.B) {
 	}
 	w.Storage.InitStorageWithData(resStore)
 	d := &processing.DataPacket{
-		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		Id:             reservationIdOne,
 		PktArrivalTime: now,
 		ColibriPath: &colibri.ColibriPath{
 			InfoField: &colibri.InfoField{
-				ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+				ResIdSuffix: reservationIdOne[:],
 				Ver:         0,
 				BwCls:       1,
 				Rlc:         1,
@@ -1242,10 +1242,10 @@ func BenchmarkTrafficMonitoring(b *testing.B) {
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1, nil, coligateMetrics)
 	now := time.Now()
 	d := &processing.DataPacket{
-		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		Id:             reservationIdOne,
 		PktArrivalTime: now,
 		Reservation: &storage.Reservation{
-			Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Id:            reservationIdOne,
 			ActiveIndexId: 0,
 			Indices: map[uint8]*storage.ReservationIndex{
 				0: {
@@ -1266,7 +1266,7 @@ func BenchmarkStamp(b *testing.B) {
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1, nil, coligateMetrics)
 	now := time.Now()
 	defaultPkt := &processing.DataPacket{
-		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		Id:             reservationIdOne,
 		PktArrivalTime: now,
 		ScionLayer: &slayers.SCION{
 			PathType: colibri.PathType,
@@ -1275,7 +1275,7 @@ func BenchmarkStamp(b *testing.B) {
 		ColibriPath: &colibri.ColibriPath{
 			InfoField: &colibri.InfoField{
 				Ver:         1,
-				ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+				ResIdSuffix: reservationIdOne[:],
 				BwCls:       1,
 				ExpTick:     uint32(now.Add(12*time.Second).Unix() / 4),
 				HFCount:     5,
@@ -1315,7 +1315,7 @@ func BenchmarkStamp(b *testing.B) {
 		},
 		RawPacket: make([]byte, 400),
 		Reservation: &storage.Reservation{
-			Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Id: reservationIdOne,
 			Hops: []storage.HopField{
 				{
 					IngressId: 1,
@@ -1378,10 +1378,10 @@ func BenchmarkForwardPacket(b *testing.B) {
 		2: borderRouterAddr,
 	}, coligateMetrics)
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1,
-		c.GetPacketForwarderChannels(), coligateMetrics)
+		c.GetPacketForwarderContainers(), coligateMetrics)
 	now := time.Now()
 	defaultPkt := &processing.DataPacket{
-		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		Id:             reservationIdOne,
 		PktArrivalTime: time.Now(),
 		ScionLayer: &slayers.SCION{
 			PathType: 4,
@@ -1390,7 +1390,7 @@ func BenchmarkForwardPacket(b *testing.B) {
 		ColibriPath: &colibri.ColibriPath{
 			InfoField: &colibri.InfoField{
 				Ver:         1,
-				ResIdSuffix: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+				ResIdSuffix: reservationIdOne[:],
 				BwCls:       60,
 				ExpTick:     uint32(now.Add(12*time.Second).Unix() / 4),
 			},

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -113,7 +113,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateReservationBelongsToOtherAS",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
@@ -168,7 +168,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateInvalidNumberOfHopfields",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
@@ -203,7 +203,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateCurrHFIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
@@ -240,7 +240,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateBwClsIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
@@ -278,7 +278,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateRlcIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
@@ -318,7 +318,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateExpTickIsInvalid",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id:            reservationIdOne,
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
@@ -359,7 +359,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateInvalidIngressId",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id: reservationIdOne,
 					Hops: []storage.HopField{
 						{
@@ -411,7 +411,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateInvalidEgressId",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id: reservationIdOne,
 					Hops: []storage.HopField{
 						{
@@ -463,7 +463,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "TestValidateAllValid",
 			resStore: map[[12]byte]*storage.Reservation{
-				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+				reservationIdOne: {
 					Id: reservationIdOne,
 					Hops: []storage.HopField{
 						{
@@ -518,7 +518,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			worker.Storage.InitStorageWithData(tc.resStore)
 			for _, en := range tc.entries {
-				err := worker.Validate(&en.proc)
+				err := worker.Validate(en.proc.Convert())
 				if en.err == "" {
 					assert.NoError(t, err)
 				} else {
@@ -880,7 +880,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 			for _, en := range tc.entries {
 				monitor := m[en.proc.Reservation.Id]
 				en.proc.Reservation.TrafficMonitor = monitor
-				err := worker.PerformTrafficMonitoring(&en.proc)
+				err := worker.PerformTrafficMonitoring(en.proc.Convert())
 				m[en.proc.Reservation.Id] = en.proc.Reservation.TrafficMonitor
 				assert.True(t, (err == nil && en.success) || (err != nil && !en.success))
 			}
@@ -977,7 +977,7 @@ func TestUpdateMacs(t *testing.T) {
 
 	// Update mac fields of EE data packet with wrong sigma
 	d.Reservation.Indices[0].Sigmas[0] = []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
-	err = w.Stamp(d)
+	err = w.Stamp(d.Convert())
 	assert.NoError(t, err)
 	// Validate the computed mac
 	err = libcolibri.VerifyMAC(privateKeyCipher, d.ColibriPath.PacketTimestamp,
@@ -989,7 +989,7 @@ func TestUpdateMacs(t *testing.T) {
 		sigmaBuffer,
 	}
 	d.Reservation.Indices[0].Ciphers = nil
-	err = w.Stamp(d)
+	err = w.Stamp(d.Convert())
 	assert.NoError(t, err)
 	// Validate the computed mac
 	err = libcolibri.VerifyMAC(privateKeyCipher, d.ColibriPath.PacketTimestamp,
@@ -1072,7 +1072,7 @@ func BenchmarkProcess(b *testing.B) {
 		c.GetPacketForwarderContainers(), coligateMetrics)
 	now := time.Now()
 	resStore := map[[12]byte]*storage.Reservation{
-		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+		reservationIdOne: {
 			Id: reservationIdOne,
 			Indices: map[uint8]*storage.ReservationIndex{
 				1: {
@@ -1174,9 +1174,10 @@ func BenchmarkProcess(b *testing.B) {
 	}
 	defer server.Close()
 	time.Sleep(1 * time.Millisecond)
+	pkt := defaultPkt.Convert()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		assert.NoError(b, w.Process(defaultPkt))
+		assert.NoError(b, w.Process(pkt))
 	}
 	c.StopPacketForwarder()
 	errGroup.Wait()
@@ -1187,7 +1188,7 @@ func BenchmarkValidate(b *testing.B) {
 	now := time.Now()
 
 	resStore := map[[12]byte]*storage.Reservation{
-		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+		reservationIdOne: {
 			Id: reservationIdOne,
 			Hops: []storage.HopField{
 				{
@@ -1231,10 +1232,10 @@ func BenchmarkValidate(b *testing.B) {
 			SrcIA: addr.MustIAFrom(1, 1),
 		},
 	}
-
+	pkt := d.Convert()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		assert.NoError(b, w.Validate(d))
+		assert.NoError(b, w.Validate(pkt))
 	}
 }
 
@@ -1256,9 +1257,10 @@ func BenchmarkTrafficMonitoring(b *testing.B) {
 			},
 		},
 	}
+	pkt := d.Convert()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		assert.NoError(b, w.PerformTrafficMonitoring(d))
+		assert.NoError(b, w.PerformTrafficMonitoring(pkt))
 	}
 }
 
@@ -1361,9 +1363,10 @@ func BenchmarkStamp(b *testing.B) {
 			},
 		},
 	}
+	pkt := defaultPkt.Convert()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		w.Stamp(defaultPkt)
+		w.Stamp(pkt)
 	}
 }
 
@@ -1436,9 +1439,10 @@ func BenchmarkForwardPacket(b *testing.B) {
 		b.FailNow()
 	}
 	defer server.Close()
+	pkt := defaultPkt.Convert()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		w.ForwardPacket(defaultPkt)
+		w.ForwardPacket(pkt)
 	}
 	c.StopPacketForwarder()
 	errGroup.Wait()

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -1066,7 +1066,8 @@ func BenchmarkProcess(b *testing.B) {
 		2: borderRouterAddr,
 	}, coligateMetrics)
 
-	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1, c.GetPacketForwarderChannels(), coligateMetrics)
+	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1,
+		c.GetPacketForwarderChannels(), coligateMetrics)
 	now := time.Now()
 	resStore := map[[12]byte]*storage.Reservation{
 		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
@@ -1374,7 +1375,8 @@ func BenchmarkForwardPacket(b *testing.B) {
 	c.SetupPacketForwarder(errGroup, map[uint16]*net.UDPAddr{
 		2: borderRouterAddr,
 	}, coligateMetrics)
-	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1, c.GetPacketForwarderChannels(), coligateMetrics)
+	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1,
+		c.GetPacketForwarderChannels(), coligateMetrics)
 	now := time.Now()
 	defaultPkt := &processing.DataPacket{
 		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -980,6 +980,7 @@ func TestUpdateMacs(t *testing.T) {
 
 	// Update mac fields of EE data packet with correct sigma
 	d.Reservation.Indices[0].Sigmas[0] = sigmaBuffer
+	d.Reservation.Indices[0].Ciphers = nil
 	err = w.Stamp(d)
 	assert.NoError(t, err)
 	// Validate the computed mac

--- a/go/coligate/processing/processing_test.go
+++ b/go/coligate/processing/processing_test.go
@@ -53,7 +53,7 @@ func TestValidate(t *testing.T) {
 	type test struct {
 		name     string
 		entries  []entry
-		resStore map[string]*storage.Reservation
+		resStore map[[12]byte]*storage.Reservation
 	}
 	worker := processing.NewWorker(getColigateConfiguration(), 1, 1, 1)
 
@@ -110,10 +110,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateReservationBelongsToOtherAS",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string(
-						[]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -129,6 +128,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -148,6 +148,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -164,10 +165,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateInvalidNumberOfHopfields",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string(
-						[]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -183,6 +183,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -199,10 +200,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateCurrHFIsInvalid",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string(
-						[]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -218,6 +218,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -236,10 +237,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateBwClsIsInvalid",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string(
-						[]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -255,6 +255,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -274,10 +275,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateRlcIsInvalid",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string(
-						[]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -294,6 +294,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -314,10 +315,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateExpTickIsInvalid",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string(
-						[]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops:          make([]storage.HopField, 1),
 					ActiveIndexId: 0,
 					Indices: map[uint8]*storage.ReservationIndex{
@@ -334,6 +334,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -355,9 +356,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateInvalidIngressId",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops: []storage.HopField{
 						{
 							IngressId: 1,
@@ -379,6 +380,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -406,9 +408,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateInvalidEgressId",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops: []storage.HopField{
 						{
 							IngressId: 1,
@@ -430,6 +432,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -457,9 +460,9 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "TestValidateAllValid",
-			resStore: map[string]*storage.Reservation{
-				string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-					Id: string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			resStore: map[[12]byte]*storage.Reservation{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+					Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 					Hops: []storage.HopField{
 						{
 							IngressId: 1,
@@ -481,6 +484,7 @@ func TestValidate(t *testing.T) {
 			entries: []entry{
 				{
 					proc: processing.DataPacket{
+						Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 						PktArrivalTime: startTime,
 						ColibriPath: &colibri.ColibriPath{
 							InfoField: &colibri.InfoField{
@@ -546,7 +550,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -564,7 +568,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -587,7 +591,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -605,7 +609,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -623,7 +627,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -641,7 +645,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 500),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -659,7 +663,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -682,7 +686,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -700,7 +704,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "B",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -723,7 +727,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -741,7 +745,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -769,7 +773,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -787,7 +791,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2750),
 						PktArrivalTime: startTime.Add(1 * time.Second),
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -815,7 +819,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2750),
 						PktArrivalTime: startTime,
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 0,
 							Indices: map[uint8]*storage.ReservationIndex{
 								0: {
@@ -833,7 +837,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 2000),
 						PktArrivalTime: startTime.Add(1 * time.Second),
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								1: {
@@ -851,7 +855,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 						RawPacket:      make([]byte, 1),
 						PktArrivalTime: startTime.Add(1 * time.Second),
 						Reservation: &storage.Reservation{
-							Id:            "A",
+							Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 							ActiveIndexId: 1,
 							Indices: map[uint8]*storage.ReservationIndex{
 								1: {
@@ -870,7 +874,7 @@ func TestPerformTrafficMonitoring(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := make(map[string]*storage.TrafficMonitor)
+			m := make(map[[12]byte]*storage.TrafficMonitor)
 			for _, en := range tc.entries {
 				monitor := m[en.proc.Reservation.Id]
 				en.proc.Reservation.TrafficMonitor = monitor
@@ -947,7 +951,7 @@ func TestUpdateMacs(t *testing.T) {
 			PathType:    colibri.PathType,
 		},
 		Reservation: &storage.Reservation{
-			Id:            "A",
+			Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			ActiveIndexId: 0,
 			Hops: []storage.HopField{
 				{
@@ -1052,9 +1056,9 @@ func BenchmarkParsing(b *testing.B) {
 func BenchmarkProcess(b *testing.B) {
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1)
 	now := time.Now()
-	resStore := map[string]*storage.Reservation{
-		string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-			Id: string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+	resStore := map[[12]byte]*storage.Reservation{
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+			Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			Indices: map[uint8]*storage.ReservationIndex{
 				1: {
 					Index:    0,
@@ -1100,6 +1104,7 @@ func BenchmarkProcess(b *testing.B) {
 	}
 	w.Storage.InitStorageWithData(resStore)
 	defaultPkt := &processing.DataPacket{
+		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		PktArrivalTime: time.Now(),
 		ScionLayer: &slayers.SCION{
 			PathType: 4,
@@ -1156,9 +1161,9 @@ func BenchmarkValidate(b *testing.B) {
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1)
 	now := time.Now()
 
-	resStore := map[string]*storage.Reservation{
-		string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}): {
-			Id: string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+	resStore := map[[12]byte]*storage.Reservation{
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}: {
+			Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			Hops: []storage.HopField{
 				{
 					IngressId: 1,
@@ -1179,6 +1184,7 @@ func BenchmarkValidate(b *testing.B) {
 	}
 	w.Storage.InitStorageWithData(resStore)
 	d := &processing.DataPacket{
+		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		PktArrivalTime: now,
 		ColibriPath: &colibri.ColibriPath{
 			InfoField: &colibri.InfoField{
@@ -1211,9 +1217,10 @@ func BenchmarkTrafficMonitoring(b *testing.B) {
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1)
 	now := time.Now()
 	d := &processing.DataPacket{
+		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		PktArrivalTime: now,
 		Reservation: &storage.Reservation{
-			Id:            "A",
+			Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			ActiveIndexId: 0,
 			Indices: map[uint8]*storage.ReservationIndex{
 				0: {
@@ -1234,6 +1241,7 @@ func BenchmarkStamp(b *testing.B) {
 	w := processing.NewWorker(getColigateConfiguration(), 1, 1, 1)
 	now := time.Now()
 	defaultPkt := &processing.DataPacket{
+		Id:             [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		PktArrivalTime: now,
 		ScionLayer: &slayers.SCION{
 			PathType: colibri.PathType,
@@ -1282,7 +1290,7 @@ func BenchmarkStamp(b *testing.B) {
 		},
 		RawPacket: make([]byte, 400),
 		Reservation: &storage.Reservation{
-			Id: string([]byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			Id: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			Hops: []storage.HopField{
 				{
 					IngressId: 1,

--- a/go/coligate/processing/processor.go
+++ b/go/coligate/processing/processor.go
@@ -103,8 +103,8 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 		if !found {
 			continue
 		}
-		ch := make(chan []byte, numOfMessages)
-		pf := NewPacketForwarder(info.InternalAddr, numOfMessages, ch, coligateMetrics)
+		ch := make(chan []byte, config.ForwarderBatchSize)
+		pf := NewPacketForwarder(info.InternalAddr, config.ForwarderBatchSize, ch, coligateMetrics)
 		g.Go(func() error {
 			defer log.HandlePanic()
 			return pf.Start()

--- a/go/coligate/processing/processor.go
+++ b/go/coligate/processing/processor.go
@@ -240,7 +240,8 @@ func initializeMetrics(metrics *common.Metrics) *ColigateMetrics {
 
 // Loads the active EE Reservations from the colibri service
 func (p *Processor) loadActiveReservationsFromColibriService(ctx context.Context,
-	config *config.ColigateConfig, colibiServiceAddr *net.UDPAddr, timeout int, coligateId string) error {
+	config *config.ColigateConfig, colibiServiceAddr *net.UDPAddr, timeout int,
+	coligateId string) error {
 
 	log.Info("Loading active reservation indices from colibri service")
 	var response *copb.ActiveIndicesResponse

--- a/go/coligate/processing/processor.go
+++ b/go/coligate/processing/processor.go
@@ -47,7 +47,7 @@ type Processor struct {
 	controlUpdateChannels   []chan *storage.UpdateTask
 	controlDeletionChannels []chan *storage.DeletionTask
 	cleanupChannel          chan *storage.UpdateTask
-	packetForwardChannels   map[uint16]chan []byte
+	packetForwardChannels   map[uint16]packetForwarderContainer
 	saltHasher              common.SaltHasher
 	exit                    bool
 	metrics                 *ColigateMetrics
@@ -76,7 +76,9 @@ func (c *Processor) shutdown() {
 		c.controlDeletionChannels[i] <- nil
 	}
 	for _, v := range c.packetForwardChannels {
-		v <- nil
+		for _, c := range v.ForwardTasks {
+			c <- nil
+		}
 	}
 }
 
@@ -89,27 +91,55 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 		return err
 	}
 
-	config := &cfg.Coligate
+	coligateConfig := &cfg.Coligate
 	coligateMetrics := initializeMetrics(metrics)
-	forwardChannels := make(map[uint16]chan []byte)
+	forwardChannels := make(map[uint16]packetForwarderContainer)
 	for ifid, info := range topo.InterfaceInfoMap() {
 		found := false
 		// We skip all interface ids that are not used by this instance of Colibri Gateway
 		for _, eggr := range coligateInfo.Egresses {
 			if eggr == uint32(ifid) {
 				found = true
+				break
 			}
 		}
 		if !found {
 			continue
 		}
-		ch := make(chan []byte, config.ForwarderBatchSize)
-		pf := NewPacketForwarder(info.InternalAddr, config.ForwarderBatchSize, ch, coligateMetrics)
-		g.Go(func() error {
-			defer log.HandlePanic()
-			return pf.Start()
-		})
-		forwardChannels[uint16(ifid)] = ch
+		// If a configuration for that interface exists use it otherwise use default values
+		found = false
+		var forwarderConfig config.ForwarderConfig
+		for _, fw := range coligateConfig.Forwarder {
+			if uint32(fw.InterfaceId) == uint32(ifid) {
+				found = true
+				forwarderConfig = fw
+				break
+			}
+		}
+		if !found {
+			forwarderConfig = config.ForwarderConfig{
+				InterfaceId: int(ifid),
+				BatchSize:   16,
+				Count:       1,
+			}
+		}
+
+		chs := make([]chan []byte, forwarderConfig.Count)
+		for i := 0; i < forwarderConfig.Count; i++ {
+			chs[i] = make(chan []byte, forwarderConfig.BatchSize)
+			pf := NewPacketForwarder(info.InternalAddr, forwarderConfig.BatchSize, chs[i], coligateMetrics)
+			func(pf *packetForwarder) {
+				g.Go(func() error {
+					defer log.HandlePanic()
+					log.Debug("Started Packet forwarder", "addr", pf.addr.String())
+					return pf.Start()
+				})
+			}(pf)
+		}
+		forwardChannels[uint16(ifid)] = packetForwarderContainer{
+			Length:       uint32(forwarderConfig.Count),
+			ForwardTasks: chs,
+		}
 	}
 
 	grpcAddr, err := net.ResolveTCPAddr("tcp", cfg.Coligate.ColigateGRPCAddr)
@@ -126,8 +156,8 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 
 	// Loads the salt for load balancing from the config.
 	// If the salt is empty a random value will be chosen
-	salt := []byte(config.Salt)
-	if config.Salt == "" {
+	salt := []byte(coligateConfig.Salt)
+	if coligateConfig.Salt == "" {
 		salt := make([]byte, 16)
 		rand.Read(salt)
 	}
@@ -136,12 +166,12 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 		localIA: topo.IA(),
 		// TODO(rohrerj) check cleanupChannel capacity
 		cleanupChannel:          make(chan *storage.UpdateTask, 1000),
-		dataChannels:            make([]chan *dataPacket, config.NumWorkers),
-		controlUpdateChannels:   make([]chan *storage.UpdateTask, config.NumWorkers),
-		controlDeletionChannels: make([]chan *storage.DeletionTask, config.NumWorkers),
+		dataChannels:            make([]chan *dataPacket, coligateConfig.NumWorkers),
+		controlUpdateChannels:   make([]chan *storage.UpdateTask, coligateConfig.NumWorkers),
+		controlDeletionChannels: make([]chan *storage.DeletionTask, coligateConfig.NumWorkers),
 		saltHasher:              common.NewFnv1aHasher(salt),
 		metrics:                 coligateMetrics,
-		numWorkers:              config.NumWorkers,
+		numWorkers:              coligateConfig.NumWorkers,
 		packetForwardChannels:   forwardChannels,
 	}
 
@@ -152,16 +182,16 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 
 	// Creates all the channels and starts the go routines
 	for i := 0; i < p.numWorkers; i++ {
-		p.dataChannels[i] = make(chan *dataPacket, config.MaxQueueSizePerWorker)
+		p.dataChannels[i] = make(chan *dataPacket, coligateConfig.MaxQueueSizePerWorker)
 		p.controlUpdateChannels[i] = make(chan *storage.UpdateTask,
-			config.MaxQueueSizePerWorker)
+			coligateConfig.MaxQueueSizePerWorker)
 		// TODO(rohrerj) Check control deletion channel size
 		p.controlDeletionChannels[i] = make(chan *storage.DeletionTask, 1000)
 		func(i int) {
 			g.Go(func() error {
 				defer log.HandlePanic()
-				return p.workerReceiveEntry(config,
-					uint32(i), uint32(config.ColibriGatewayID), localAS,
+				return p.workerReceiveEntry(coligateConfig,
+					uint32(i), uint32(coligateConfig.ColibriGatewayID), localAS,
 				)
 			})
 		}(i)
@@ -175,15 +205,15 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 
 	g.Go(func() error {
 		defer log.HandlePanic()
-		return p.initControlPlane(config, cleanup, grpcAddr)
+		return p.initControlPlane(coligateConfig, cleanup, grpcAddr)
 	})
 
 	// We start the data plane as soon as we retrieved the active reservations from colibri service
-	if err := p.loadActiveReservationsFromColibriService(ctx, config, colibriServiceAddresses[0],
-		config.COSyncTimeout, cfg.General.ID); err != nil {
+	if err := p.loadActiveReservationsFromColibriService(ctx, coligateConfig, colibriServiceAddresses[0],
+		coligateConfig.COSyncTimeout, cfg.General.ID); err != nil {
 		return err
 	}
-	if err := p.initDataPlane(config, coligateInfo.Addr, g, cleanup); err != nil {
+	if err := p.initDataPlane(coligateConfig, coligateInfo.Addr, g, cleanup); err != nil {
 		return err
 	}
 

--- a/go/coligate/processing/processor.go
+++ b/go/coligate/processing/processor.go
@@ -107,8 +107,7 @@ func Init(ctx context.Context, cfg *config.Config, cleanup *app.Cleanup,
 		pf := NewPacketForwarder(info.InternalAddr, numOfMessages, ch, coligateMetrics)
 		g.Go(func() error {
 			defer log.HandlePanic()
-			pf.Start()
-			return nil
+			return pf.Start()
 		})
 		forwardChannels[uint16(ifid)] = ch
 	}

--- a/go/coligate/processing/processor_test.go
+++ b/go/coligate/processing/processor_test.go
@@ -81,7 +81,7 @@ func TestCleanupRoutineSingleTaskSequentially(t *testing.T) {
 			assert.NotNil(t, task)
 			assert.IsType(t, &storage.DeletionTask{}, task)
 			assert.Equal(t, newId, task.ResId)
-		case <-time.After(1 * time.Second):
+		case <-time.After(1100 * time.Millisecond):
 			assert.Fail(t, "reservation not deleted")
 		}
 	}
@@ -130,7 +130,7 @@ func TestCleanupRoutineBatchOfTasksSequentially(t *testing.T) {
 		select {
 		case <-reservationDeletionChannels[0]:
 			reportedReservations++
-		case <-time.After(20 * time.Millisecond):
+		case <-time.After(1100 * time.Millisecond):
 			exit = true
 		}
 	}
@@ -186,7 +186,7 @@ func TestCleanupRoutineSupersedeOld(t *testing.T) {
 		case task := <-reservationDeletionChannels[0]:
 			assert.IsType(t, &storage.DeletionTask{}, task)
 			reportedReservations++
-		case <-time.After(40 * time.Millisecond):
+		case <-time.After(1100 * time.Millisecond):
 			exit = true
 		}
 	}

--- a/go/coligate/processing/processor_test.go
+++ b/go/coligate/processing/processor_test.go
@@ -209,9 +209,10 @@ func BenchmarkWorker(b *testing.B) {
 	}
 	conn, _ := net.DialUDP("udp", nil, borderRouterAddr)
 	borderRouterConnection[uint16(2)] = ipv4.NewPacketConn(conn)
+	c.SetBorderRouterConnections(borderRouterConnection)
 	errGroup := &errgroup.Group{}
 	errGroup.Go(func() error {
-		return c.WorkerReceiveEntry(getColigateConfiguration(), 0, 1, addr.MustIAFrom(1, 1).AS(), &borderRouterConnection)
+		return c.WorkerReceiveEntry(getColigateConfiguration(), 0, 1, addr.MustIAFrom(1, 1).AS())
 	})
 
 	now := time.Now()

--- a/go/coligate/processing/processor_test.go
+++ b/go/coligate/processing/processor_test.go
@@ -347,10 +347,10 @@ func BenchmarkWorker(b *testing.B) {
 		}
 	})
 	time.Sleep(10 * time.Millisecond)
-
+	pkt := defaultPkt.Convert()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		dataChannels[0] <- defaultPkt.Convert()
+		dataChannels[0] <- pkt
 	}
 	dataChannels[0] <- nil
 	for len(dataChannels[0]) != 0 {

--- a/go/coligate/storage/storage.go
+++ b/go/coligate/storage/storage.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"crypto/cipher"
 	"time"
 
 	"github.com/scionproto/scion/go/coligate/tokenbucket"
@@ -40,6 +41,7 @@ type ReservationIndex struct {
 	Index    uint8
 	Validity time.Time
 	Sigmas   [][]byte
+	Ciphers  []cipher.Block
 	BwCls    uint8
 }
 

--- a/go/coligate/storage/storage.go
+++ b/go/coligate/storage/storage.go
@@ -23,10 +23,10 @@ import (
 )
 
 type Storage struct {
-	reservations map[string]*Reservation
+	reservations map[[12]byte]*Reservation
 }
 type Reservation struct {
-	Id             string
+	Id             [12]byte
 	Hops           []HopField
 	Rlc            uint8
 	ActiveIndexId  uint8
@@ -62,7 +62,7 @@ type UpdateTask struct {
 }
 
 type DeletionTask struct {
-	ResId string
+	ResId [12]byte
 }
 
 // Execute merges (overwrites if exists in both) all provided reservation indices
@@ -94,28 +94,28 @@ func (res *Reservation) Current() *ReservationIndex {
 }
 
 // InitStorageWithData initializes the reservation storage
-func (store *Storage) InitStorageWithData(data map[string]*Reservation) {
+func (store *Storage) InitStorageWithData(data map[[12]byte]*Reservation) {
 	if data == nil {
-		store.reservations = make(map[string]*Reservation)
+		store.reservations = make(map[[12]byte]*Reservation)
 	} else {
 		store.reservations = data
 	}
 }
 
-func (store *Storage) get(resId string) (*Reservation, bool) {
+func (store *Storage) get(resId [12]byte) (*Reservation, bool) {
 	res, found := store.reservations[resId]
 	return res, found
 }
 
-func (store *Storage) store(resId string, reservation *Reservation) {
+func (store *Storage) store(resId [12]byte, reservation *Reservation) {
 	store.reservations[resId] = reservation
 }
 
-func (store *Storage) remove(resId string) {
+func (store *Storage) remove(resId [12]byte) {
 	delete(store.reservations, resId)
 }
 
-func NewReservation(resId string, hops []HopField) *Reservation {
+func NewReservation(resId [12]byte, hops []HopField) *Reservation {
 	return &Reservation{
 		Id:      resId,
 		Rlc:     0, //TODO(rohrerj)
@@ -137,7 +137,7 @@ func NewUpdateTask(res *Reservation, highestValidity time.Time) *UpdateTask {
 		HighestValidity: highestValidity,
 	}
 }
-func NewDeletionTask(resId string) *DeletionTask {
+func NewDeletionTask(resId [12]byte) *DeletionTask {
 	return &DeletionTask{
 		ResId: resId,
 	}
@@ -146,7 +146,7 @@ func NewDeletionTask(resId string) *DeletionTask {
 // UseReservation checks whether the reservation index exists and is valid. If the
 // reservation exists but contains no longer valid indices, they will be removed.
 // If the reservation index exists and is valid, the reservation is returned.
-func (store *Storage) UseReservation(resId string, providedIndex uint8,
+func (store *Storage) UseReservation(resId [12]byte, providedIndex uint8,
 	pktTime time.Time) (*Reservation, bool) {
 
 	log.Debug("use resId", "resId", resId)

--- a/go/coligate/storage/storage_test.go
+++ b/go/coligate/storage/storage_test.go
@@ -26,56 +26,56 @@ import (
 func TestReservationNotFound(t *testing.T) {
 	storage := &storage.Storage{}
 	storage.InitStorageWithData(nil)
-	res, found := storage.UseReservation("A", 0, time.Now())
+	res, found := storage.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, time.Now())
 	assert.False(t, found)
 	assert.Nil(t, res)
 }
 
 func TestReservationVersionNotFound(t *testing.T) {
 	s := &storage.Storage{}
-	resmap := make(map[string]*storage.Reservation)
+	resmap := make(map[[12]byte]*storage.Reservation)
 	resvmap := make(map[uint8]*storage.ReservationIndex)
 	resvmap[0] = &storage.ReservationIndex{
 		Index:    0,
 		Validity: time.Now().Add(1 * time.Minute),
 	}
 
-	resmap["A"] = &storage.Reservation{
-		Id:            "A",
+	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
+		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation("A", 1, time.Now())
+	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 1, time.Now())
 	assert.False(t, found)
 	assert.Nil(t, res)
 }
 
 func TestActiveVersionIsProvidedVersion(t *testing.T) {
 	s := &storage.Storage{}
-	resmap := make(map[string]*storage.Reservation)
+	resmap := make(map[[12]byte]*storage.Reservation)
 	resvmap := make(map[uint8]*storage.ReservationIndex)
 	resvmap[0] = &storage.ReservationIndex{
 		Index:    0,
 		Validity: time.Now().Add(1 * time.Minute),
 	}
 
-	resmap["A"] = &storage.Reservation{
-		Id:            "A",
+	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
+		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation("A", 0, time.Now())
+	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, time.Now())
 	assert.True(t, found)
 	assert.Equal(t, uint8(0), res.ActiveIndexId)
 }
 
 func TestActiveVersionOlder(t *testing.T) {
 	s := &storage.Storage{}
-	resmap := make(map[string]*storage.Reservation)
+	resmap := make(map[[12]byte]*storage.Reservation)
 	resvmap := make(map[uint8]*storage.ReservationIndex)
 	resvmap[0] = &storage.ReservationIndex{
 		Index:    0,
@@ -86,14 +86,14 @@ func TestActiveVersionOlder(t *testing.T) {
 		Validity: time.Now().Add(2 * time.Minute),
 	}
 
-	resmap["A"] = &storage.Reservation{
-		Id:            "A",
+	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
+		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation("A", 1, time.Now())
+	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 1, time.Now())
 	assert.True(t, found)
 	assert.Equal(t, uint8(1), res.ActiveIndexId)
 	_, found = res.Indices[0]
@@ -103,7 +103,7 @@ func TestActiveVersionOlder(t *testing.T) {
 
 func TestActiveVersionNewer(t *testing.T) {
 	s := &storage.Storage{}
-	resmap := make(map[string]*storage.Reservation)
+	resmap := make(map[[12]byte]*storage.Reservation)
 	resvmap := make(map[uint8]*storage.ReservationIndex)
 	resvmap[0] = &storage.ReservationIndex{
 		Index:    0,
@@ -114,13 +114,13 @@ func TestActiveVersionNewer(t *testing.T) {
 		Validity: time.Now().Add(1 * time.Minute),
 	}
 
-	resmap["A"] = &storage.Reservation{
-		Id:            "A",
+	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
+		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
-	_, found := s.UseReservation("A", 1, time.Now())
+	_, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 1, time.Now())
 	assert.False(t, found)
 	_, found = resvmap[1]
 	assert.False(t, found)
@@ -128,7 +128,7 @@ func TestActiveVersionNewer(t *testing.T) {
 
 func TestPacketValidityIsChecked(t *testing.T) {
 	s := &storage.Storage{}
-	resmap := make(map[string]*storage.Reservation)
+	resmap := make(map[[12]byte]*storage.Reservation)
 	resvmap := make(map[uint8]*storage.ReservationIndex)
 	now := time.Now()
 	resvmap[0] = &storage.ReservationIndex{
@@ -136,17 +136,17 @@ func TestPacketValidityIsChecked(t *testing.T) {
 		Validity: now,
 	}
 
-	resmap["A"] = &storage.Reservation{
-		Id:            "A",
+	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
+		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation("A", 0, now)
+	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, now)
 	assert.True(t, found)
-	assert.Equal(t, "A", res.Id)
-	res, found = s.UseReservation("A", 0, now.Add(1*time.Second))
+	assert.Equal(t, [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, res.Id)
+	res, found = s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, now.Add(1*time.Second))
 	assert.False(t, found)
 	assert.Nil(t, res)
 }

--- a/go/coligate/storage/storage_test.go
+++ b/go/coligate/storage/storage_test.go
@@ -26,7 +26,8 @@ import (
 func TestReservationNotFound(t *testing.T) {
 	storage := &storage.Storage{}
 	storage.InitStorageWithData(nil)
-	res, found := storage.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, time.Now())
+	res, found := storage.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		0, time.Now())
 	assert.False(t, found)
 	assert.Nil(t, res)
 }
@@ -146,7 +147,8 @@ func TestPacketValidityIsChecked(t *testing.T) {
 	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, now)
 	assert.True(t, found)
 	assert.Equal(t, [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, res.Id)
-	res, found = s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, now.Add(1*time.Second))
+	res, found = s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		0, now.Add(1*time.Second))
 	assert.False(t, found)
 	assert.Nil(t, res)
 }

--- a/go/coligate/storage/storage_test.go
+++ b/go/coligate/storage/storage_test.go
@@ -23,10 +23,12 @@ import (
 	"github.com/scionproto/scion/go/coligate/storage"
 )
 
+var reservationIdOne [12]byte = [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+
 func TestReservationNotFound(t *testing.T) {
 	storage := &storage.Storage{}
 	storage.InitStorageWithData(nil)
-	res, found := storage.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	res, found := storage.UseReservation(reservationIdOne,
 		0, time.Now())
 	assert.False(t, found)
 	assert.Nil(t, res)
@@ -41,14 +43,14 @@ func TestReservationVersionNotFound(t *testing.T) {
 		Validity: time.Now().Add(1 * time.Minute),
 	}
 
-	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
-		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	resmap[reservationIdOne] = &storage.Reservation{
+		Id:            reservationIdOne,
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 1, time.Now())
+	res, found := s.UseReservation(reservationIdOne, 1, time.Now())
 	assert.False(t, found)
 	assert.Nil(t, res)
 }
@@ -62,14 +64,14 @@ func TestActiveVersionIsProvidedVersion(t *testing.T) {
 		Validity: time.Now().Add(1 * time.Minute),
 	}
 
-	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
-		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	resmap[reservationIdOne] = &storage.Reservation{
+		Id:            reservationIdOne,
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, time.Now())
+	res, found := s.UseReservation(reservationIdOne, 0, time.Now())
 	assert.True(t, found)
 	assert.Equal(t, uint8(0), res.ActiveIndexId)
 }
@@ -87,14 +89,14 @@ func TestActiveVersionOlder(t *testing.T) {
 		Validity: time.Now().Add(2 * time.Minute),
 	}
 
-	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
-		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	resmap[reservationIdOne] = &storage.Reservation{
+		Id:            reservationIdOne,
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 1, time.Now())
+	res, found := s.UseReservation(reservationIdOne, 1, time.Now())
 	assert.True(t, found)
 	assert.Equal(t, uint8(1), res.ActiveIndexId)
 	_, found = res.Indices[0]
@@ -115,13 +117,13 @@ func TestActiveVersionNewer(t *testing.T) {
 		Validity: time.Now().Add(1 * time.Minute),
 	}
 
-	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
-		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	resmap[reservationIdOne] = &storage.Reservation{
+		Id:            reservationIdOne,
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
-	_, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 1, time.Now())
+	_, found := s.UseReservation(reservationIdOne, 1, time.Now())
 	assert.False(t, found)
 	_, found = resvmap[1]
 	assert.False(t, found)
@@ -137,17 +139,17 @@ func TestPacketValidityIsChecked(t *testing.T) {
 		Validity: now,
 	}
 
-	resmap[[12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}] = &storage.Reservation{
-		Id:            [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	resmap[reservationIdOne] = &storage.Reservation{
+		Id:            reservationIdOne,
 		Indices:       resvmap,
 		ActiveIndexId: 0,
 	}
 	s.InitStorageWithData(resmap)
 
-	res, found := s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 0, now)
+	res, found := s.UseReservation(reservationIdOne, 0, now)
 	assert.True(t, found)
-	assert.Equal(t, [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, res.Id)
-	res, found = s.UseReservation([12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	assert.Equal(t, reservationIdOne, res.Id)
+	res, found = s.UseReservation(reservationIdOne,
 		0, now.Add(1*time.Second))
 	assert.False(t, found)
 	assert.Nil(t, res)

--- a/go/pkg/co/colibri/grpc/BUILD.bazel
+++ b/go/pkg/co/colibri/grpc/BUILD.bazel
@@ -21,9 +21,9 @@ go_library(
         "//go/lib/slayers/path/empty:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/util:go_default_library",
-        "//go/pkg/grpc:go_default_library",
         "//go/pkg/proto/colibri:go_default_library",
         "//go/pkg/proto/coligate:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//peer:go_default_library",
     ],
 )

--- a/go/pkg/co/colibri/grpc/colibri_service.go
+++ b/go/pkg/co/colibri/grpc/colibri_service.go
@@ -362,10 +362,9 @@ func (s *ColibriService) SetupReservation(ctx context.Context, msg *colpb.SetupR
 			return nil, serrors.New("at least one hopfield is required")
 		}
 
+		// TODO(rohrerj) don't always create a new goroutine
 		// contact the colibri gateway to update the sigmas:
-		go func(colPath *colpath.ColibriPath,
-			token *reservation.Token) {
-
+		go func(colPath *colpath.ColibriPath, token *reservation.Token) {
 			defer log.HandlePanic()
 			s.updateSigmas(path, token)
 		}(path, token)

--- a/go/pkg/coligate/config/coligate.go
+++ b/go/pkg/coligate/config/coligate.go
@@ -35,6 +35,7 @@ type ColigateConfig struct {
 	MaxQueueSizePerWorker int    `toml:"MaxQueueSizePerWorker"`
 	Salt                  string `toml:"Salt"`
 	ColigateGRPCAddr      string `toml:"ColigateGRPCAddr"`
+	ForwarderBatchSize    int    `toml:"ForwarderBatchSize"`
 }
 
 func (cfg *ColigateConfig) Validate() error {
@@ -51,6 +52,9 @@ func (cfg *ColigateConfig) Validate() error {
 	if int(math.Pow(2, float64(cfg.NumBitsForWorkerId))-1) < cfg.NumWorkers {
 		return serrors.New("Too small bit count for too many workers", "NumBitsForWorkerId",
 			cfg.NumBitsForWorkerId, "NumWorkers", cfg.NumWorkers)
+	}
+	if cfg.ForwarderBatchSize < 1 {
+		return serrors.New("ForwarderBatchSize < 1")
 	}
 	return nil
 }
@@ -74,6 +78,9 @@ func (cfg *ColigateConfig) InitDefaults() {
 	}
 	if cfg.COSyncTimeout == 0 {
 		cfg.COSyncTimeout = 10
+	}
+	if cfg.ForwarderBatchSize == 0 {
+		cfg.ForwarderBatchSize = 32
 	}
 }
 

--- a/go/pkg/coligate/config/coligate.go
+++ b/go/pkg/coligate/config/coligate.go
@@ -29,13 +29,19 @@ type ColigateConfig struct {
 	NumBitsForPerWorkerCounter int `toml:"NumBitsForPerWorkerCounter"`
 
 	//Timeout in sec
-	COSyncTimeout         int    `toml:"COSyncTimeout"`
-	ColibriGatewayID      int    `toml:"ColibriGatewayID"`
-	NumWorkers            int    `toml:"NumWorkers"`
-	MaxQueueSizePerWorker int    `toml:"MaxQueueSizePerWorker"`
-	Salt                  string `toml:"Salt"`
-	ColigateGRPCAddr      string `toml:"ColigateGRPCAddr"`
-	ForwarderBatchSize    int    `toml:"ForwarderBatchSize"`
+	COSyncTimeout         int               `toml:"COSyncTimeout"`
+	ColibriGatewayID      int               `toml:"ColibriGatewayID"`
+	NumWorkers            int               `toml:"NumWorkers"`
+	MaxQueueSizePerWorker int               `toml:"MaxQueueSizePerWorker"`
+	Salt                  string            `toml:"Salt"`
+	ColigateGRPCAddr      string            `toml:"ColigateGRPCAddr"`
+	Forwarder             []ForwarderConfig `toml:"Forwarder"`
+}
+
+type ForwarderConfig struct {
+	InterfaceId int `toml:"InterfaceId"`
+	BatchSize   int `toml:"BatchSize"`
+	Count       int `toml:"Count"`
 }
 
 func (cfg *ColigateConfig) Validate() error {
@@ -53,8 +59,10 @@ func (cfg *ColigateConfig) Validate() error {
 		return serrors.New("Too small bit count for too many workers", "NumBitsForWorkerId",
 			cfg.NumBitsForWorkerId, "NumWorkers", cfg.NumWorkers)
 	}
-	if cfg.ForwarderBatchSize < 1 {
-		return serrors.New("ForwarderBatchSize < 1")
+	for _, fw := range cfg.Forwarder {
+		if fw.BatchSize < 1 {
+			return serrors.New("ForwarderBatchSize < 1")
+		}
 	}
 	return nil
 }
@@ -79,8 +87,13 @@ func (cfg *ColigateConfig) InitDefaults() {
 	if cfg.COSyncTimeout == 0 {
 		cfg.COSyncTimeout = 10
 	}
-	if cfg.ForwarderBatchSize == 0 {
-		cfg.ForwarderBatchSize = 32
+	for _, fw := range cfg.Forwarder {
+		if fw.BatchSize == 0 {
+			fw.BatchSize = 16
+		}
+		if fw.Count == 0 {
+			fw.Count = 1
+		}
 	}
 }
 

--- a/go/pkg/coligate/grpc/BUILD.bazel
+++ b/go/pkg/coligate/grpc/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//go/coligate/storage:go_default_library",
         "//go/lib/addr:go_default_library",
-        "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/metrics:go_default_library",
         "//go/lib/util:go_default_library",

--- a/go/pkg/coligate/observability.go
+++ b/go/pkg/coligate/observability.go
@@ -17,6 +17,7 @@ type Metrics struct {
 	UpdateSigmasTotal             *prometheus.CounterVec
 	DataPacketInTotal             *prometheus.CounterVec
 	DataPacketInInvalid           *prometheus.CounterVec
+	DataPacketInDropped           *prometheus.CounterVec
 	LoadActiveReservationsTotal   *prometheus.CounterVec
 	WorkerPacketInTotal           *prometheus.CounterVec
 	WorkerPacketOutTotal          *prometheus.CounterVec
@@ -57,8 +58,16 @@ func NewMetrics() *Metrics {
 		DataPacketInInvalid: promauto.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "coligate_data_packet_in_invalid",
-				Help: `"Total number of data packets received by the colibri gateway 
-				whose headers cannot be parsed correctly."`,
+				Help: "Total number of data packets received by the colibri gateway " +
+					"whose headers cannot be parsed correctly.",
+			},
+			[]string{},
+		),
+		DataPacketInDropped: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "coligate_data_packet_in_dropped",
+				Help: "Total number of data packets received by the colibri gateway " +
+					"that were dropped because of busy workers.",
 			},
 			[]string{},
 		),
@@ -107,8 +116,8 @@ func NewMetrics() *Metrics {
 		CleanupReservationUpdateNew: promauto.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "coligate_cleanup_reservation_update_new",
-				Help: `"Total number of reservation updates registered in the cleanup 
-				routine that extend the validity of a reservation."`,
+				Help: "Total number of reservation updates registered in the cleanup " +
+					"routine that extend the validity of a reservation.",
 			},
 			[]string{},
 		),

--- a/go/pkg/coligate/observability.go
+++ b/go/pkg/coligate/observability.go
@@ -21,6 +21,7 @@ type Metrics struct {
 	LoadActiveReservationsTotal   *prometheus.CounterVec
 	WorkerPacketInTotal           *prometheus.CounterVec
 	WorkerPacketOutTotal          *prometheus.CounterVec
+	WorkerPacketOutError          *prometheus.CounterVec
 	WorkerPacketInInvalid         *prometheus.CounterVec
 	WorkerReservationUpdateTotal  *prometheus.CounterVec
 	CleanupReservationUpdateTotal *prometheus.CounterVec
@@ -89,6 +90,13 @@ func NewMetrics() *Metrics {
 			prometheus.CounterOpts{
 				Name: "coligate_worker_packet_out_total",
 				Help: "Total number of data packets forwarded by the workers.",
+			},
+			[]string{},
+		),
+		WorkerPacketOutError: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "coligate_worker_packet_out_error",
+				Help: "Total number of data packets dropped by workers because of writing errors",
 			},
 			[]string{},
 		),

--- a/proto/colibri/v1/colibri.proto
+++ b/proto/colibri/v1/colibri.proto
@@ -448,6 +448,7 @@ message AddAdmissionEntryResponse {
 }
 
 message ActiveIndicesRequest {
+    // the colibri gateway topology id
     string coligate_id = 1;
 }
 


### PR DESCRIPTION
This Pullrequest contains several implementation changes that lead to better performance and benchmark tests.
- cache ciphers, delete sigmas
- reuse grpc clients for update sigmas
- change reservation id mapping from string to [12]byte
- improve performance of cleanup routine
- introduced packet forwarder

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/149)
<!-- Reviewable:end -->
