### PR TITLE
fix: Parsing the AS with the built-in parsing function

### DIFF
--- a/pkg/addr/fmt.go
+++ b/pkg/addr/fmt.go
@@ -65,7 +65,7 @@ func ParseFormattedAS(as string, opts ...FormatOption) (AS, error) {
 		}
 		as = trimmed
 	}
-	return ParseASSep(as, o.separator)
+	return parseAS(as, o.separator)
 }
 
 // FormatIA formats the ISD-AS.

--- a/private/path/fabridquery/parser.go
+++ b/private/path/fabridquery/parser.go
@@ -176,7 +176,7 @@ func (l *pathpolicyConstraintsListener) ExitWildcardAS(c *pathpolicyconstraints.
 
 // ExitLegacyAS is called when exiting the LegacyAS production.
 func (l *pathpolicyConstraintsListener) ExitLegacyAS(c *pathpolicyconstraints.LegacyASContext) {
-	as, err := addr.ParseASSep(c.GetText()[1:], "_")
+	as, err := addr.ParseFormattedAS(c.GetText()[1:], addr.WithSeparator("_"))
 	if err != nil {
 		c.SetException(antlr.NewFailedPredicateException(c.GetParser(), c.GetText(), err.Error()))
 	}
@@ -186,7 +186,7 @@ func (l *pathpolicyConstraintsListener) ExitLegacyAS(c *pathpolicyconstraints.Le
 
 // ExitAS is called when exiting the AS production.
 func (l *pathpolicyConstraintsListener) ExitAS(c *pathpolicyconstraints.ASContext) {
-	as, err := addr.ParseASSep(c.GetText()[1:], "_")
+	as, err := addr.ParseFormattedAS(c.GetText()[1:], addr.WithSeparator("_"))
 	if err != nil {
 		c.SetException(antlr.NewFailedPredicateException(c.GetParser(), c.GetText(), err.Error()))
 	}


### PR DESCRIPTION
Fixes the issue introduced in https://github.com/netsec-ethz/scion/pull/168/commits/bf6678297e16f3b49c3585d4137ecac1374af616, where the ParseASSep function was removed, but the function calls to the function were still present. This new commit uses the formatting functions already present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/171)
<!-- Reviewable:end -->
