### PR TITLE
fix fabrid path.Choose in case where there are no fabrid paths satisfying the query

### DIFF
--- a/private/app/path/path.go
+++ b/private/app/path/path.go
@@ -132,6 +132,9 @@ func Choose(
 				DataplanePath: fabridPath, NextHop: p.UnderlayNextHop(), Meta: *p.Metadata()}
 			validFabridPaths = append(validFabridPaths, resPath)
 		}
+		if len(validFabridPaths) == 0 {
+			return nil, serrors.New("no fabrid path available satisfying this query")
+		}
 		paths = validFabridPaths
 	}
 	if o.probeCfg != nil {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/177)
<!-- Reviewable:end -->
