### PR TITLE
Directly send time sync packets to egress interface without queueing.

### DIFF
--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -29,8 +29,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/ipv4"
-
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/prometheus/client_golang/prometheus"

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -547,14 +547,7 @@ func (d *DataPlane) Run(ctx context.Context) error {
 				}
 
 				if result.Class == tc.ClsSNC {
-					var op ipv4.Message
-					op.Buffers[0] = result.OutPkt
-					op.Addr = nil
-					if result.OutAddr != nil {
-						op.Addr = result.OutAddr
-					}
-					addr := op.Addr.(*net.UDPAddr)
-					_, err = result.OutConn.WriteTo(op.Buffers[0], addr)
+					_, err = result.OutConn.WriteTo(result.OutPkt, result.OutAddr)
 				} else {
 					d.enqueue(&result)
 				}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/156)
<!-- Reviewable:end -->
