### PR TITLE
Mattn's sqlite as default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 ### common options for all subcommands (help, query, build, ...)
-common --show_timestamps --enable_platform_specific_config
+common --define gotags=sqlite_mattn --show_timestamps --enable_platform_specific_config
 
 # connect to buchgr/bazel-remote cache
 # These flags can unfortunately not be specified for `common`, as they are not accepted by all subcommands (help, version, dump)
@@ -21,8 +21,8 @@ build --flag_alias=file_name_version=//:file_name_version
 
 # include one of "--define gotags=sqlite_mattn" or "--define gotags=sqlite_modernc"
 # cannot be in common, because query chokes on it.
-build --define gotags=sqlite_modernc,netgo
-build:osx --define gotags=sqlite_modernc
+build --define gotags=netgo
+build:osx
 
 ### options for test
 test --build_tests_only --print_relative_test_log_paths --test_output=errors

--- a/private/storage/db/BUILD.bazel
+++ b/private/storage/db/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "metrics.go",
         "sqler.go",
         "sqlite.go",
-        "sqlite_modernc.go",
+        "sqlite_mattn.go",
     ],
     importpath = "github.com/scionproto/scion/private/storage/db",
     visibility = ["//visibility:public"],
@@ -17,7 +17,7 @@ go_library(
         "//pkg/private/common:go_default_library",
         "//pkg/private/prom:go_default_library",
         "//pkg/private/serrors:go_default_library",
-        "@org_modernc_sqlite//:go_default_library",
+        "@com_github_mattn_go_sqlite3//:go_default_library",
     ],
 )
 

--- a/private/storage/db/sqlite_mattn.go
+++ b/private/storage/db/sqlite_mattn.go
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build sqlite_mattn
+//go:build sqlite_mattn || !sqlite_modernc
+
+// XXX(juagargi): This setting is different from upstream, where the default is modernc.
+
+// Note that above go:build expression makes mattn the default by matching
+// the absence of sqlite_modernc. Should there be more alternatives, please
+// update that expression to match their absence too.
+// Also note that this default is overridden by a build configuration
+// in .bazelrc, so this is only useful when building with "go build" and
+// may not match the bazel build configuration.
 
 package db
 

--- a/private/storage/db/sqlite_modernc.go
+++ b/private/storage/db/sqlite_modernc.go
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build sqlite_modernc || !sqlite_mattn
-
-// Note that above go:build expression makes modernc the default by matching
-// the absence of sqlite_mattn. Should there be more alternatives, please
-// update that expression to match their absence too.
-// Also note that this default is overridden by a build configuration
-// in .bazelrc, so this is only useful when building with "go build" and
-// may not match the bazel build configuration.
+//go:build sqlite_modernc
 
 package db
 


### PR DESCRIPTION
Use the older sqlite library from mattn repository as default.
Mitigates #166

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/167)
<!-- Reviewable:end -->
